### PR TITLE
Revert "Use the keyspace aware sep queue for everything, call it parameterized"

### DIFF
--- a/src/java/org/apache/cassandra/concurrent/KeyspaceAwareSepQueue.java
+++ b/src/java/org/apache/cassandra/concurrent/KeyspaceAwareSepQueue.java
@@ -32,13 +32,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService.FutureTask;
-import org.apache.cassandra.db.AbstractRangeCommand;
-import org.apache.cassandra.service.IReadCommand;
 
-public final class ParameterizedSepQueue extends AbstractQueue<FutureTask<?>>
+public final class KeyspaceAwareSepQueue extends AbstractQueue<FutureTask<?>>
 {
-    private static final Logger log = LoggerFactory.getLogger(ParameterizedSepQueue.class);
-    private static final ThreadLocal<String> queueingParameter = new ThreadLocal<>();
+    private static final Logger log = LoggerFactory.getLogger(KeyspaceAwareSepQueue.class);
+    private static final ThreadLocal<String> currentKeyspace = new ThreadLocal<>();
     @GuardedBy("this")
     private final Map<String, Queue<FutureTask<?>>> queue = new LinkedHashMap<>();
 
@@ -51,8 +49,8 @@ public final class ParameterizedSepQueue extends AbstractQueue<FutureTask<?>>
 
     // If someone didn't set the current keyspace, gracefully fall back to a backup queue.
     private static String currentKeyspace() {
-        String current = queueingParameter.get();
-        queueingParameter.remove();
+        String current = currentKeyspace.get();
+        currentKeyspace.remove();
         if (current == null) {
             log.info("Saw a command where the current keyspace was not set, which indicates a bug");
             return "";
@@ -97,16 +95,7 @@ public final class ParameterizedSepQueue extends AbstractQueue<FutureTask<?>>
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * Hypothesis: Gets happen on all tables, so you want to prioritize per keyspace. Scans happen on individual
-     * tables, and we'd rather indicate that gets to a specific table are expensive rather than all tables; better
-     * to take out reads to a single table than all.
-     */
-    public static void setQueueingParameter(IReadCommand read) {
-        if (read instanceof AbstractRangeCommand) {
-            queueingParameter.set(((AbstractRangeCommand) read).columnFamily);
-        } else {
-            queueingParameter.set(read.getKeyspace());
-        }
+    public static void setCurrentKeyspace(String keyspace) {
+        currentKeyspace.set(checkNotNull(keyspace));
     }
 }

--- a/src/java/org/apache/cassandra/concurrent/SharedExecutorPool.java
+++ b/src/java/org/apache/cassandra/concurrent/SharedExecutorPool.java
@@ -114,7 +114,7 @@ public class SharedExecutorPool
     int maxConcurrency, int maxQueuedTasks, String jmxPath, String name)
     {
         SEPExecutor executor = new SEPExecutor(
-        this, new ParameterizedSepQueue(), maxConcurrency, maxQueuedTasks, jmxPath, name);
+            this, new KeyspaceAwareSepQueue(), maxConcurrency, maxQueuedTasks, jmxPath, name);
         executors.add(executor);
         return executor;
     }

--- a/src/java/org/apache/cassandra/concurrent/StageManager.java
+++ b/src/java/org/apache/cassandra/concurrent/StageManager.java
@@ -46,7 +46,7 @@ public class StageManager
     {
         stages.put(Stage.MUTATION, multiThreadedLowSignalStage(Stage.MUTATION, getConcurrentWriters()));
         stages.put(Stage.COUNTER_MUTATION, multiThreadedLowSignalStage(Stage.COUNTER_MUTATION, getConcurrentCounterWriters()));
-        stages.put(Stage.READ, readStage(Stage.READ, getConcurrentReaders()));
+        stages.put(Stage.READ, multiThreadedLowSignalStage(Stage.READ, getConcurrentReaders()));
         stages.put(Stage.READ_CHEAP, readStage(Stage.READ_CHEAP, getConcurrentReaders()));
         stages.put(Stage.REQUEST_RESPONSE, multiThreadedLowSignalStage(Stage.REQUEST_RESPONSE, FBUtilities.getAvailableProcessors()));
         stages.put(Stage.INTERNAL_RESPONSE, multiThreadedStage(Stage.INTERNAL_RESPONSE, FBUtilities.getAvailableProcessors()));

--- a/src/java/org/apache/cassandra/net/MessageIn.java
+++ b/src/java/org/apache/cassandra/net/MessageIn.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.concurrent.ParameterizedSepQueue;
+import org.apache.cassandra.concurrent.KeyspaceAwareSepQueue;
 import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ReadCommand;
@@ -106,7 +106,7 @@ public class MessageIn<T>
     {
         if (payload instanceof ReadCommand) {
             ReadCommand command = (ReadCommand) payload;
-            ParameterizedSepQueue.setQueueingParameter(command);
+            KeyspaceAwareSepQueue.setCurrentKeyspace(command.ksName);
             return command.isCheap() ? Stage.READ_CHEAP : Stage.READ;
         }
         return MessagingService.verbStages.get(verb);

--- a/src/java/org/apache/cassandra/service/AbstractReadExecutor.java
+++ b/src/java/org/apache/cassandra/service/AbstractReadExecutor.java
@@ -26,7 +26,7 @@ import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.concurrent.ParameterizedSepQueue;
+import org.apache.cassandra.concurrent.KeyspaceAwareSepQueue;
 import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.concurrent.StageManager;
 import org.apache.cassandra.config.CFMetaData.SpeculativeRetry.RetryType;
@@ -117,7 +117,7 @@ public abstract class AbstractReadExecutor
         if (hasLocalEndpoint)
         {
             logger.trace("reading {} locally", readCommand.isDigestQuery() ? "digest" : "data");
-            ParameterizedSepQueue.setQueueingParameter(command);
+            KeyspaceAwareSepQueue.setCurrentKeyspace(command.ksName);
             StageManager.getStage(stage(command)).maybeExecuteImmediately(new LocalReadRunnable(command, handler));
         }
     }

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -37,7 +37,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.concurrent.ParameterizedSepQueue;
 import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.concurrent.StageManager;
 import org.apache.cassandra.config.CFMetaData;
@@ -1850,7 +1849,6 @@ public class StorageProxy implements StorageProxyMBean
                     if (filteredEndpoints.size() == 1
                         && filteredEndpoints.get(0).equals(FBUtilities.getBroadcastAddress()))
                     {
-                        ParameterizedSepQueue.setQueueingParameter(command);
                         StageManager.getStage(Stage.READ).execute(new LocalRangeSliceRunnable(nodeCmd, handler));
                     }
                     else


### PR DESCRIPTION
Reverts palantir/cassandra#10

Analyzing this change on some of the larger clusters in our fleet does not show a significant change in performance or latencies. Since it is not in practice providing value we should be reverting back to a state that is close to standard vanilla cassandra.