### PR TITLE
Don't 'maybeExecuteImmediately'

### DIFF
--- a/src/java/org/apache/cassandra/service/AbstractReadExecutor.java
+++ b/src/java/org/apache/cassandra/service/AbstractReadExecutor.java
@@ -118,7 +118,7 @@ public abstract class AbstractReadExecutor
         {
             logger.trace("reading {} locally", readCommand.isDigestQuery() ? "digest" : "data");
             KeyspaceAwareSepQueue.setCurrentKeyspace(command.ksName);
-            StageManager.getStage(stage(command)).maybeExecuteImmediately(new LocalReadRunnable(command, handler));
+            StageManager.getStage(stage(command)).execute(new LocalReadRunnable(command, handler));
         }
     }
 


### PR DESCRIPTION
When running read commands, Cassandra attempts to run the task on the request's thread. This avoids the cost of enqueuing the task. Unfortunately, this code is called while iterating through a _list_, which means that we will until the queue gets backed up, execute the batches serially rather than in parallel. This leads to weird queuing properties; until you get backed up we execute 1 at a time per thread, then when we're backed up we submit all at once.

We replaced the built in C* queue with one that does the fifo-y behaviour we want here; let's try out not queueing in this way.

Potential costs are higher overheads in an unloaded (<64 concurrent queries) environment.

Another solution would be to actually force us to execute our queries one-at-a-time within a request. It'll make Cassandra work much better with regard to single very expensive requests, I think - you can only lock up one core. But this won't happen on the second node we're querying.