### PR TITLE
bump guava to 23.6-jre

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -336,7 +336,7 @@
           <dependency groupId="org.xerial.snappy" artifactId="snappy-java" version="1.1.1.7"/>
           <dependency groupId="net.jpountz.lz4" artifactId="lz4" version="1.3.0"/>
           <dependency groupId="com.ning" artifactId="compress-lzf" version="0.8.4"/>
-          <dependency groupId="com.google.guava" artifactId="guava" version="16.0"/>
+          <dependency groupId="com.google.guava" artifactId="guava" version="23.6-jre"/>
           <dependency groupId="commons-cli" artifactId="commons-cli" version="1.1"/>
           <dependency groupId="commons-codec" artifactId="commons-codec" version="1.2"/>
           <dependency groupId="org.apache.commons" artifactId="commons-lang3" version="3.1"/>


### PR DESCRIPTION
This is safe to make:
- It is compatible with all current usage of guava in the repo (formerly 16.0)
- In practice we've actually been running with 23.6-jre in production for a while

Why? Bumping to 23.6 gives us runtime compatibility with other modern tooling (errorprone is an example) and makes some downstream usage of the cassandra-all library a lot easier.