### PR TITLE
Revert "bump guava to 23.6-jre (#16)"

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -341,7 +341,7 @@
           <dependency groupId="org.xerial.snappy" artifactId="snappy-java" version="1.1.1.7"/>
           <dependency groupId="net.jpountz.lz4" artifactId="lz4" version="1.3.0"/>
           <dependency groupId="com.ning" artifactId="compress-lzf" version="0.8.4"/>
-          <dependency groupId="com.google.guava" artifactId="guava" version="23.6-jre"/>
+          <dependency groupId="com.google.guava" artifactId="guava" version="16.0"/>
           <dependency groupId="commons-cli" artifactId="commons-cli" version="1.1"/>
           <dependency groupId="commons-codec" artifactId="commons-codec" version="1.2"/>
           <dependency groupId="org.apache.commons" artifactId="commons-lang3" version="3.1"/>


### PR DESCRIPTION
This reverts commit 3d08963b93cac2dfffe7c6c25fd696d2c4e9eb09.

As discussed offline; I didn't do due diligence on ensuring this was enough or even correct. This effectively did nothing other than modify our POM. We cannot practically bump guava in this repo without significant changes because of breaks in guava and the datastax java driver's usage of guava.