### PR TITLE
compile with source and target of java 8

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -70,9 +70,9 @@
     <property name="dist.dir" value="${build.dir}/dist"/>
     <property name="tmp.dir" value="${java.io.tmpdir}"/>
 	
-    <property name="source.version" value="1.7"/>
+    <property name="source.version" value="1.8"/>
     <property name="source.test.version" value="1.8"/>
-    <property name="target.version" value="1.7"/>
+    <property name="target.version" value="1.8"/>
     <property name="target.test.version" value="1.8"/>
 	
     <condition property="version" value="${base.version}">


### PR DESCRIPTION
As Leon stated, we should for security reasons not deploy against java 7 anyways.