### PR TITLE
Allow unsafe schema migration mode

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1758,7 +1758,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                         break;
                     case SCHEMA:
                         SystemKeyspace.updatePeerInfo(endpoint, "schema_version", UUID.fromString(value.value));
-                        MigrationManager.instance.scheduleSchemaPull(endpoint, epState);
+                        MigrationManager.instance.scheduleSchemaPull(endpoint, epState, true);
                         break;
                     case HOST_ID:
                         SystemKeyspace.updatePeerInfo(endpoint, "host_id", UUID.fromString(value.value));


### PR DESCRIPTION
By adding a jvm `-Dpalantir_cassandra.unsafe_schema_migration`, cassandra will consider all application state changes of other nodes in the cluster as a result of schema version updates to not require executing a "schema pull" or "migration task".

During period of heavy schema churn, like during a restore, the time it takes to restore the entirety of the schema is significantly longer than the grace period (60 seconds) introduced in [CASSANDRA-5025](https://issues.apache.org/jira/browse/CASSANDRA-5025). As the total size of the schema grows larger and larger during said time period the likelihood of triggering a MigrationTask increases and the cost/complexity of said MigrationTask also increases.

We've seen this result in timeouts and/or OOMs during our restores. During the schema phase of the restore we intend to enable this flag and route all schema modifications through a single node to prevent these failures.