### PR TITLE
option to disable key cache in compactions

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -126,7 +126,7 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
                 boolean save = false;
                 for (SSTableReader reader : transaction.originals())
                 {
-                    if (reader.getCachedPosition(row.key, false) != null)
+                    if (reader.getCachedPosition(row.key, false, true) != null)
                     {
                         save = true;
                         break;

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -1540,11 +1540,33 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
 
     public RowIndexEntry getCachedPosition(DecoratedKey key, boolean updateStats)
     {
-        return getCachedPosition(new KeyCacheKey(metadata.ksAndCFName, descriptor, key.getKey()), updateStats);
+        return getCachedPosition(key, updateStats, false);
+    }
+
+    public RowIndexEntry getCachedPosition(DecoratedKey key, boolean updateStats, boolean isSstableRewrite)
+    {
+        return getCachedPosition(
+                new KeyCacheKey(metadata.ksAndCFName, descriptor, key.getKey()),
+                updateStats,
+                isSstableRewrite);
     }
 
     protected RowIndexEntry getCachedPosition(KeyCacheKey unifiedKey, boolean updateStats)
     {
+        return getCachedPosition(unifiedKey, updateStats, false);
+    }
+
+    protected RowIndexEntry getCachedPosition(KeyCacheKey unifiedKey, boolean updateStats, boolean isSstableRewrite)
+    {
+        //Lock contention in the cache causes unnecessary overhead during compactions that slows the overall compaction
+        //speed to a crawl. We don't need to update the cache on the basis of values read during a compaction anyway
+        //because they don't represent real read load.
+        if (isSstableRewrite && Boolean.getBoolean("palantir_cassandra.disable_sstablerewrite_keycache"))
+        {
+            logger.trace("Not returning cached position of row for SSTable rewrite");
+            return null;
+        }
+
         if (keyCache != null && keyCache.getCapacity() > 0 && metadata.getCaching().keyCache.isEnabled()) {
             if (updateStats)
             {


### PR DESCRIPTION
We've proven that under certain conditions a major compaction of a table where the cluster has the key cache enabled and said cache has capacity that processing keys for the cache can slow down the compaction by as much as one half to one tenth the speed otherwise.

The key cache still has its value so I don't want to disable it across the cluster so much as in the compaction codepaths, where the cache entries are generated not by real user load anyway and thus likely less valuable.

CC @sirstevepal 