### PR TITLE
log size of most interesting bucket

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/SizeTieredCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/SizeTieredCompactionStrategy.java
@@ -96,7 +96,7 @@ public class SizeTieredCompactionStrategy extends AbstractCompactionStrategy
         {
             if (logger.isTraceEnabled())
             {
-                logger.trace("Most interesting bucket for {}.{} is {}", cfs.keyspace.getName(), cfs.getColumnFamilyName(), Arrays.toString(mostInteresting.toArray()));
+                logger.trace("Size of most interesting bucket for {}.{} is {}", cfs.keyspace.getName(), cfs.getColumnFamilyName(), mostInteresting.size());
             }
             return mostInteresting;
         }


### PR DESCRIPTION
since I now have max_threshold for `system.compactions_in_progress` at 1024 in our dist, logging all those paths is waaaay too much