### PR TITLE
Disallow sending gossip messages if the filesystem doesn't work

### DIFF
--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -52,6 +52,7 @@ import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JVMStabilityInspector;
+import org.joda.time.Instant;
 
 import static com.google.common.base.Preconditions.checkState;
 


### PR DESCRIPTION
Internally we've seen a number of cases where our hosts have blown up in
super exciting ways - basically leaving a partially working filesystem.

This leads to huge performance issues whenever that node gets hit.
AtlasDB notices and blacklists the host due to failures, but internal to
Cassandra it continues retrying the host because the failure detector
does not recognize that the service is down. This leads to terrible perf.

In this PR, we force a few filesystem operations in the Gossiper before we're
allowed to write out our digest. This should cause the heartbeat
messages to stop being sent, and for Cassandra to then convict the host.