### PR TITLE
Don't purge tombstones on recipient of range movement

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.db.compaction;
 
 import java.util.*;
 
-import com.google.common.base.Predicates;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.base.Predicate;
@@ -37,8 +36,6 @@ import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
-import org.apache.cassandra.service.StorageService;
-import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 
 /**


### PR DESCRIPTION
**Problem**

We have come across a scenario in which data that is deleted from Cassandra at consistency ALL can permanently re-appear.

The basic idea is that if a delete is issued during a range movement (i.e. bootstrap, decommission, move), and gc_grace_seconds is surpassed before the streams are finished, then the tombstones from the delete can be purged from the recipient node before the data it is deleting is streamed.  Once the move is complete, the data now exists on the recipient node without a tombstone.

**Resolution**

We need to ensure that any node that is the recipient of data in a range move operation does not purge tombstones for data which it has not yet received. 

The methodology for determining a node that is a recipient of a range movement comes from here: https://github.com/apache/cassandra/blob/cassandra-2.2/src/java/org/apache/cassandra/service/StorageService.java#L3517