### PR TITLE
Return number of sstables loaded upon refresh

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -746,7 +746,48 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
         loadNewSSTables(false);
     }
 
-    public synchronized void loadNewSSTables(boolean assumeCfIsEmpty)
+    public synchronized void loadNewSSTables(boolean assumeCfIsEmpty) {
+        loadNewSSTablesWithCount(assumeCfIsEmpty);
+    }
+
+    /**
+     * See #{@code StorageService.loadNewSSTablesWithCount(String, String)} for more info
+     *
+     * @param ksName The keyspace name
+     * @param cfName The columnFamily name
+     *
+     * @return the number of new sstables loaded
+     */
+    public static synchronized int loadNewSSTablesWithCount(String ksName, String cfName)
+    {
+        return loadNewSSTablesWithCount(ksName, cfName, false);
+    }
+
+    /**
+     * See #{@code StorageService.loadNewSSTablesWithCount(String, String, boolean)} for more info
+     *
+     * @param ksName        The keyspace name
+     * @param cfName        The columnFamily name
+     * @param assumeCfIsEmpty   Whether or not we can assume the column family is empty before and while loading the new SSTables
+     *
+     * @return the number of new sstables loaded
+     */
+    public static synchronized int loadNewSSTablesWithCount(String ksName, String cfName, boolean assumeCfIsEmpty)
+    {
+        /** ks/cf existence checks will be done by open and getCFS methods for us */
+        Keyspace keyspace = Keyspace.open(ksName);
+        return keyspace.getColumnFamilyStore(cfName).loadNewSSTablesWithCount(assumeCfIsEmpty);
+    }
+
+    /**
+     * #{@inheritDoc}
+     */
+    public synchronized int loadNewSSTablesWithCount()
+    {
+        return loadNewSSTablesWithCount(false);
+    }
+
+    public synchronized int loadNewSSTablesWithCount(boolean assumeCfIsEmpty)
     {
         logger.info("Loading new SSTables for {}/{}{}...",
                     keyspace.getName(), name,
@@ -830,7 +871,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
         if (newSSTables.isEmpty())
         {
             logger.info("No new SSTables were found for {}/{}", keyspace.getName(), name);
-            return;
+            return 0;
         }
 
         logger.info("Loading new SSTables and building secondary indexes for {}/{}: {}", keyspace.getName(), name, newSSTables);
@@ -842,6 +883,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
         }
 
         logger.info("Done loading load new SSTables for {}/{}", keyspace.getName(), name);
+        return newSSTables.size();
     }
 
     public void rebuildSecondaryIndex(String idxName)

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStoreMBean.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStoreMBean.java
@@ -146,6 +146,13 @@ public interface ColumnFamilyStoreMBean
     public void loadNewSSTables();
 
     /**
+     * Scan through Keyspace/ColumnFamily's data directory
+     * determine which SSTables should be loaded and load them
+     * @return the number of sstables loaded
+     */
+    public int loadNewSSTablesWithCount();
+
+    /**
      * @return the number of SSTables in L0.  Always return 0 if Leveled compaction is not enabled.
      */
     public int getUnleveledSSTables();

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5154,6 +5154,22 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     /**
      * #{@inheritDoc}
      */
+    public int loadNewSSTablesWithCount(String ksName, String cfName)
+    {
+        return ColumnFamilyStore.loadNewSSTablesWithCount(ksName, cfName, false);
+    }
+
+    /**
+     * #{@inheritDoc}
+     */
+    public int loadNewSSTablesWithCount(String ksName, String cfName, boolean assumeCfIsEmpty)
+    {
+        return ColumnFamilyStore.loadNewSSTablesWithCount(ksName, cfName, assumeCfIsEmpty);
+    }
+
+    /**
+     * #{@inheritDoc}
+     */
     public List<String> sampleKeyRange() // do not rename to getter - see CASSANDRA-4452 for details
     {
         List<DecoratedKey> keys = new ArrayList<>();

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -631,6 +631,27 @@ public interface StorageServiceMBean extends NotificationEmitter
     public void loadNewSSTables(String ksName, String cfName, boolean assumeCfIsEmpty);
 
     /**
+     * Load new SSTables to the given keyspace/columnFamily
+     *
+     * @param ksName The parent keyspace name
+     * @param cfName The ColumnFamily name where SSTables belong
+     *
+     * @return the number of new sstables loaded
+     */
+    public int loadNewSSTablesWithCount(String ksName, String cfName);
+
+    /**
+     * Load new SSTables to the given keyspace/columnFamily
+     *
+     * @param ksName            The parent keyspace name
+     * @param cfName            The ColumnFamily name where SSTables belong
+     * @param assumeCfIsEmpty   Whether or not we can assume the column family is empty before and while loading the new SSTables
+     *
+     * @return the number of new sstables loaded
+     */
+    public int loadNewSSTablesWithCount(String ksName, String cfName, boolean assumeCfIsEmpty);
+
+    /**
      * Return a List of Tokens representing a sample of keys across all ColumnFamilyStores.
      *
      * Note: this should be left as an operation, not an attribute (methods starting with "get")

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1120,6 +1120,11 @@ public class NodeProbe implements AutoCloseable
         ssProxy.loadNewSSTables(ksName, cfName, assumeCfIsEmpty);
     }
 
+    public int loadNewSSTablesWithCount(String ksName, String cfName, boolean assumeCfIsEmpty)
+    {
+        return ssProxy.loadNewSSTablesWithCount(ksName, cfName, assumeCfIsEmpty);
+    }
+
     public void rebuildIndex(String ksName, String cfName, String... idxNames)
     {
         ssProxy.rebuildSecondaryIndex(ksName, cfName, idxNames);


### PR DESCRIPTION
loadNewSSTablesWithCount returns an int representing the number of sstables loaded.

Port from Cassandra 2.2.