### PR TITLE
Metric for max total commit log size (#51)

### DIFF
--- a/src/java/org/apache/cassandra/metrics/CommitLogMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CommitLogMetrics.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.metrics;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Timer;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.commitlog.AbstractCommitLogService;
 import org.apache.cassandra.db.commitlog.AbstractCommitLogSegmentManager;
 
@@ -37,6 +38,8 @@ public class CommitLogMetrics
     public Gauge<Long> pendingTasks;
     /** Current size used by all the commit log segments */
     public Gauge<Long> totalCommitLogSize;
+    /** Max total size for all commit log segments, as set in cassandra.yaml */
+    public Gauge<Long> maxTotalCommitLogSizeBytes;
     /** Time spent waiting for a CLS to be allocated - under normal conditions this should be zero */
     public final Timer waitingOnSegmentAllocation;
     /** The time spent waiting on CL sync; for Periodic this is only occurs when the sync is lagging its sync interval */
@@ -69,6 +72,13 @@ public class CommitLogMetrics
             public Long getValue()
             {
                 return segmentManager.onDiskSize();
+            }
+        });
+        maxTotalCommitLogSizeBytes = Metrics.register(factory.createMetricName("MaxTotalCommitLogSizeBytes"), new Gauge<Long>()
+        {
+            public Long getValue()
+            {
+                return DatabaseDescriptor.getTotalCommitlogSpaceInMB() * 1024 * 1024;
             }
         });
     }


### PR DESCRIPTION
Port from Palantir Cassandra 2.2.