### PR TITLE
Add metric for total compactions completed

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -273,6 +273,7 @@ public class CompactionTask extends AbstractCompactionTask
 
                 // update the metrics
                 cfs.metric.compactionBytesWritten.inc(endsize);
+                cfs.metric.compactionsCompleted.inc();
             }
         }
     }

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -88,6 +88,8 @@ public class TableMetrics
     public final Counter bytesFlushed;
     /** Total number of bytes written by compaction since server [re]start */
     public final Counter compactionBytesWritten;
+    /** Total number of compactions since server [re]start */
+    public final Counter compactionsCompleted;
     /** Estimate of number of pending compactios for this table */
     public final Gauge<Integer> pendingCompactions;
     /** Number of SSTables on disk for this CF */
@@ -411,6 +413,7 @@ public class TableMetrics
         pendingFlushes = createTableCounter("PendingFlushes");
         bytesFlushed = createTableCounter("BytesFlushed");
         compactionBytesWritten = createTableCounter("CompactionBytesWritten");
+        compactionsCompleted = createTableCounter("CompactionsCompleted");
         pendingCompactions = createTableGauge("PendingCompactions", new Gauge<Integer>()
         {
             public Integer getValue()


### PR DESCRIPTION
Similar to #30, but Cassandra 3 already includes a metric for `compactionBytesWritten`.  This is a breaking change since both metrics are named differently, and are Counters rather than Meters.

Reviewer: should we change these to Meters, or are Counters okay?  Are we fine with the metric name change (my preference is to use new names)?
