### PR TITLE
only lookup and load jvm prop at startup

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -136,6 +136,8 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
     private static final Logger logger = LoggerFactory.getLogger(SSTableReader.class);
     private static final int ACCURATE_BOUNDARIES_MAGIC_NUMBER = 248923458;
 
+    private static final boolean DISABLE_SSTABLE_REWRITE_KEYCACHE = Boolean.getBoolean("palantir_cassandra.disable_sstablerewrite_keycache");
+
     private static final ScheduledThreadPoolExecutor syncExecutor = new ScheduledThreadPoolExecutor(1);
     static
     {
@@ -1561,7 +1563,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         //Lock contention in the cache causes unnecessary overhead during compactions that slows the overall compaction
         //speed to a crawl. We don't need to update the cache on the basis of values read during a compaction anyway
         //because they don't represent real read load.
-        if (isSstableRewrite && Boolean.getBoolean("palantir_cassandra.disable_sstablerewrite_keycache"))
+        if (isSstableRewrite && DISABLE_SSTABLE_REWRITE_KEYCACHE)
         {
             logger.trace("Not returning cached position of row for SSTable rewrite");
             return null;


### PR DESCRIPTION
noticed we were spending more time in the `Boolean#getBoolean` codepath on a major compact than I would have liked.

we're not doing anything crazy like modifying system properties at runtime so this value should be safe to lookup once and store at the class level