### PR TITLE
no schema migration task if remote version has changed

### DIFF
--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -143,8 +143,11 @@ public class MigrationManager
                     if (!currentVersion.equals(theirVersion))
                     {
                         logger.debug("A subsequent change has been made to the other endpoint's schema version and " +
-                                     "so we should wait for the subsequently scheduled task instead of trying to " +
-                                     "do the work in this one.  Endpoint {}", endpoint);
+                                "so we should wait for the subsequently scheduled task instead of trying to do the " +
+                                "work in this one. Endpoint: {}; Former schema version: {}; Current schema version: {}",
+                                endpoint,
+                                theirVersion,
+                                currentVersion);
                         return;
                     }
 


### PR DESCRIPTION
When a schema change happens, we schedule a schema pull for 60 seconds
in the future because we expect to be pushed the schema change by the
coordinator. If we're at sync at that point, it no-ops.

Unfortunately, if changes are constantly happening (due to e.g. creating
100 tables), then all of these schema change pull tasks will

1) do redundant work
2) potentially oom cassandra by running a bajillion schema pulls.

This PR makes it so that the task will only pull the schema version if
it is still equivalent to the one that we started the task with. If the
schema version has been subsequently updated, we will simply exit
immediately.

This should also enable us to remove
palantir_cassandra.unsafe_schema_migration.