### PR TITLE
don't publish the 3.11.4 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,3 @@ workflows:
       - artifacts:
           requires: [ build ]
           filters: { tags: { only: /.*/ } }
-      - publish:
-          requires: [ build, test , artifacts ]
-          filters: { tags: { only: /.*/ }, branches: { only: palantir-cassandra-3.11.4 } }


### PR DESCRIPTION
just a temporary measure so circle success/failure is higher signal