### PR TITLE
Add a kind of prioritization for compactions

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
@@ -156,6 +156,11 @@ public abstract class AbstractCompactionStrategy
     public abstract AbstractCompactionTask getNextBackgroundTask(final int gcBefore);
 
     /**
+     * Returns a higher-priority task that must occur soon for safety reasons, if one exists. E.g. LCS STCS L0 compactions.
+     */
+    public abstract AbstractCompactionTask getNextCriticalBackgroundTask(final int gcBefore);
+
+    /**
      * @param gcBefore throw away tombstones older than this
      *
      * @return a compaction task that should be run to compact this columnfamilystore

--- a/src/java/org/apache/cassandra/db/compaction/DateTieredCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/DateTieredCompactionStrategy.java
@@ -75,6 +75,12 @@ public class DateTieredCompactionStrategy extends AbstractCompactionStrategy
         }
     }
 
+    @Override
+    public AbstractCompactionTask getNextCriticalBackgroundTask(int gcBefore)
+    {
+        return null;
+    }
+
     /**
      *
      * @param gcBefore

--- a/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
@@ -356,7 +356,7 @@ public class LeveledManifest
         return new CompactionCandidate(candidates, getNextLevel(candidates), cfs.getCompactionStrategy().getMaxSSTableBytes());
     }
 
-    private CompactionCandidate getSTCSInL0CompactionCandidate()
+    protected CompactionCandidate getSTCSInL0CompactionCandidate()
     {
         if (!DatabaseDescriptor.getDisableSTCSInL0() && getLevel(0).size() > MAX_COMPACTING_L0)
         {

--- a/src/java/org/apache/cassandra/db/compaction/SizeTieredCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/SizeTieredCompactionStrategy.java
@@ -202,6 +202,12 @@ public class SizeTieredCompactionStrategy extends AbstractCompactionStrategy
         }
     }
 
+    @Override
+    public AbstractCompactionTask getNextCriticalBackgroundTask(int gcBefore)
+    {
+        return null;
+    }
+
     @SuppressWarnings("resource")
     public Collection<AbstractCompactionTask> getMaximalTask(final int gcBefore, boolean splitOutput)
     {

--- a/src/java/org/apache/cassandra/db/compaction/WrappingCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/WrappingCompactionStrategy.java
@@ -99,6 +99,19 @@ public final class WrappingCompactionStrategy extends AbstractCompactionStrategy
     }
 
     @Override
+    public AbstractCompactionTask getNextCriticalBackgroundTask(int gcBefore)
+    {
+        if (!isEnabled())
+            return null;
+
+        AbstractCompactionTask task = repaired.getNextCriticalBackgroundTask(gcBefore);
+        if (task != null) {
+            return task;
+        }
+        return unrepaired.getNextCriticalBackgroundTask(gcBefore);
+    }
+
+    @Override
     public Collection<AbstractCompactionTask> getMaximalTask(final int gcBefore, final boolean splitOutput)
     {
         // runWithCompactionsDisabled cancels active compactions and disables them, then we are able


### PR DESCRIPTION
This is really simple - add a kind of 'critical compaction' which
executes in parallel to normal compactions and basically just means
'if lcs were to run a stcs on l0, do that one'. Basically if the system
thinks it's getting into a bad state, prioritize fixing that.