### PR TITLE
Remove forceCompactionForTokenRange from ColumnFamilyStoreMBean

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStoreMBean.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStoreMBean.java
@@ -17,16 +17,12 @@
  */
 package org.apache.cassandra.db;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.OpenDataException;
-
-import org.apache.cassandra.dht.Range;
-import org.apache.cassandra.dht.Token;
 
 /**
  * The MBean interface for ColumnFamilyStore
@@ -48,10 +44,6 @@ public interface ColumnFamilyStoreMBean
      */
     public void forceMajorCompaction(boolean splitOutput) throws ExecutionException, InterruptedException;
 
-    /**
-     * force a major compaction of specified key range in this column family
-     */
-    public void forceCompactionForTokenRange(Collection<Range<Token>> tokenRanges) throws ExecutionException, InterruptedException;
     /**
      * Gets the minimum number of sstables in queue before compaction kicks off
      */


### PR DESCRIPTION
Using gradle magic in https://github.com/palantir/cassandra/blob/palantir-cassandra-2.2.14/palantir-cassandra-jmx-api/build.gradle we pull out the MBeans into their own project.  However, this method requires knowledge of classes in the Cassandra package, which we do not want to pull in.

Since we don't use this function, we can just remove it from the interface.