### PR TITLE
Separate Cassandra and Palantir version with 'pt'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ allprojects {
         'ant-' + antTaskName
     }
 
-    version ant.'base.version' + '-' + gitVersion()
+    version ant.'base.version' + '-pt-' + gitVersion()
     group 'com.palantir.cassandra'
 
     // so the artifacts have our name and version, not apache's

--- a/src/java/org/apache/cassandra/utils/CassandraVersion.java
+++ b/src/java/org/apache/cassandra/utils/CassandraVersion.java
@@ -22,6 +22,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -59,7 +61,9 @@ public class CassandraVersion implements Comparable<CassandraVersion>
     public CassandraVersion(String version)
     {
         String stripped = SNAPSHOT.matcher(version).replaceFirst("");
-        Matcher matcher = pattern.matcher(stripped);
+        String cassandraVersion = Iterables.get(Splitter.on("-pt-").split(stripped), 0);
+
+        Matcher matcher = pattern.matcher(cassandraVersion);
         if (!matcher.matches())
             throw new IllegalArgumentException("Invalid version value: " + version);
 

--- a/test/unit/org/apache/cassandra/utils/CassandraVersionTest.java
+++ b/test/unit/org/apache/cassandra/utils/CassandraVersionTest.java
@@ -52,6 +52,21 @@ public class CassandraVersionTest
     }
 
     @Test
+    public void testPalantirVersionsParse()
+    {
+        CassandraVersion version;
+
+        version = new CassandraVersion("2.2.14-pt-1.10.0");
+        assertTrue(version.major == 2 && version.minor == 2 && version.patch == 14);
+
+        version = new CassandraVersion("3.11.4-pt-2.0.0");
+        assertTrue(version.major == 3 && version.minor == 11 && version.patch == 4);
+
+        version = new CassandraVersion("3.11.4-pt-2.0.0-rc1");
+        assertTrue(version.major == 3 && version.minor == 11 && version.patch == 4);
+    }
+
+    @Test
     public void testComparison()
     {
         CassandraVersion v1, v2;


### PR DESCRIPTION
Cassandra 3 has more stringent requirements for its version number, which it uses for various validations.  Since we supply our own version number, let's separate the Palantir part with a "pt" prefix and strip that in Cassandra.