### PR TITLE
Fix thrift interface version

### DIFF
--- a/interface/thrift/gen-java/org/apache/cassandra/thrift/cassandraConstants.java
+++ b/interface/thrift/gen-java/org/apache/cassandra/thrift/cassandraConstants.java
@@ -55,6 +55,6 @@ import org.slf4j.LoggerFactory;
 
 public class cassandraConstants {
 
-  public static final String VERSION = "20.1.0-pt0";
+  public static final String VERSION = "20.1.0-pt2";
 
 }


### PR DESCRIPTION
In #83, the version was updated in `cassandra.thrift` but not in the generated Java code.

See https://github.com/palantir/cassandra/blob/palantir-cassandra-2.2.14/interface/thrift/gen-java/org/apache/cassandra/thrift/cassandraConstants.java#L59 for 2.2.14 equivalent.