### PR TITLE
Don't throw SyntaxException on obsolete keywords

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/TableAttributes.java
+++ b/src/java/org/apache/cassandra/cql3/statements/TableAttributes.java
@@ -46,7 +46,11 @@ public final class TableAttributes extends PropertyDefinitions
             validBuilder.add(option.toString());
         validBuilder.add(KW_ID);
         validKeywords = validBuilder.build();
-        obsoleteKeywords = ImmutableSet.of();
+        // These keywords are no longer used, but still supported by the Thrift API
+        obsoleteKeywords = ImmutableSet.of(
+            "index_interval",
+            "replicate_on_write",
+            "populate_io_cache_on_flush");
     }
 
     public void validate()


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/CASSANDRA-15408

The Thrift API still supports the use of these obsolete keywords, but Cassandra will throw a syntax exception due to a refactor that did not include these.  Add them back as no-op keywords.