### PR TITLE
Docker: make entrypoint executable

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,10 +7,10 @@ ENV CASSANDRA_ENV $CASSANDRA_CONFIG/cassandra-env.sh
 
 COPY cassandra.yaml $CASSANDRA_YAML
 COPY cassandra-env.sh $CASSANDRA_ENV
+
 COPY entrypoint.sh /entrypoint.sh
+RUN ["chmod", "+x", "/entrypoint.sh"]
 
 EXPOSE 7000 7001 7199 9042 9160
-
-RUN ["chmod", "+x", "/entrypoint.sh"]
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["cassandra", "-f"]


### PR DESCRIPTION
After copying the entry point file, we need to make it executable.  Otherwise docker is failing with:

```
[00:00:39]     ERROR: for atlasdbcontainers_cassandra_1  Cannot start service cassandra: b'OCI runtime create failed: container_linux.go:346: starting container process caused "exec: \\"/entrypoint.sh\\": permission denied": unknown'
```
