### PR TITLE
Add max size paging to Cassandra

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1902,7 +1902,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
                 // If the filter count is less than the number of rows cached, we simply extend it to make sure we do cover the
                 // number of rows to cache, and if that count is greater than the number of rows to cache, we simply filter what
                 // needs to be cached afterwards.
-                if (sliceFilter.count < rowsToCache)
+                if (sliceFilter.count() < rowsToCache)
                 {
                     toCache = getTopLevelColumns(cacheFilter, Integer.MIN_VALUE);
                     if (toCache != null)
@@ -1922,7 +1922,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
                         if (sliceFilter.finish().isEmpty() || sliceFilter.lastCounted() >= rowsToCache)
                         {
                             toCache = filterColumnFamily(data, cacheFilter);
-                            Tracing.trace("Caching {} rows (out of {} requested)", cacheSlice.lastCounted(), sliceFilter.count);
+                            Tracing.trace("Caching {} rows (out of {} requested)", cacheSlice.lastCounted(), sliceFilter.count());
                         }
                         else
                         {
@@ -2409,7 +2409,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
             assert sfilter.slices.length == 1;
             // create a new SliceQueryFilter that selects all cells, but pass the original slice start and finish
             // through to DataRange.Paging to be used on the first and last partitions
-            SliceQueryFilter newFilter = new SliceQueryFilter(ColumnSlice.ALL_COLUMNS_ARRAY, sfilter.isReversed(), sfilter.count);
+            SliceQueryFilter newFilter = new SliceQueryFilter(ColumnSlice.ALL_COLUMNS_ARRAY, sfilter.isReversed(), sfilter.count());
             dataRange = new DataRange.Paging(range, newFilter, sfilter.start(), sfilter.finish(), metadata);
         }
         else

--- a/src/java/org/apache/cassandra/db/DataRange.java
+++ b/src/java/org/apache/cassandra/db/DataRange.java
@@ -62,7 +62,7 @@ public class DataRange
         return filter.slices.length == 1
             && filter.start().isEmpty()
             && filter.finish().isEmpty()
-            && filter.count == Integer.MAX_VALUE;
+            && filter.count() == Integer.MAX_VALUE;
     }
 
     public static DataRange allData(IPartitioner partitioner)

--- a/src/java/org/apache/cassandra/db/PagedRangeCommand.java
+++ b/src/java/org/apache/cassandra/db/PagedRangeCommand.java
@@ -186,7 +186,7 @@ public class PagedRangeCommand extends AbstractRangeCommand
             int limit = in.readInt();
             boolean countCQL3Rows = version >= MessagingService.VERSION_21
                                   ? in.readBoolean()
-                                  : predicate.compositesToGroup >= 0 || predicate.count != 1; // See #6857
+                                  : predicate.compositesToGroup >= 0 || predicate.count() != 1; // See #6857
             return new PagedRangeCommand(keyspace, columnFamily, timestamp, keyRange, predicate, start, stop, rowFilter, limit, countCQL3Rows);
         }
 

--- a/src/java/org/apache/cassandra/db/RetriedSliceFromReadCommandMaxBytes.java
+++ b/src/java/org/apache/cassandra/db/RetriedSliceFromReadCommandMaxBytes.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db;
+
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.db.filter.SliceQueryFilter;
+
+public class RetriedSliceFromReadCommandMaxBytes extends SliceFromReadCommand
+{
+    public final int originalBytes;
+
+    public RetriedSliceFromReadCommandMaxBytes(String keyspaceName, ByteBuffer key, String cfName, long timestamp, SliceQueryFilter filter, int originalBytes)
+    {
+        super(keyspaceName, key, cfName, timestamp, filter);
+        this.originalBytes = originalBytes;
+    }
+
+    @Override
+    public ReadCommand copy()
+    {
+        return new RetriedSliceFromReadCommandMaxBytes(ksName, key, cfName, timestamp, filter, originalBytes).setIsDigestQuery(isDigestQuery());
+    }
+
+    @Override
+    public int getOriginalRequestedBytes()
+    {
+        return originalBytes;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "RetriedSliceFromReadCommandMaxBytes(" + "cmd=" + super.toString() + ", originalCount=" + originalBytes + ")";
+    }
+
+}

--- a/src/java/org/apache/cassandra/db/SuperColumns.java
+++ b/src/java/org/apache/cassandra/db/SuperColumns.java
@@ -213,7 +213,7 @@ public class SuperColumns
             Composite finish = filter.finish().isEmpty()
                              ? Composites.EMPTY
                              : builder.buildWith(filter.finish().toByteBuffer()).withEOC(filter.reversed ? Composite.EOC.START : Composite.EOC.END);
-            return new SliceQueryFilter(start, finish, filter.reversed, filter.count, 1);
+            return new SliceQueryFilter(start, finish, filter.reversed, filter.count(), 1);
         }
         else
         {
@@ -224,7 +224,7 @@ public class SuperColumns
             Composite end = filter.finish().isEmpty()
                           ? builder.build().withEOC(filter.reversed ? Composite.EOC.START : Composite.EOC.END)
                           : builder.buildWith(filter.finish().toByteBuffer());
-            return new SliceQueryFilter(start, end, filter.reversed, filter.count);
+            return new SliceQueryFilter(start, end, filter.reversed, filter.count());
         }
     }
 }

--- a/src/java/org/apache/cassandra/db/filter/ColumnCounter.java
+++ b/src/java/org/apache/cassandra/db/filter/ColumnCounter.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.db.DeletionInfo;
 public class ColumnCounter
 {
     protected int live;
+    private int bytes;
     protected int tombstones;
     protected final long timestamp;
 
@@ -50,9 +51,10 @@ public class ColumnCounter
         if (tester.isDeleted(cell))
             return false;
 
-        if (cell.isLive(timestamp))
+        if (cell.isLive(timestamp)) {
             live++;
-        else
+            bytes = Math.addExact(bytes, cell.cellDataSize());
+        } else
             tombstones++;
 
         return true;
@@ -61,6 +63,10 @@ public class ColumnCounter
     public int live()
     {
         return live;
+    }
+
+    public int liveBytes() {
+        return bytes;
     }
 
     public int tombstones()
@@ -73,6 +79,10 @@ public class ColumnCounter
      */
     public boolean hasSeenAtLeast(int numLiveCellsDesired) {
         return live() >= numLiveCellsDesired;
+    }
+
+    public boolean hasSeenBytesAtLeast(int numBytesDesired) {
+        return bytes >= numBytesDesired;
     }
 
     public ColumnCounter countAll(ColumnFamily container)

--- a/src/java/org/apache/cassandra/db/filter/IDiskAtomFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/IDiskAtomFilter.java
@@ -77,6 +77,7 @@ public interface IDiskAtomFilter
     public void updateColumnsLimit(int newLimit);
 
     public int getLiveCount(ColumnFamily cf, long now);
+    public int getLiveBytes(ColumnFamily cf, long now);
     public ColumnCounter columnCounter(CellNameType comparator, long now);
 
     public IDiskAtomFilter cloneShallow();

--- a/src/java/org/apache/cassandra/db/filter/NamesQueryFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/NamesQueryFilter.java
@@ -139,6 +139,17 @@ public class NamesQueryFilter implements IDiskAtomFilter
         return count;
     }
 
+    public int getLiveBytes(ColumnFamily cf, long now)
+    {
+        int count = 0;
+        for (Cell cell : cf) {
+            if (cell.isLive(now)) {
+                count = Math.addExact(count, cell.cellDataSize());
+            }
+        }
+        return count;
+    }
+
     public boolean maySelectPrefix(CType type, Composite prefix)
     {
         for (CellName column : columns)

--- a/src/java/org/apache/cassandra/service/RowDataResolver.java
+++ b/src/java/org/apache/cassandra/service/RowDataResolver.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.utils.FBUtilities;
 public class RowDataResolver extends AbstractRowResolver
 {
     private int maxLiveCount = 0;
+    private int maxLiveBytes = 0;
     public List<AsyncOneResponse> repairResults = Collections.emptyList();
     private final IDiskAtomFilter filter;
     private final long timestamp;
@@ -81,6 +82,9 @@ public class RowDataResolver extends AbstractRowResolver
                 int liveCount = cf == null ? 0 : filter.getLiveCount(cf, timestamp);
                 if (liveCount > maxLiveCount)
                     maxLiveCount = liveCount;
+                int liveBytes = cf == null ? 0 : filter.getLiveBytes(cf, timestamp);
+                if (liveBytes > maxLiveBytes)
+                    maxLiveBytes = liveBytes;
             }
 
             resolved = resolveSuperset(versions, timestamp);
@@ -171,6 +175,11 @@ public class RowDataResolver extends AbstractRowResolver
     }
 
     public int getMaxLiveCount()
+    {
+        return maxLiveCount;
+    }
+
+    public int getMaxLiveBytes()
     {
         return maxLiveCount;
     }

--- a/src/java/org/apache/cassandra/service/pager/QueryPagers.java
+++ b/src/java/org/apache/cassandra/service/pager/QueryPagers.java
@@ -48,7 +48,7 @@ public class QueryPagers
         else
         {
             SliceQueryFilter filter = ((SliceFromReadCommand)command).filter;
-            return filter.count;
+            return filter.count();
         }
     }
 
@@ -78,7 +78,7 @@ public class QueryPagers
             // get a RangeSliceCommand from CQL3 without the countCQL3Rows flag set is for DISTINCT. In that case
             // however, the underlying sliceQueryFilter count is 1, so that the RSC limit is still a limit on the
             // number of CQL3 rows returned.
-            assert rsc.countCQL3Rows || (rsc.predicate instanceof SliceQueryFilter && ((SliceQueryFilter)rsc.predicate).count == 1);
+            assert rsc.countCQL3Rows || (rsc.predicate instanceof SliceQueryFilter && ((SliceQueryFilter)rsc.predicate).count() == 1);
             return rsc.maxResults > pageSize;
         }
     }

--- a/src/java/org/apache/cassandra/service/pager/RangeSliceQueryPager.java
+++ b/src/java/org/apache/cassandra/service/pager/RangeSliceQueryPager.java
@@ -74,7 +74,7 @@ public class RangeSliceQueryPager extends AbstractQueryPager
     throws RequestExecutionException
     {
         SliceQueryFilter rawFilter = (SliceQueryFilter)columnFilter;
-        SliceQueryFilter sf = rawFilter.withUpdatedCount(Math.min(rawFilter.count, pageSize));
+        SliceQueryFilter sf = rawFilter.withUpdatedCount(Math.min(rawFilter.count(), pageSize));
         AbstractBounds<RowPosition> keyRange = lastReturnedKey == null ? command.keyRange : makeIncludingKeyBounds(lastReturnedKey);
         // For DISTINCT queries we can and must ignore the lastReturnedName (see CASSANDRA-13017)
         Composite start = lastReturnedName == null || isDistinct() ? sf.start() : lastReturnedName;

--- a/src/java/org/apache/cassandra/service/pager/SliceQueryPager.java
+++ b/src/java/org/apache/cassandra/service/pager/SliceQueryPager.java
@@ -48,7 +48,7 @@ public class SliceQueryPager extends AbstractQueryPager implements SinglePartiti
     // Don't use directly, use QueryPagers method instead
     SliceQueryPager(SliceFromReadCommand command, ConsistencyLevel consistencyLevel, ClientState cstate, boolean localQuery)
     {
-        super(consistencyLevel, command.filter.count, localQuery, command.ksName, command.cfName, command.filter, command.timestamp);
+        super(consistencyLevel, command.filter.count(), localQuery, command.ksName, command.cfName, command.filter, command.timestamp);
         this.command = command;
         this.cstate = cstate;
     }
@@ -85,7 +85,7 @@ public class SliceQueryPager extends AbstractQueryPager implements SinglePartiti
         // For some queries, such as a DISTINCT query on static columns, the limit for slice queries will be lower
         // than the page size (in the static example, it will be 1).  We use the min here to ensure we don't fetch
         // more rows than we're supposed to.  See CASSANDRA-8108 for more details.
-        SliceQueryFilter filter = command.filter.withUpdatedCount(Math.min(command.filter.count, pageSize));
+        SliceQueryFilter filter = command.filter.withUpdatedCount(Math.min(command.filter.count(), pageSize));
         if (lastReturned != null)
             filter = filter.withUpdatedStart(lastReturned, cfm);
 

--- a/src/java/org/apache/cassandra/thrift/ThriftValidation.java
+++ b/src/java/org/apache/cassandra/thrift/ThriftValidation.java
@@ -267,9 +267,6 @@ public class ThriftValidation
 
     public static void validateRange(CFMetaData metadata, ColumnParent column_parent, SliceRange range) throws org.apache.cassandra.exceptions.InvalidRequestException
     {
-        if (range.count < 0)
-            throw new org.apache.cassandra.exceptions.InvalidRequestException("get_slice requires non-negative count");
-
         int maxNameLength = Cell.MAX_NAME_LENGTH;
         if (range.start.remaining() > maxNameLength)
             throw new org.apache.cassandra.exceptions.InvalidRequestException("range start length cannot be larger than " + maxNameLength);

--- a/test/unit/org/apache/cassandra/thrift/MultiGetMultiSliceTest.java
+++ b/test/unit/org/apache/cassandra/thrift/MultiGetMultiSliceTest.java
@@ -70,6 +70,8 @@ public class MultiGetMultiSliceTest
     = keyPredicateForRange(PARTITION_1, COLUMN_A, COLUMN_Z, 3);
     private static final KeyPredicate PARTITION_1_RANGE_THREE_FROM_B_TO_Z
     = keyPredicateForRange(PARTITION_1, COLUMN_B, COLUMN_Z, 3);
+    private static final KeyPredicate PARTITION_1_MAX_TEN_BYTES
+    = keyPredicateForRange(PARTITION_1, COLUMN_A, COLUMN_Z, -10);
 
     private static CassandraServer server;
 
@@ -85,6 +87,16 @@ public class MultiGetMultiSliceTest
                                     SchemaLoader.standardCFMD(KEYSPACE, CF_STANDARD));
         server = new CassandraServer();
         server.set_keyspace(KEYSPACE);
+    }
+
+    @Test
+    public void canFilterByMaxSize() throws TimedOutException, UnavailableException, InvalidRequestException
+    {
+        ColumnParent cp = new ColumnParent(CF_STANDARD);
+        addTheAlphabetToRow(PARTITION_1, cp);
+        List<KeyPredicate> request = ImmutableList.of(PARTITION_1_MAX_TEN_BYTES);
+        Map<ByteBuffer, List<List<ColumnOrSuperColumn>>> result = server.multiget_multislice(request, cp, ConsistencyLevel.ONE);
+        assertColumnNamesMatchPrecisely(ImmutableList.of(COLUMN_A, COLUMN_B), Iterables.getOnlyElement(result.get(PARTITION_1)));
     }
 
     @Test


### PR DESCRIPTION
Right now the user of Cassandra must pick an appropriate batch size.
This means that the user is on the critical path to ensuring safety;
a table with 100kB cells has a very different max safe size than a table
with 1kB cells.

In practice, this means that we generally pick a very small batch size,
which decreases performance considerably. This PR enables greater
performance and safety.

1. A negative limit is understood to be 'max bytes' (this is expressed
as such in order to not change the Cassandra serialization format).
When we filter on slices, we count the number of bytes read, and return at most one cell past the max bytes.
2. We make the current field for count private, and appropriately
protect against misinterpretation.
3. Most of the usages of this field are for CQL things - make these
access the current max count in the current way, and make them throw as
necessary.
4. The other case is related to retries when nodes disagree - in this
case create an analogue for the current behaviour for the new behaviour
(increase sizes in the cases where multiple nodes returned values but
some were tombstoned by other nodes).

Broadly, this should mean that we can safely up our page sizes.

This is one of 2 PRs we'd need to make in order to solve this for us overall. The other such PR is range scans, which is a little more complicated but is roughly the same approach.