### PR TITLE
Dump timings in dynamic snitch nodetool command

### DIFF
--- a/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
+++ b/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
@@ -24,14 +24,10 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.codahale.metrics.ExponentiallyDecayingReservoir;
 
 import org.apache.cassandra.concurrent.ScheduledExecutors;
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
@@ -258,7 +254,6 @@ public class DynamicEndpointSnitch extends AbstractEndpointSnitch implements ILa
         {
             double mean = entry.getValue().getSnapshot().getMedian();
             if (mean > maxLatency)
-
                 maxLatency = mean;
         }
         // now make another pass to do the weighting based on the maximums we found before


### PR DESCRIPTION
I want to see the actual timings as well, so added a flag that will show the timings in the output if desired. Unchanged behavior if `-t` is not added

```
$ ./nodetool dynamicendpointsnitchstats -t
Dynamic Endpoint Snitch Configuration:
        Update Interval (ms): 100
        Reset Interval (ms): 600000
        Badness Threshold: 2.0
        Subsnitch: org.apache.cassandra.locator.GossipingPropertyFileSnitch
        Severity: 0.39630118012428284
Dynamic Endpoint Snitch Scores:
        <host1>: 1.0
        <host2>: 0.0
        <host3>: 0.5
        <host4>: 0.5
        <host5>: 0.0
        <host6>: 0.0
Timings sent to Dynamic Snitch (ms):
        <host1>:
                0.000000 ms (32 occurrences)
                1.000000 ms (29 occurrences)
                2.000000 ms (16 occurrences)
                3.000000 ms (11 occurrences)
                4.000000 ms (10 occurrences)
                5.000000 ms (2 occurrences)
        <host2>:
                0.000000 ms (72 occurrences)
                1.000000 ms (8 occurrences)
                2.000000 ms (3 occurrences)
                3.000000 ms (3 occurrences)
                4.000000 ms (4 occurrences)
                5.000000 ms (5 occurrences)
                6.000000 ms (4 occurrences)
                7.000000 ms (1 occurrences)
        <host3>:
[...]
```