### PR TITLE
Add buffer to compaction space calculation

### DIFF
--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -92,7 +92,7 @@ public class Directories
     // If conservative compaction is enabled, add a buffer of CONSERVATIVE_COMPACTION_BUFFER_SPACE to the
     // minimum required available space to perform a set of compactions
     private static final boolean CONSERVATIVE_COMPACTION = Boolean.getBoolean("palantir_cassandra.conservative_compaction");
-    private static final long CONSERVATIVE_COMPACTION_BUFFER_SPACE = 10 * FileUtils.ONE_GB;
+    private static final long CONSERVATIVE_COMPACTION_BUFFER_SPACE = CONSERVATIVE_COMPACTION ? 10 * FileUtils.ONE_GB : 0;
 
     public static final String BACKUPS_SUBDIR = "backups";
     public static final String SNAPSHOT_SUBDIR = "snapshots";
@@ -407,8 +407,7 @@ public class Directories
             totalAvailable += candidate.availableSpace;
         }
 
-        long availableSpaceBuffer = CONSERVATIVE_COMPACTION ? CONSERVATIVE_COMPACTION_BUFFER_SPACE : 0;
-        return (totalAvailable - availableSpaceBuffer) > expectedTotalWriteSize;
+        return (totalAvailable - CONSERVATIVE_COMPACTION_BUFFER_SPACE) > expectedTotalWriteSize;
     }
 
     public static File getSnapshotDirectory(Descriptor desc, String snapshotName)


### PR DESCRIPTION
Not sure in practice how much this actually helps, but Cassandra's compaction calculation makes me kind of nervous and gets _really_ close sometimes. This adds a layer of protection to make sure we aren't compacting ourselves to 100% disk.

I arbitrarily chose 10G as a buffer but could also make it higher.  Maybe something like 50G?

