### PR TITLE
Backport ephemeral snapshot API from Cassandra 3

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2815,6 +2815,29 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     }
 
     /**
+     * This API is directly backported from Cassandra 3.
+     * Takes the snapshot of multiple keyspaces. A snapshot name must be specified.
+     *
+     * @param tag
+     *            the tag given to the snapshot; may not be null or empty
+     * @param options
+     *            Map of options (ephemeral is supported)
+     * @param entities
+     *            list of keyspaces in the form of empty | ks1 ks2 ...
+     *            table entities in the form of ks1.cf1,ks2.cf2,... are not supported
+     */
+    @Override
+    public void takeSnapshot(String tag, Map<String, String> options, String... entities) throws IOException
+    {
+        for (String entity : entities)
+            if (entity.contains("."))
+                throw new IllegalArgumentException("Snapshot entity must be keyspace only");
+
+        boolean ephemeral = Boolean.parseBoolean(options.getOrDefault("ephemeral", "false"));
+        takeSnapshot(tag, ephemeral, entities);
+    }
+
+    /**
      * Takes the snapshot of a specific column family. A snapshot name must be specified.
      *
      * @param keyspaceName the keyspace which holds the specified column family

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -247,6 +247,20 @@ public interface StorageServiceMBean extends NotificationEmitter
     public void takeMultipleColumnFamilySnapshot(String tag, String... columnFamilyList) throws IOException;
 
     /**
+     * This API is directly backported from Cassandra 3.
+     * Takes the snapshot of multiple keyspaces. A snapshot name must be specified.
+     *
+     * @param tag
+     *            the tag given to the snapshot; may not be null or empty
+     * @param options
+     *            Map of options (ephemeral is supported)
+     * @param entities
+     *            list of keyspaces in the form of empty | ks1 ks2 ...
+     *            table entities in the form of ks1.cf1,ks2.cf2,... are not supported
+     */
+    public void takeSnapshot(String tag, Map<String, String> options, String... entities) throws IOException;
+
+    /**
      * Remove the snapshot with the given name from the given keyspaces.
      * If no tag is specified we will remove all snapshots.
      */


### PR DESCRIPTION
This is the API that we will use in Cassandra 3 (see #77).  Backporting to allow clients to seamlessly transition between both versions.