### PR TITLE
Port forceKeyspaceCompaction API

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3109,6 +3109,16 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
     }
 
+    /**
+     * Forces major compaction of a single keyspace.  Deprecated API from Cassandra 2.2.
+     */
+    public void forceKeyspaceCompaction(boolean _bypassDiskspaceCheck, boolean splitOutput, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException
+    {
+        logger.warn("Ignoring 'bypassDiskspaceCheck' option passed into forceKeyspaceCompaction function");
+        forceKeyspaceCompaction(splitOutput, keyspaceName, columnFamilies);
+    }
+
+
     public int relocateSSTables(String keyspaceName, String ... columnFamilies) throws IOException, ExecutionException, InterruptedException
     {
         return relocateSSTables(0, keyspaceName, columnFamilies);

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -280,6 +280,12 @@ public interface StorageServiceMBean extends NotificationEmitter
      */
     public void forceKeyspaceCompaction(boolean splitOutput, String keyspaceName, String... tableNames) throws IOException, ExecutionException, InterruptedException;
 
+    /**
+     * Forces major compaction of a single keyspace, API from Cassandra 2.2
+     */
+    @Deprecated
+    public void forceKeyspaceCompaction(boolean bypassDiskspaceCheck, boolean splitOutput, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
+
     @Deprecated
     public int relocateSSTables(String keyspace, String ... cfnames) throws IOException, ExecutionException, InterruptedException;
     public int relocateSSTables(int jobs, String keyspace, String ... cfnames) throws IOException, ExecutionException, InterruptedException;


### PR DESCRIPTION
Allows clients to transition between the Cassandra 2 and 3 JMX API.   In Cassandra 3, though, `bypassDiskspaceCheck` will be unused.