### PR TITLE
Port "jmx re-init daemon from commitlog corruption"

### DIFF
--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -324,6 +325,10 @@ public class CassandraDaemon
             logger.warn("Unable to start GCInspector (currently only supported on the Sun JVM)");
         }
 
+        recoverCommitlogAndCompleteSetup();
+    }
+
+    private void recoverCommitlogAndCompleteSetup() {
         // Replay any CommitLogSegments found on disk
         try
         {
@@ -775,6 +780,41 @@ public class CassandraDaemon
         public boolean isMemoryLockable()
         {
             return NativeLibrary.jnaMemoryLockable();
+        }
+
+        public void reinitializeFromCommitlogCorruption() throws IllegalNonTransientErrorStateException
+        {
+            if (!StorageService.instance.inNonTransientErrorMode())
+            {
+                logger.error("Attempted to reinitializeFromCommitlogCorruption when not in NonTransientError mode; "
+                             + "current mode: " + StorageService.instance.getOperationMode());
+                throw new IllegalNonTransientErrorStateException("Can only reinitializeFromCommitlogCorruption when in NonTransientError mode");
+            }
+
+            boolean hasCommitlogNte = false;
+            boolean onlyCommitlogNte = true;
+            for (Map<String, String> nte : StorageService.instance.getNonTransientErrors())
+            {
+                boolean isCommitlogNte = StorageServiceMBean.NonTransientError.COMMIT_LOG_CORRUPTION
+                                         .name()
+                                         .equals(nte.get(StorageServiceMBean.NON_TRANSIENT_ERROR_TYPE_KEY));
+                hasCommitlogNte |= isCommitlogNte;
+                onlyCommitlogNte &= isCommitlogNte;
+            }
+            if (!hasCommitlogNte || !onlyCommitlogNte)
+            {
+                logger.error("Attempted to reinitializeFromCommitlogCorruption when there is no known commitlog corruption "
+                             + "or there are other non commitlog corruption NonTransientErrors");
+                throw new IllegalArgumentException("Can only reinitializeFromCommitlogCorruption when there are commitlog "
+                                                   + "corruption NonTransientErrors and only commitlog corruption NonTransientErrors");
+            }
+
+            StorageService.instance.clearNonTransientErrors();
+            CassandraDaemon.instance.recoverCommitlogAndCompleteSetup();
+            if (CassandraDaemon.instance.setupCompleted())
+            {
+                CassandraDaemon.instance.start();
+            }
         }
     }
 

--- a/src/java/org/apache/cassandra/service/NativeAccessMBean.java
+++ b/src/java/org/apache/cassandra/service/NativeAccessMBean.java
@@ -17,9 +17,31 @@
  */
 package org.apache.cassandra.service;
 
-public interface NativeAccessMBean 
+import java.io.Serializable;
+
+public interface NativeAccessMBean
 {
     boolean isAvailable();
 
     boolean isMemoryLockable();
+
+    /**
+     * After having properly remediated a commitlog corruption including removing the corrupted commitlog file from the
+     * node's commitlog_directory, an operator may execute this method to safely re-initialize the CassandraDaemon and
+     * StorageService.
+     *
+     * @throws IllegalNonTransientErrorStateException if StorageService in not in NonTransientError mode or has no
+     *          known NonTransientError of the type COMMIT_LOG_CORRUPTION
+     */
+    void reinitializeFromCommitlogCorruption() throws IllegalNonTransientErrorStateException;
+
+    class IllegalNonTransientErrorStateException extends Exception implements Serializable
+    {
+        private static final long serialVersionUID = 1068347274649406245L;
+
+        public IllegalNonTransientErrorStateException(String message)
+        {
+            super(message);
+        }
+    }
 }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1656,6 +1656,10 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
     }
 
+    public void clearNonTransientErrors() {
+        nonTransientErrors.clear();
+    }
+
     @Override
     public Set<Map<String, String>> getNonTransientErrors() {
         return ImmutableSet.copyOf(nonTransientErrors);
@@ -4533,6 +4537,11 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public boolean isDraining()
     {
         return operationMode == Mode.DRAINING;
+    }
+
+    public boolean inNonTransientErrorMode()
+    {
+        return operationMode == Mode.NON_TRANSIENT_ERROR;
     }
 
     public String getDrainProgress()


### PR DESCRIPTION
Cassandra 3 port of https://github.com/palantir/cassandra/pull/148
Original author @tpetracca 