### PR TITLE
Fix bug in new codepath

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
@@ -369,11 +369,7 @@ public class LeveledManifest
     }
 
     private static boolean l0IsSmallerThan100MB(Collection<SSTableReader> sstables) {
-        long levelZeroSize = 0;
-        for (SSTableReader sstable : sstables) {
-            levelZeroSize += sstable.bytesOnDisk();
-        }
-        return levelZeroSize <= 100_000_000;
+        return SSTableReader.getTotalBytes(sstables) <= 100_000_000;
     }
 
     private static boolean hasNoTombstones(Collection<SSTableReader> sstables) {


### PR DESCRIPTION
When testing internally, I noticed that it behaved weirdly, notably it compacted into L1, which wasn't the intention, and meaned that this PR actually no-opped. I realised after the fact that the compaction candidates it's picking contains the tables in the next level, and the property represents the level that written SSTables should be assigned into, rather than some kind of selection predicate.

This PR changes the logic to the intended 'compact according to whether L0 is too small'.