### PR TITLE
Fix a case where Cassandra will do too much work in the presence of tombstones

### DIFF
--- a/src/java/org/apache/cassandra/db/RangeTombstone.java
+++ b/src/java/org/apache/cassandra/db/RangeTombstone.java
@@ -293,6 +293,11 @@ public class RangeTombstone extends Interval<Composite, DeletionTime> implements
                     iterator.add(toAdd);
                     unwrittenTombstones.add(toAdd);
                 }
+                // Palantir: This codepath is an optimization that delays writing range tombstones in case it can drop
+                // some of them due to later overlaps. In practice, this can become highly aggressive, because
+                // it delays writing out column index entries as well, which governs how much data is in the working set
+                // when the row is read. So, we change this from always delaying write to delaying if the buffer is
+                // small enough.
                 return unwrittenTombstones.size() > 100;
             }
             // Caller should write cell.


### PR DESCRIPTION
Cassandra delays writing range tombstones, which can lead to too few column index entries. In practice, Cassandra is supposed to read data from disk ~64kB at a time, but if we have written e.g. 100k range tombstones in a row, then this might be order of megabytes. Therefore, even if the range tombstones are never read higher up the stack, these megabytes of unnecessary extra work are still done.

So, two specific examples where this goes bad:
1. If you just write a lot of tombstones and try to scan past them, you'll use too much memory.
1. If you write 100k range tombstones (but _after_ your data), and then do a read, you'll still read them all.

Here, we bound this by flushing whenever the buffer gets too large (it's to enable an optimization so should/does not affect correctness).