### PR TITLE
New metric for latency of read phase of range scans

### DIFF
--- a/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
@@ -167,6 +167,7 @@ public class ColumnFamilyMetrics
     public final Meter readBytesRead;
 
     public final LatencyMetrics coordinatorReadLatency;
+    public final LatencyMetrics coordinatorReadScanLatency;
     public final LatencyMetrics coordinatorScanLatency;
 
     /** Time spent waiting for free memtable space, either on- or off-heap */
@@ -383,6 +384,7 @@ public class ColumnFamilyMetrics
         writeLatency = new LatencyMetrics(factory, "Write", cfs.keyspace.metric.writeLatency, globalWriteLatency);
         rangeLatency = new LatencyMetrics(factory, "Range", cfs.keyspace.metric.rangeLatency, globalRangeLatency);
         coordinatorReadLatency = new LatencyMetrics(factory, "CoordinatorRead",  new LatencyMetrics(globalNameFactory, "CoordinatorRead"));
+        coordinatorReadScanLatency = new LatencyMetrics(factory, "CoordinatorReadScan",  new LatencyMetrics(globalNameFactory, "CoordinatorReadScan"));
         coordinatorScanLatency = new LatencyMetrics(factory, "CoordinatorScan", new LatencyMetrics(globalNameFactory, "CoordinatorScan"));
         pendingFlushes = createColumnFamilyCounter("PendingFlushes");
         bytesFlushed = createColumnFamilyCounter("BytesFlushed");

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -1855,6 +1855,7 @@ public class StorageProxy implements StorageProxyMBean
                 Tracing.trace("Submitted {} concurrent range requests covering {} ranges", concurrentRequests, i - concurrentFetchStartingIndex);
 
                 List<AsyncOneResponse> repairResponses = new ArrayList<>();
+                long readStartTime = System.nanoTime();
                 for (Pair<AbstractRangeCommand, ReadCallback<RangeSliceReply, Iterable<Row>>> cmdPairHandler : scanHandlers)
                 {
                     ReadCallback<RangeSliceReply, Iterable<Row>> handler = cmdPairHandler.right;
@@ -1905,6 +1906,7 @@ public class StorageProxy implements StorageProxyMBean
                         break;
                     }
                 }
+                Keyspace.open(command.keyspace).getColumnFamilyStore(command.columnFamily).metric.coordinatorReadScanLatency.addNano(System.nanoTime() - readStartTime);
 
                 try
                 {


### PR DESCRIPTION
Having this metric will rule out, in a period of degradation, whether the actual reads are being slow. If this is the case, and range read phase latencies degrade much more so than regular read latencies, it hints that the range scan merging behavior is the issue.