### PR TITLE
Preferably compact SSTables with the range tombstones that are being read the most

### DIFF
--- a/src/java/com/palantir/cassandra/TombstoneHotness.java
+++ b/src/java/com/palantir/cassandra/TombstoneHotness.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.metrics.RestorableMeter;
+
+public class TombstoneHotness
+{
+    public static final Logger log = LoggerFactory.getLogger(TombstoneHotness.class);
+    // will not prefer compacting any table that we have not read at least 1MM tombstones from
+    private static final long LOWER_READ_THRESHOLD = 1_000_000;
+    private static final int NUMBER_OF_TABLES_ELIGIBLE_FOR_COMPACTION = 10;
+    private static final Supplier<Set<SSTableReader>> hottestSstables =
+        Suppliers.memoizeWithExpiration(TombstoneHotness::hottestSstablesUnmemoized, 5, TimeUnit.MINUTES)::get;
+
+    private TombstoneHotness() {}
+
+    private static Set<SSTableReader> hottestSstablesUnmemoized() {
+        PriorityQueue<Map.Entry<SSTableReader, Double>> sstables = new PriorityQueue<>(ReaderComparator.INSTANCE);
+        for (Keyspace keyspace : Keyspace.nonSystem()) {
+            for (ColumnFamilyStore store : keyspace.getColumnFamilyStores()) {
+                for (SSTableReader sstable : store.getSSTables()) {
+                    if (sstable.getTombstoneReadMeter() != null
+                            && sstable.getTombstoneReadMeter().count() >= LOWER_READ_THRESHOLD) {
+                        sstables.add(Maps.immutableEntry(sstable, sstable.getTombstoneReadMeter().meanRate()));
+                    }
+                }
+            }
+        }
+        ImmutableSet.Builder<SSTableReader> result = ImmutableSet.builder();
+        for (int i = 0; i < NUMBER_OF_TABLES_ELIGIBLE_FOR_COMPACTION && !sstables.isEmpty(); i++) {
+            result.add(sstables.remove().getKey());
+        }
+        return result.build();
+    }
+
+    public static Set<SSTableReader> maybeGetHotSstables(Iterable<SSTableReader> readers) {
+        Set<SSTableReader> result = new HashSet<>();
+        Set<SSTableReader> hottest = hottestSstables.get();
+        for (SSTableReader reader : readers) {
+            if (hottest.contains(reader)) {
+                result.add(reader);
+            }
+        }
+        return result;
+    }
+
+    private enum ReaderComparator implements Comparator<Map.Entry<SSTableReader, Double>> {
+        INSTANCE;
+
+        @Override
+        public int compare(Map.Entry<SSTableReader, Double> left, Map.Entry<SSTableReader, Double> right)
+        {
+            // reverse - more reads comes first
+            return -Double.compare(left.getValue(), right.getValue());
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/db/columniterator/TombstoneCountingColumnIterator.java
+++ b/src/java/org/apache/cassandra/db/columniterator/TombstoneCountingColumnIterator.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.columniterator;
+
+import java.io.IOException;
+
+import org.apache.cassandra.db.ColumnFamily;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.DeletedCell;
+import org.apache.cassandra.db.OnDiskAtom;
+import org.apache.cassandra.db.RangeTombstone;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+public class TombstoneCountingColumnIterator implements OnDiskAtomIterator
+{
+    private final SSTableReader reader;
+    private final OnDiskAtomIterator delegate;
+    private int tombstonesRead = 0;
+
+    public TombstoneCountingColumnIterator(SSTableReader reader, OnDiskAtomIterator delegate)
+    {
+        this.reader = reader;
+        this.delegate = delegate;
+    }
+
+    public ColumnFamily getColumnFamily()
+    {
+        return delegate.getColumnFamily();
+    }
+
+    public DecoratedKey getKey()
+    {
+        return delegate.getKey();
+    }
+
+    public void close() throws IOException
+    {
+        reader.incrementTombstonesRead(tombstonesRead);
+        delegate.close();
+    }
+
+    public boolean hasNext()
+    {
+        return delegate.hasNext();
+    }
+
+    public OnDiskAtom next()
+    {
+        OnDiskAtom atom = delegate.next();
+        if (isTombstone(atom)) {
+            ++tombstonesRead;
+        }
+        return atom;
+    }
+
+    private static boolean isTombstone(OnDiskAtom atom) {
+        return atom instanceof RangeTombstone | atom instanceof DeletedCell;
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -220,6 +220,8 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
     private final Ref<SSTableReader> selfRef = new Ref<>(this, tidy);
 
     private RestorableMeter readMeter;
+    // PT: The read meter is written to the activity table so that it is persisted across reboots. We ignore this for now.
+    private RestorableMeter tombstoneReadMeter = new RestorableMeter();
 
     /**
      * Calculate approximate key count.
@@ -1216,6 +1218,10 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         return readMeter;
     }
 
+    public RestorableMeter getTombstoneReadMeter() {
+        return tombstoneReadMeter;
+    }
+
     public int getIndexSummarySamplingLevel()
     {
         return indexSummary.getSamplingLevel();
@@ -1985,6 +1991,12 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
     {
         if (readMeter != null)
             readMeter.mark();
+    }
+
+    public void incrementTombstonesRead(int tombstonesRead)
+    {
+        if (tombstoneReadMeter != null)
+            tombstoneReadMeter.mark(tombstonesRead);
     }
 
     public static class SizeComparator implements Comparator<SSTableReader>

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
@@ -25,6 +25,7 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.RowIndexEntry;
 import org.apache.cassandra.db.RowPosition;
 import org.apache.cassandra.db.columniterator.OnDiskAtomIterator;
+import org.apache.cassandra.db.columniterator.TombstoneCountingColumnIterator;
 import org.apache.cassandra.db.composites.CellName;
 import org.apache.cassandra.db.filter.ColumnSlice;
 import org.apache.cassandra.dht.IPartitioner;
@@ -72,12 +73,12 @@ public class BigTableReader extends SSTableReader
 
     public OnDiskAtomIterator iterator(DecoratedKey key, ColumnSlice[] slices, boolean reverse)
     {
-        return new SSTableSliceIterator(this, key, slices, reverse);
+        return new TombstoneCountingColumnIterator(this, new SSTableSliceIterator(this, key, slices, reverse));
     }
 
     public OnDiskAtomIterator iterator(FileDataInput input, DecoratedKey key, ColumnSlice[] slices, boolean reverse, RowIndexEntry indexEntry)
     {
-        return new SSTableSliceIterator(this, input, key, slices, reverse, indexEntry);
+        return new TombstoneCountingColumnIterator(this, new SSTableSliceIterator(this, input, key, slices, reverse, indexEntry));
     }
     /**
      *


### PR DESCRIPTION
STCS has a notion of hotness - it first compacts the tables that are
being read the most, because it assumes that compacting them will lead
to the biggest win.

LCS does not do this, and most of our issues at this point relate to
range tombstones being read.

Range tombstones can only really be dropped when they reach the highest
level, so when there's a really hot SSTable in a low level, there's no
real forcing function for C* to improve things.

Here, we alter the compaction strategy (behind a feature flag). We say:

1. Let's look for the top 10 SSTables across all keyspaces which are
responsible for the most tombstone reads (asserting that we must have
read at least 1MM tombstones from each table for it to be considered).
2. When we try to compact a table, if it's in this list of worst tables,
we choose to compact that one first, because it's likely we'll get a
bigger win from compacting it.
3. If in Level 0, we look for a level 0 task, and then compact this with
that.
4. If in level n (n not largest), we look for overlapping tables in the
next level, and compact with those, compacting into n+1.
5. If in the top level, we basically just compact the table with itself.

When the compaction is done, another compaction will be triggered in
order to compact any _other_ sstables that need compacting.