### PR TITLE
Count droppable range tombstone markers

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -563,6 +563,22 @@ public abstract class ReadCommand extends MonitorableImpl implements ReadQuery
             public RangeTombstoneMarker applyToMarker(RangeTombstoneMarker marker)
             {
                 countTombstone(marker.clustering());
+                if (marker.isBoundary())
+                {
+                    if (marker.openDeletionTime(false).localDeletionTime() < gcBeforeInSeconds
+                        && marker.closeDeletionTime(false).localDeletionTime() < gcBeforeInSeconds)
+                    {
+                        ++droppableTombstones;
+                    }
+                }
+                else
+                {
+                    if (((RangeTombstoneBoundMarker) marker).deletionTime().localDeletionTime() < gcBeforeInSeconds)
+                    {
+                        ++droppableTombstones;
+                    }
+                }
+
                 return marker;
             }
 


### PR DESCRIPTION
By my reading of the code, this should reasonably count totally deleted range tombstone markers as droppable tombstones.  It doesn't differentiate between the type of range tombstones (bound or boundary), and so counts a "boundary" as its own cell, but if the client is inserting homogenous tombstones then this should be a sufficient metric.

Would we prefer to have this be reported separately from droppableTombstones?