### PR TITLE
Add log line about is_new_cluster config

### DIFF
--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -1357,7 +1357,11 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
 
                 slept += 1000;
                 if (slept > StorageService.RING_DELAY)
+                {
+                    logger.error("Unable to gossip with any seeds.  If this is the first time that you are starting the cluster," +
+                                 "ensure that `conf.cassandra-env_sh.is_new_cluster` is set to true");
                     throw new RuntimeException("Unable to gossip with any seeds");
+                }
             }
         }
         catch (InterruptedException wtf)


### PR DESCRIPTION
In our upstream packaging, we have added a configuration point that must be set to true for Cassandra to start for the first time.

This log line should make it easier for users to debug a startup failure.