### PR TITLE
Don't let a compaction run if it will exceed max disk usage

### DIFF
--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -880,7 +880,7 @@ public class Directories
         for (int i = 0; i < locations.length; ++i)
             dataDirectories[i] = new DataDirectory(new File(locations[i]));
     }
-
+    
     private class TrueFilesSizeVisitor extends SimpleFileVisitor<Path>
     {
         private final AtomicLong size = new AtomicLong(0);
@@ -919,11 +919,11 @@ public class Directories
         }
 
         @Override
-        public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException
+        public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException 
         {
             return FileVisitResult.CONTINUE;
         }
-
+        
         public long getAllocatedSize()
         {
             return size.get();


### PR DESCRIPTION
When checking if there's enough available space to run a compaction, change logic so that we don't fill up the disk to more than 'max-compaction-disk-usage'%, which is at 0.95 (95%) default.