### PR TITLE
Add read repair latency metrics

### DIFF
--- a/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
@@ -170,6 +170,11 @@ public class ColumnFamilyMetrics
     public final LatencyMetrics coordinatorReadScanLatency;
     public final LatencyMetrics coordinatorScanLatency;
 
+    public final LatencyMetrics blockingReadRepairLatency;
+    public final Meter blockingReadRepairs;
+    public final Meter attemptedReadRepairs;
+    public final Meter backgroundReadRepairs;
+
     /** Request rounds in range scan queries on this CF **/
     public final ColumnFamilyHistogram coordinatorScanRequestRounds;
 
@@ -395,6 +400,10 @@ public class ColumnFamilyMetrics
         coordinatorReadLatency = new LatencyMetrics(factory, "CoordinatorRead",  new LatencyMetrics(globalNameFactory, "CoordinatorRead"));
         coordinatorReadScanLatency = new LatencyMetrics(factory, "CoordinatorReadScan",  new LatencyMetrics(globalNameFactory, "CoordinatorReadScan"));
         coordinatorScanLatency = new LatencyMetrics(factory, "CoordinatorScan", new LatencyMetrics(globalNameFactory, "CoordinatorScan"));
+        blockingReadRepairLatency = new LatencyMetrics(factory, "BlockingReadRepair", new LatencyMetrics(globalNameFactory, "BlockingReadRepair"));
+        blockingReadRepairs = Metrics.meter(factory.createMetricName("BlockingReadRepairs"));
+        backgroundReadRepairs = Metrics.meter(factory.createMetricName("BackgroundReadRepairs"));
+        attemptedReadRepairs = Metrics.meter(factory.createMetricName("AttemptedReadRepairs"));
         pendingFlushes = createColumnFamilyCounter("PendingFlushes");
         bytesFlushed = createColumnFamilyCounter("BytesFlushed");
         compactionBytesWritten = createColumnFamilyCounter("CompactionBytesWritten");

--- a/src/java/org/apache/cassandra/service/AbstractReadExecutor.java
+++ b/src/java/org/apache/cassandra/service/AbstractReadExecutor.java
@@ -174,6 +174,8 @@ public abstract class AbstractReadExecutor
         {
             Tracing.trace("Read-repair {}", repairDecision);
             ReadRepairMetrics.attempted.mark();
+            Keyspace.open(command.ksName).getColumnFamilyStore(command.cfName).metric.attemptedReadRepairs.mark();
+
         }
 
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(command.cfName);

--- a/src/java/org/apache/cassandra/service/ReadCallback.java
+++ b/src/java/org/apache/cassandra/service/ReadCallback.java
@@ -254,10 +254,11 @@ public class ReadCallback<TMessage, TResolved> implements IAsyncCallbackWithFail
                     traceState.trace("Digest mismatch: {}", e.toString());
                 if (logger.isTraceEnabled())
                     logger.trace("Digest mismatch:", e);
-                
-                ReadRepairMetrics.repairedBackground.mark();
-                
+
                 ReadCommand readCommand = (ReadCommand) command;
+                ReadRepairMetrics.repairedBackground.mark();
+                Keyspace.open(readCommand.ksName).getColumnFamilyStore(readCommand.cfName).metric.backgroundReadRepairs.mark();
+
                 final RowDataResolver repairResolver = new RowDataResolver(readCommand.ksName, readCommand.key, readCommand.filter(), readCommand.timestamp, endpoints.size());
                 AsyncRepairCallback repairHandler = new AsyncRepairCallback(repairResolver, endpoints.size());
 


### PR DESCRIPTION
Add read repair metrics per keyspace/column family. 

These metrics include: meters for the number of blocking/background/attempted read repairs, and latency metrics for blocking reads. 

We do not record latency metrics for background read repairs (as they are performed on separate thread than that of the read path), and attempted simply has no latency to measure (hence the name).