### PR TITLE
Enable gossip and reset opmode on sstable corruption remedation

### DIFF
--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -740,6 +740,8 @@ public class CassandraDaemon
             }
             else
             {
+                StorageService.instance.startGossiping();
+                StorageService.instance.setOperationModeNormal();
                 CassandraDaemon.instance.start();
                 enableAutoCompaction();
             }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1344,6 +1344,10 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         nonTransientErrors.clear();
     }
 
+    public void setOperationModeNormal() {
+        setMode(Mode.NORMAL, false);
+    }
+
     @Override
     public Set<Map<String, String>> getNonTransientErrors() {
         return ImmutableSet.copyOf(nonTransientErrors);


### PR DESCRIPTION
Fixes the implementation of `reinitializeFromSstableCorruption` to also start Gossip and reset the operation mode back to `NORMAL`.  It's only necessary to do that if the corruption happened during non-starting operatons.  Otherwise, we go through the code path that will do these for us.

I've validated that this works correctly on a test cluster.