### PR TITLE
Add bytes read for range scan

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -486,6 +486,7 @@ public abstract class ReadCommand extends MonitorableImpl implements ReadQuery
             private int tombstones = 0;
             private int droppableTtls = 0;
             private int droppableTombstones = 0;
+            private int rangeScanBytesRead = 0;
 
             private DecoratedKey currentKey;
 
@@ -556,6 +557,8 @@ public abstract class ReadCommand extends MonitorableImpl implements ReadQuery
                     countTombstone(row.clustering());
                 }
 
+                rangeScanBytesRead += row.dataSize();
+
                 return row;
             }
 
@@ -604,6 +607,7 @@ public abstract class ReadCommand extends MonitorableImpl implements ReadQuery
                 metric.droppableTombstonesReadHistogram.update(droppableTombstones);
                 metric.droppableTtlsReadHistogram.update(droppableTtls);
                 metric.liveReadHistogram.update(liveCells);
+                metric.rangeScanBytesRead.mark(rangeScanBytesRead);
 
                 boolean warnTombstones = tombstones > warningThreshold && respectTombstoneThresholds;
                 if (warnTombstones)

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -486,7 +486,7 @@ public abstract class ReadCommand extends MonitorableImpl implements ReadQuery
             private int tombstones = 0;
             private int droppableTtls = 0;
             private int droppableTombstones = 0;
-            private int rangeScanBytesRead = 0;
+            private int bytesRead = 0;
 
             private DecoratedKey currentKey;
 
@@ -557,7 +557,7 @@ public abstract class ReadCommand extends MonitorableImpl implements ReadQuery
                     countTombstone(row.clustering());
                 }
 
-                rangeScanBytesRead += row.dataSize();
+                bytesRead += row.dataSize();
 
                 return row;
             }
@@ -607,7 +607,12 @@ public abstract class ReadCommand extends MonitorableImpl implements ReadQuery
                 metric.droppableTombstonesReadHistogram.update(droppableTombstones);
                 metric.droppableTtlsReadHistogram.update(droppableTtls);
                 metric.liveReadHistogram.update(liveCells);
-                metric.rangeScanBytesRead.mark(rangeScanBytesRead);
+
+                if (kind == Kind.PARTITION_RANGE) {
+                    metric.rangeScanBytesRead.mark(bytesRead);
+                } else {
+                    metric.readBytesRead.mark(bytesRead);
+                }
 
                 boolean warnTombstones = tombstones > warningThreshold && respectTombstoneThresholds;
                 if (warnTombstones)

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -164,6 +164,9 @@ public class TableMetrics
     /** Estimated ratio of tombstones and number of cells in this table */
     public final Gauge<Double> tombstoneRatio;
 
+    /** Bytes read on range scans **/
+    public final Meter rangeScanBytesRead;
+
     public final LatencyMetrics coordinatorReadLatency;
     public final LatencyMetrics coordinatorScanLatency;
 
@@ -754,6 +757,8 @@ public class TableMetrics
                 return cfs.getTombstoneRatio();
             }
         });
+
+        rangeScanBytesRead = Metrics.meter(factory.createMetricName("RangeScanBytesRead"));
 
         readRepairRequests = Metrics.meter(factory.createMetricName("ReadRepairRequests"));
         shortReadProtectionRequests = Metrics.meter(factory.createMetricName("ShortReadProtectionRequests"));

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -167,6 +167,9 @@ public class TableMetrics
     /** Bytes read on range scans **/
     public final Meter rangeScanBytesRead;
 
+    /** Bytes read on a read **/
+    public final Meter readBytesRead;
+
     public final LatencyMetrics coordinatorReadLatency;
     public final LatencyMetrics coordinatorScanLatency;
 
@@ -759,7 +762,7 @@ public class TableMetrics
         });
 
         rangeScanBytesRead = Metrics.meter(factory.createMetricName("RangeScanBytesRead"));
-
+        readBytesRead = Metrics.meter(factory.createMetricName("ReadBytesRead"));
         readRepairRequests = Metrics.meter(factory.createMetricName("ReadRepairRequests"));
         shortReadProtectionRequests = Metrics.meter(factory.createMetricName("ShortReadProtectionRequests"));
     }


### PR DESCRIPTION
To the best of my knowledge, the context in which dataSize is being called here should strictly contain what has been transported to the node. Thus, it should only reference the size of data held in-memory. 

To see how the dataSize calculated, you can view the [BTreeRow](https://github.com/palantir/cassandra/blob/palantir-cassandra-3.11.6/src/java/org/apache/cassandra/db/rows/BTreeRow.java#L436) class, which contains all the necessary cells for a given read. 

Local read messages serialize this into a partition iterator (that's raw -- unfiltered of any tombstones): https://github.com/palantir/cassandra/blob/palantir-cassandra-3.11.6/src/java/org/apache/cassandra/db/ReadResponse.java#L187

And the coordinator node does the same thing: https://github.com/palantir/cassandra/blob/palantir-cassandra-3.11.6/src/java/org/apache/cassandra/db/ReadResponse.java#L82