### PR TITLE
Log high memory usage on cell collection

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/SliceQueryFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/SliceQueryFilter.java
@@ -280,6 +280,7 @@ public class SliceQueryFilter implements IDiskAtomFilter
 
         boolean hasBreachedCollectionThreshold = false;
         long dataSizeCollected = 0;
+        long metadataSizeCollected = 0;
 
         while (!columnCounter.hasSeenAtLeast(count) && reducedCells.hasNext())
         {
@@ -320,11 +321,12 @@ public class SliceQueryFilter implements IDiskAtomFilter
                 // only log once per iteration
                 if (!hasBreachedCollectionThreshold)
                 {
-                    dataSizeCollected += cell.cellDataSize() + cell.unsharedHeapSizeExcludingData();
-                    if (dataSizeCollected > highMemoryCollectionThreshold)
+                    dataSizeCollected += cell.cellDataSize();
+                    metadataSizeCollected += cell.unsharedHeapSizeExcludingData();
+                    if (dataSizeCollected + metadataSizeCollected > highMemoryCollectionThreshold)
                     {
-                        logger.warn("Breached memory threshold while collecting cells for keyspace/cf {} and key {}}",
-                                    container.metadata().ksAndCFName, key);
+                        logger.warn("Breached memory threshold while collecting cells for keyspace/cf {} and key {}; data size: {}; metadata size: {}",
+                                    container.metadata().ksAndCFName, key, dataSizeCollected, metadataSizeCollected);
                         hasBreachedCollectionThreshold = true;
                     }
                 }

--- a/src/java/org/apache/cassandra/db/filter/SliceQueryFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/SliceQueryFilter.java
@@ -17,8 +17,6 @@
  */
 package org.apache.cassandra.db.filter;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadMXBean;
 import java.nio.ByteBuffer;
 import java.io.DataInput;
 import java.io.IOException;
@@ -106,10 +104,9 @@ public class SliceQueryFilter implements IDiskAtomFilter
         this.reversed = reversed;
         this.count = count;
         this.compositesToGroup = compositesToGroup;
-        if (LOG_HIGH_MEMORY_COLLECTION)
-        {
-            highMemoryCollectionThreshold = Long.parseLong("palantir_cassandra.high_memory_collection_threshold_in_mb") * FileUtils.ONE_MB;
-        }
+        this.highMemoryCollectionThreshold = LOG_HIGH_MEMORY_COLLECTION
+                                             ? Long.parseLong(System.getProperty("palantir_cassandra.high_memory_collection_threshold_in_mb")) * FileUtils.ONE_MB
+                                             : null;
     }
 
     public SliceQueryFilter cloneShallow()


### PR DESCRIPTION
While iterating through a collection of cells, count the accumulated amount of memory consumed by the cells, and log if it breaches a threshold.  The goal is to log collections that may be contributing to heavy heap usage and garbage collection problems.