### PR TITLE
Dnyamic snitch force stop

### DIFF
--- a/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
+++ b/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
@@ -154,10 +154,6 @@ public class DynamicEndpointSnitch extends AbstractEndpointSnitch implements ILa
     {
         assert address.equals(FBUtilities.getBroadcastAddress()); // we only know about ourself
 
-        if (USE_FORCE_STOP && nodeHasDegraded) {
-            throw new InvalidRequestException("Node is degraded, please try a different host");
-        }
-
         if (BADNESS_THRESHOLD == 0)
         {
             sortByProximityWithScore(address, addresses);
@@ -212,6 +208,10 @@ public class DynamicEndpointSnitch extends AbstractEndpointSnitch implements ILa
         {
             if (subsnitchScore > (sortedScoreIterator.next() * (1.0 + BADNESS_THRESHOLD)))
             {
+                if (USE_FORCE_STOP && nodeHasDegraded) {
+                    throw new InvalidRequestException("Node is degraded, please try a different host");
+                }
+
                 sortByProximityWithScore(address, addresses);
                 return;
             }

--- a/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
+++ b/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
@@ -298,7 +298,7 @@ public class DynamicEndpointSnitch extends AbstractEndpointSnitch implements ILa
             newScores.put(entry.getKey(), score);
 
             if(USE_FORCE_STOP && entry.getKey() == FBUtilities.getBroadcastAddress()) {
-                nodeHasDegraded = entry.getValue().getSnapshot().getMedian() >= maxLatency && score >= 1.0;
+                nodeHasDegraded = entry.getValue().getSnapshot().getMedian() >= maxLatency;
             }
         }
 

--- a/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
+++ b/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
@@ -298,7 +298,7 @@ public class DynamicEndpointSnitch extends AbstractEndpointSnitch implements ILa
             newScores.put(entry.getKey(), score);
 
             if(USE_FORCE_STOP && entry.getKey() == FBUtilities.getBroadcastAddress()) {
-                nodeHasDegraded = entry.getValue().getSnapshot().getMedian() >= maxLatency;
+                nodeHasDegraded = entry.getValue().getSnapshot().getMedian() >= maxLatency && score >= 1.0;
             }
         }
 


### PR DESCRIPTION
Forcefully stop coordinator read path when we detect the node is degraded by throwing an exception from the dynamic snitch when sorting the list of addresses. 