### PR TITLE
Add consistency level write metrics

### DIFF
--- a/src/java/org/apache/cassandra/metrics/ClientRequestMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientRequestMetrics.java
@@ -31,14 +31,29 @@ public class ClientRequestMetrics extends LatencyMetrics
     public final Meter timeouts;
     public final Meter unavailables;
     public final Meter failures;
+    private final String scope;
 
     public ClientRequestMetrics(String scope)
     {
         super("ClientRequest", scope);
-
+        this.scope = scope;
         timeouts = Metrics.meter(factory.createMetricName("Timeouts"));
         unavailables = Metrics.meter(factory.createMetricName("Unavailables"));
         failures = Metrics.meter(factory.createMetricName("Failures"));
+    }
+
+    public ClientRequestMetrics(MetricNameFactory factory, ClientRequestMetrics parent)
+    {
+        super(factory, "ClientRequest", parent);
+
+        this.scope = "";
+        timeouts = Metrics.meter(factory.createMetricName("Timeouts"));
+        unavailables = Metrics.meter(factory.createMetricName("Unavailables"));
+        failures = Metrics.meter(factory.createMetricName("Failures"));
+    }
+
+    public String getScope() {
+        return scope;
     }
 
     public void release()

--- a/src/java/org/apache/cassandra/metrics/ClientRequestMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientRequestMetrics.java
@@ -31,7 +31,7 @@ public class ClientRequestMetrics extends LatencyMetrics
     public final Meter timeouts;
     public final Meter unavailables;
     public final Meter failures;
-    private final String scope;
+    protected final String scope;
 
     public ClientRequestMetrics(String scope)
     {
@@ -42,11 +42,11 @@ public class ClientRequestMetrics extends LatencyMetrics
         failures = Metrics.meter(factory.createMetricName("Failures"));
     }
 
-    public ClientRequestMetrics(MetricNameFactory factory, ClientRequestMetrics parent)
+    public ClientRequestMetrics(MetricNameFactory factory, String scope, String namePrefix, ClientRequestMetrics parent)
     {
-        super(factory, "ClientRequest", parent);
+        super(factory, namePrefix, parent);
 
-        this.scope = "";
+        this.scope = scope;
         timeouts = Metrics.meter(factory.createMetricName("Timeouts"));
         unavailables = Metrics.meter(factory.createMetricName("Unavailables"));
         failures = Metrics.meter(factory.createMetricName("Failures"));

--- a/src/java/org/apache/cassandra/metrics/ConsistencyLevelRequestMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ConsistencyLevelRequestMetrics.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import org.apache.cassandra.db.ConsistencyLevel;
+
+public class ConsistencyLevelRequestMetrics extends ClientRequestMetrics
+{
+    public ConsistencyLevelRequestMetrics(ConsistencyLevel consistencyLevel, ClientRequestMetrics parent) {
+        super(new ConsistencyLevelRequestMetricNameFactory(consistencyLevel, parent.getScope()), parent);
+    }
+
+    static class ConsistencyLevelRequestMetricNameFactory implements MetricNameFactory {
+        private final String type = "ConsistencyLevelRequest";
+        private final String consistencyLevelName;
+        private final String scope;
+
+        ConsistencyLevelRequestMetricNameFactory(ConsistencyLevel consistencyLevelName, String scope)
+        {
+            this.consistencyLevelName = consistencyLevelName.name();
+            this.scope = scope;
+        }
+
+        public CassandraMetricsRegistry.MetricName createMetricName(String metricName) {
+            String groupName = ColumnFamilyMetrics.class.getPackage().getName();
+
+            StringBuilder mbeanName = new StringBuilder();
+            mbeanName.append(groupName).append(":");
+            mbeanName.append("type=").append(type);
+            mbeanName.append(",consistency=").append(consistencyLevelName);
+            mbeanName.append(",scope=").append(scope);
+            mbeanName.append(",name=").append(metricName);
+
+            return new CassandraMetricsRegistry.MetricName(groupName, type, metricName, scope, mbeanName.toString());
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/ConsistencyLevelRequestMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ConsistencyLevelRequestMetrics.java
@@ -22,19 +22,23 @@ import org.apache.cassandra.db.ConsistencyLevel;
 
 public class ConsistencyLevelRequestMetrics extends ClientRequestMetrics
 {
+    public static final String type = "ConsistencyLevelRequest";
+
     public ConsistencyLevelRequestMetrics(ConsistencyLevel consistencyLevel, ClientRequestMetrics parent) {
-        super(new ConsistencyLevelRequestMetricNameFactory(consistencyLevel, parent.getScope()), parent);
+        super(new ConsistencyLevelRequestMetricNameFactory(consistencyLevel, parent.getScope()),
+              consistencyLevel.name(),
+              type,
+              parent);
     }
 
     static class ConsistencyLevelRequestMetricNameFactory implements MetricNameFactory {
-        private final String type = "ConsistencyLevelRequest";
         private final String consistencyLevelName;
-        private final String scope;
+        private final String operation;
 
-        ConsistencyLevelRequestMetricNameFactory(ConsistencyLevel consistencyLevelName, String scope)
+        ConsistencyLevelRequestMetricNameFactory(ConsistencyLevel consistencyLevelName, String operation)
         {
             this.consistencyLevelName = consistencyLevelName.name();
-            this.scope = scope;
+            this.operation = operation;
         }
 
         public CassandraMetricsRegistry.MetricName createMetricName(String metricName) {
@@ -44,10 +48,10 @@ public class ConsistencyLevelRequestMetrics extends ClientRequestMetrics
             mbeanName.append(groupName).append(":");
             mbeanName.append("type=").append(type);
             mbeanName.append(",consistency=").append(consistencyLevelName);
-            mbeanName.append(",scope=").append(scope);
+            mbeanName.append(",scope=").append(operation);
             mbeanName.append(",name=").append(metricName);
 
-            return new CassandraMetricsRegistry.MetricName(groupName, type, metricName, scope, mbeanName.toString());
+            return new CassandraMetricsRegistry.MetricName(groupName, type, metricName, consistencyLevelName + "." + operation, mbeanName.toString());
         }
     }
 }

--- a/test/unit/org/apache/cassandra/metrics/ConsistencyLevelRequestMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/ConsistencyLevelRequestMetricsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import org.apache.cassandra.db.ConsistencyLevel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConsistencyLevelRequestMetricsTest
+{
+    @Test
+    public void consistencyLevelMetricsRequestWritesToParent() throws InterruptedException
+    {
+        ClientRequestMetrics topWrite = new ClientRequestMetrics("Write");
+        final ConsistencyLevelRequestMetrics consistencyLevelRequestMetrics1 = new ConsistencyLevelRequestMetrics(ConsistencyLevel.ALL, topWrite);
+        final ConsistencyLevelRequestMetrics consistencyLevelRequestMetrics2 = new ConsistencyLevelRequestMetrics(ConsistencyLevel.QUORUM, topWrite);
+        final int numSamples = 10000;
+        Runnable r1 = () -> logLatency(consistencyLevelRequestMetrics1, numSamples);
+        Runnable r2 = () -> logLatency(consistencyLevelRequestMetrics2, numSamples);
+
+        Thread first = new Thread(r1);
+        Thread second = new Thread(r2);
+        first.start();
+        second.start();
+        first.join();
+        second.join();
+
+        assertThat(topWrite.totalLatency.getCount()).isEqualTo(2*numSamples);
+    }
+
+    @Test
+    public void consistencyLevelRequestRegistersMetrics() {
+        ClientRequestMetrics topWrite = new ClientRequestMetrics("Write");
+        new ConsistencyLevelRequestMetrics(ConsistencyLevel.ALL, topWrite);
+        Map<String, Metric> existing = CassandraMetricsRegistry.Metrics.getMetrics();
+        String group = "org.apache.cassandra.metrics.ConsistencyLevelRequest.%s.write";
+        existing.get(String.format(group, "ClientRequestLatency"));
+        existing.get(String.format(group, "ClientRequestTotalLatency"));
+        existing.get(String.format(group, "Unavailables"));
+        existing.get(String.format(group, "Timeouts"));
+        existing.get(String.format(group, "Failures"));
+    }
+
+    private void logLatency(ConsistencyLevelRequestMetrics consistencyLevelRequestMetrics, int numSamples) {
+        for (int i = 0; i < numSamples; i++)
+        {
+            consistencyLevelRequestMetrics.addNano(1000);
+        }
+    }
+}


### PR DESCRIPTION
Extending ClientRequestMetrics to recording metrics per consistency level can help diagnose issues between normal writes and deletes