### PR TITLE
Shutdown node after disk usage exceeds threshold

### DIFF
--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -78,7 +78,7 @@ public class Config
 
     public ParameterizedClass seed_provider;
     public DiskAccessMode disk_access_mode = DiskAccessMode.auto;
-
+    public Double max_disk_utilization = 0.99;
     public DiskFailurePolicy disk_failure_policy = DiskFailurePolicy.ignore;
     public CommitFailurePolicy commit_failure_policy = CommitFailurePolicy.stop;
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1475,6 +1475,17 @@ public class DatabaseDescriptor
         indexAccessMode = mode;
     }
 
+    public static double getMaxDiskUtilizationThreshold()
+    {
+        return conf.max_disk_utilization;
+    }
+
+    @VisibleForTesting
+    public static void setMaxDiskUtilizationThreshold(double threshold)
+    {
+        conf.max_disk_utilization = threshold;
+    }
+
     public static void setDiskFailurePolicy(Config.DiskFailurePolicy policy)
     {
         conf.disk_failure_policy = policy;

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -110,7 +110,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
                                                                                           "internal");
 
     // post-flush executor is single threaded to provide guarantee that any flush Future on a CF will never return until prior flushes have completed
-    private static final ExecutorService postFlushExecutor = new JMXEnabledThreadPoolExecutor(1,
+    @VisibleForTesting
+    static final ExecutorService postFlushExecutor = new JMXEnabledThreadPoolExecutor(1,
                                                                                               StageManager.KEEPALIVE,
                                                                                               TimeUnit.SECONDS,
                                                                                               new LinkedBlockingQueue<Runnable>(),
@@ -119,7 +120,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
 
     // If a flush fails with an error the post-flush is never allowed to continue. This stores the error that caused it
     // to be able to show an error on following flushes instead of blindly continuing.
-    private static volatile FSWriteError previousFlushFailure = null;
+    @VisibleForTesting
+    static volatile FSWriteError previousFlushFailure = null;
 
     private static final ExecutorService reclaimExecutor = new JMXEnabledThreadPoolExecutor(1,
                                                                                             StageManager.KEEPALIVE,

--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -67,6 +67,8 @@ import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Pair;
 
 import static com.google.common.collect.Sets.newHashSet;
+import static org.mockito.Mockito.spy;
+
 /**
  * Encapsulate handling of paths to the data files.
  *
@@ -319,8 +321,9 @@ public class Directories
                                    maxPathToUtilization.getKey().location, maxPathToUtilization.getValue()));
         if (maxPathToUtilization.getValue() > MAX_DISK_UTILIZATION)
         {
-            // There's not enough disk space to handle worst case scenario of total heap dump
-            throw new FSWriteError(new ExceededDiskThresholdException(maxPathToUtilization.getKey().location, maxPathToUtilization.getValue(), MAX_DISK_UTILIZATION), maxPathToUtilization.getKey().location);
+            ExceededDiskThresholdException cause = new ExceededDiskThresholdException(
+                        maxPathToUtilization.getKey().location, maxPathToUtilization.getValue(), MAX_DISK_UTILIZATION);
+            throw new FSWriteError(cause, maxPathToUtilization.getKey().location);
         }
     }
 
@@ -959,7 +962,7 @@ public class Directories
     static void overrideDataDirectoriesForTest(String loc)
     {
         for (int i = 0; i < dataDirectories.length; ++i)
-            dataDirectories[i] = new DataDirectory(new File(loc));
+            dataDirectories[i] = spy(new DataDirectory(new File(loc)));
     }
 
     @VisibleForTesting

--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -110,8 +110,6 @@ public class Directories
                                                             ? 0.95
                                                             : Double.parseDouble(System.getProperty("palantir_cassandra.max_compaction_disk_usage"));
 
-    public static final double MAX_DISK_UTILIZATION = 0.99;
-
     public static final String BACKUPS_SUBDIR = "backups";
     public static final String SNAPSHOT_SUBDIR = "snapshots";
     public static final String SECONDARY_INDEX_NAME_SEPARATOR = ".";
@@ -319,10 +317,11 @@ public class Directories
                                                                 "Failed to filter most full data directory"));
         logger.debug(String.format("Highest data directory disk utilization on path %s (%f)",
                                    maxPathToUtilization.getKey().location, maxPathToUtilization.getValue()));
-        if (maxPathToUtilization.getValue() > MAX_DISK_UTILIZATION)
+        double threshold = DatabaseDescriptor.getMaxDiskUtilizationThreshold();
+        if (maxPathToUtilization.getValue() > threshold)
         {
             ExceededDiskThresholdException cause = new ExceededDiskThresholdException(
-                        maxPathToUtilization.getKey().location, maxPathToUtilization.getValue(), MAX_DISK_UTILIZATION);
+                                    maxPathToUtilization.getKey().location, maxPathToUtilization.getValue(), threshold);
             throw new FSWriteError(cause, maxPathToUtilization.getKey().location);
         }
     }

--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -305,7 +305,7 @@ public class Directories
         return () -> {
             try {
                 Directories.verifyDiskHasEnoughUsableSpace();
-            } catch (FSWriteError e) {
+            } catch (ExceededDiskThresholdException e) {
                 // If node is already disabled propagating the exception from scheduled executor is redundant and clogs logs.
                 if (!StorageService.instance.isNodeDisabled()) {
                     throw e;
@@ -338,9 +338,7 @@ public class Directories
         double currUtilization = maxPathToUtilization.getValue();
         if (currUtilization >= threshold)
         {
-            ExceededDiskThresholdException cause = new ExceededDiskThresholdException(
-                                    maxPathToUtilization.getKey().location, currUtilization, threshold);
-            throw new FSWriteError(cause, maxPathToUtilization.getKey().location);
+            throw new ExceededDiskThresholdException(maxPathToUtilization.getKey().location, currUtilization, threshold);
         }
 
         if (currUtilization < threshold && StorageService.instance.isNodeDisabled() && StorageService.instance.isSetupCompleted())

--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -306,7 +306,7 @@ public class Directories
             try {
                 Directories.verifyDiskHasEnoughUsableSpace();
             } catch (FSWriteError e) {
-                // If node is already disabled propagating the exception is redundant and clogs logs.
+                // If node is already disabled propagating the exception from scheduled executor is redundant and clogs logs.
                 if (!StorageService.instance.isNodeDisabled()) {
                     throw e;
                 }

--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -69,7 +69,6 @@ import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Pair;
 
 import static com.google.common.collect.Sets.newHashSet;
-import static org.mockito.Mockito.spy;
 
 /**
  * Encapsulate handling of paths to the data files.
@@ -995,12 +994,6 @@ public class Directories
         return StringUtils.join(s, File.separator);
     }
 
-    @VisibleForTesting
-    static void overrideDataDirectoriesForTest(String loc)
-    {
-        for (int i = 0; i < dataDirectories.length; ++i)
-            dataDirectories[i] = spy(new DataDirectory(new File(loc)));
-    }
 
     @VisibleForTesting
     static void resetDataDirectoriesAfterTest()

--- a/src/java/org/apache/cassandra/io/ExceededDiskThresholdException.java
+++ b/src/java/org/apache/cassandra/io/ExceededDiskThresholdException.java
@@ -18,14 +18,27 @@
 
 package org.apache.cassandra.io;
 
-import org.apache.cassandra.io.sstable.CorruptSSTableException;
+import java.io.File;
 
-/**
- * Interface for handling file system errors.
- */
-public interface FSErrorHandler
+public class ExceededDiskThresholdException extends RuntimeException
 {
-    void handleCorruptSSTable(CorruptSSTableException e);
-    void handleExceededDiskThreshold(ExceededDiskThresholdException e);
-    void handleFSError(FSError e);
+
+        public final File file;
+        public final double utilization;
+        public final double threshold;
+
+        public ExceededDiskThresholdException(Exception cause, File file, double utilization, double threshold)
+        {
+            super(
+                String.format("Host too low on usable disk space on %s. Current utilization: %f; Max threshold: %f",
+                              file, utilization, threshold),
+                cause);
+            this.file = file;
+            this.utilization = utilization;
+            this.threshold = threshold;
+        }
+
+        public ExceededDiskThresholdException(File file, double utilization, double threshold) {
+            this(null, file, utilization, threshold);
+        }
 }

--- a/src/java/org/apache/cassandra/io/util/FileUtils.java
+++ b/src/java/org/apache/cassandra/io/util/FileUtils.java
@@ -27,6 +27,7 @@ import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.cassandra.io.ExceededDiskThresholdException;
 import sun.nio.ch.DirectBuffer;
 
 import org.slf4j.Logger;
@@ -414,6 +415,13 @@ public final class FileUtils
         FSErrorHandler handler = fsErrorHandler.get();
         if (handler != null)
             handler.handleCorruptSSTable(e);
+    }
+
+    public static void handleExceededDiskThreshold(ExceededDiskThresholdException e)
+    {
+        FSErrorHandler handler = fsErrorHandler.get();
+        if (handler != null)
+            handler.handleExceededDiskThreshold(e);
     }
 
     public static void handleFSError(FSError e)

--- a/src/java/org/apache/cassandra/io/util/FileUtils.java
+++ b/src/java/org/apache/cassandra/io/util/FileUtils.java
@@ -17,29 +17,41 @@
  */
 package org.apache.cassandra.io.util;
 
-import java.io.*;
+import java.io.Closeable;
+import java.io.DataInput;
+import java.io.EOFException;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.file.*;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileStoreAttributeView;
 import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.cassandra.io.ExceededDiskThresholdException;
-import sun.nio.ch.DirectBuffer;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.concurrent.ScheduledExecutors;
+import org.apache.cassandra.io.ExceededDiskThresholdException;
 import org.apache.cassandra.io.FSError;
 import org.apache.cassandra.io.FSErrorHandler;
 import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
+import org.apache.cassandra.metrics.StorageMetrics;
+import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.JVMStabilityInspector;
+import sun.nio.ch.DirectBuffer;
 
 import static org.apache.cassandra.utils.Throwables.maybeFail;
 import static org.apache.cassandra.utils.Throwables.merge;
@@ -71,6 +83,46 @@ public final class FileUtils
             logger.info("Cannot initialize un-mmaper.  (Are you using a non-Oracle JVM?)  Compacted data files will not be removed promptly.  Consider using an Oracle JVM or using standard disk access mode");
         }
         canCleanDirectBuffers = canClean;
+    }
+
+    public static void setDefaultUncaughtExceptionHandler() {
+        Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler()
+        {
+            public void uncaughtException(Thread t, Throwable e)
+            {
+                StorageMetrics.exceptions.inc();
+                logger.error("Exception in thread " + t, e);
+                Tracing.trace("Exception in thread {}", t, e);
+                for (Throwable e2 = e; e2 != null; e2 = e2.getCause())
+                {
+                    JVMStabilityInspector.inspectThrowable(e2);
+
+                    if (e2 instanceof FSError)
+                    {
+                        if (e2 != e) // make sure FSError gets logged exactly once.
+                            logger.error("Exception in thread " + t, e2);
+
+                        if (e2.getCause() instanceof CorruptSSTableException)
+                            handleCorruptSSTable((CorruptSSTableException) e2.getCause());
+                        else if (e2.getCause() instanceof ExceededDiskThresholdException)
+                            handleExceededDiskThreshold((ExceededDiskThresholdException) e2.getCause());
+                        else
+                            handleFSError((FSError) e2);
+                    }
+
+                    if (e2 instanceof CorruptSSTableException) {
+                        if (e2 != e)
+                            logger.error("Exception in thread " + t, e2);
+                        handleCorruptSSTable((CorruptSSTableException) e2);
+                    }
+                    if (e2 instanceof ExceededDiskThresholdException) {
+                        if (e2 != e)
+                            logger.error("Exception in thread " + t, e2);
+                        handleExceededDiskThreshold((ExceededDiskThresholdException) e2);
+                    }
+                }
+            }
+        });
     }
 
     public static void createHardLink(String from, String to)

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -217,7 +217,7 @@ public class CassandraDaemon
 
         FileUtils.setDefaultUncaughtExceptionHandler();
 
-        Directories.startVerifyingDiskDoesNotExceedThreshold();
+        Directories.scheduleVerifyingDiskDoesNotExceedThresholdChecks();
         completeSetupMayThrowSstableException();
     }
 

--- a/src/java/org/apache/cassandra/service/DefaultFSErrorHandler.java
+++ b/src/java/org/apache/cassandra/service/DefaultFSErrorHandler.java
@@ -25,9 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.db.DisallowedDirectories;
-import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.io.FSError;
 import org.apache.cassandra.io.FSErrorHandler;
@@ -144,24 +142,10 @@ public class DefaultFSErrorHandler implements FSErrorHandler
 
     private static void recordErrorAndDisableNode(StorageServiceMBean.NonTransientError error, File path) {
         recordError(error, path);
-        StorageService.instance.stopTransports();
-        disableAutoCompaction();
+        StorageService.instance.disableNode();
     }
 
     private static void recordError(StorageServiceMBean.NonTransientError error, File path) {
         StorageService.instance.recordNonTransientError(error, ImmutableMap.of("path", path.toString()));
-    }
-
-    private static void disableAutoCompaction() {
-        for (String keyspaceName : Schema.instance.getKeyspaces())
-        {
-            for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
-            {
-                for (ColumnFamilyStore store : cfs.concatWithIndexes())
-                {
-                    store.disableAutoCompaction();
-                }
-            }
-        }
     }
 }

--- a/src/java/org/apache/cassandra/service/DefaultFSErrorHandler.java
+++ b/src/java/org/apache/cassandra/service/DefaultFSErrorHandler.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.service;
 
 import java.io.File;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,6 +74,11 @@ public class DefaultFSErrorHandler implements FSErrorHandler
             logger.debug("Node already disabled. Ignoring ExceededDiskThresholdException");
             return;
         }
+        handleExceededDiskThresholdInternal(e);
+    }
+
+    @VisibleForTesting
+    void handleExceededDiskThresholdInternal(ExceededDiskThresholdException e) {
         switch (DatabaseDescriptor.getDiskFailurePolicy())
         {
             case stop:

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -478,12 +478,17 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         boolean isDisabled = true;
         for (String keyspaceName : Schema.instance.getKeyspaces())
         {
-            for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
+            Keyspace keyspace = Schema.instance.getKeyspaceInstance(keyspaceName);
+            if (keyspace != null)
             {
-                for (ColumnFamilyStore store : cfs.concatWithIndexes())
+                for (ColumnFamilyStore cfs : keyspace.getColumnFamilyStores())
                 {
-                    isDisabled &= store.isAutoCompactionDisabled();
+                    for (ColumnFamilyStore store : cfs.concatWithIndexes())
+                    {
+                        isDisabled &= store.isAutoCompactionDisabled();
+                    }
                 }
+
             }
         }
         return isDisabled;

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1377,7 +1377,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     }
 
     public void recordNonTransientError(NonTransientError nonTransientError, Map<String, String> attributes) {
-        setMode(Mode.NON_TRANSIENT_ERROR, String.format("None transient error of type %s", nonTransientError.toString()), true);
+        setMode(Mode.NON_TRANSIENT_ERROR, String.format("Non transient error of type %s", nonTransientError.toString()), true);
         ImmutableMap<String, String> attributesWithErrorType =
             ImmutableMap.<String, String>builder()
             .put(StorageServiceMBean.NON_TRANSIENT_ERROR_TYPE_KEY, nonTransientError.name())

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -46,9 +46,23 @@ public interface StorageServiceMBean extends NotificationEmitter
      */
     public enum NonTransientError {
         COMMIT_LOG_CORRUPTION,
-        EXCEEDED_DISK_THRESHOLD,
         SSTABLE_CORRUPTION,
         FS_ERROR
+    }
+
+    /**
+     * Transient error type key.
+     *
+     * @see TransientError
+     * @see #getTransientErrors()
+     */
+    static final String TRANSIENT_ERROR_TYPE_KEY = "type";
+
+    /**
+     * Type of transient errors.
+     */
+    public enum TransientError {
+        EXCEEDED_DISK_THRESHOLD
     }
 
     /**
@@ -725,6 +739,31 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
      * @return a map of all recorded non transient errors.
      */
     public Set<Map<String, String>> getNonTransientErrors();
+
+    /**
+     * Retrieve a set of unique errors. every error is represented as a map from an attribute name to a value.
+     *
+     * Each map representing an error is guarenteed to have the key {@link #TRANSIENT_ERROR_TYPE_KEY} and the
+     * matching value from {@link TransientError} representing the type of the transient error.
+     * <p>
+     * Transient errors:
+     * <ul>
+     *      <li>{@link TransientError#EXCEEDED_DISK_THRESHOLD}
+     *          <ul>
+     *              <li>attributes:
+     *                  <ul>
+     *                      <li> {@code path} - field representing path of the highest utilized disk.</li>
+     *                      <li> {@code utilization} - the current percentage of disk being used.</li>
+     *                      <li> {@code threshold} - the threshold specified by Config.max_disk_utilization.</li>
+     *                  </ul>
+     *              </li>
+     *          </ul>
+     *      </li>
+     * </ul>
+     *
+     * @return a map of all recorded transient errors.
+     */
+    public Set<Map<String, String>> getTransientErrors();
 
     /**
      * Every read this node performs will have the specified read delay

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -46,6 +46,7 @@ public interface StorageServiceMBean extends NotificationEmitter
      */
     public enum NonTransientError {
         COMMIT_LOG_CORRUPTION,
+        EXCEEDED_DISK_THRESHOLD,
         SSTABLE_CORRUPTION,
         FS_ERROR
     }

--- a/test/unit/org/apache/cassandra/db/DirectoriesTest.java
+++ b/test/unit/org/apache/cassandra/db/DirectoriesTest.java
@@ -441,7 +441,7 @@ public class DirectoriesTest
         Directories.verifyDiskHasEnoughUsableSpace();
         DatabaseDescriptor.setMaxDiskUtilizationThreshold(0.0);
         assertThatThrownBy(Directories::verifyDiskHasEnoughUsableSpace)
-                .hasRootCauseInstanceOf(ExceededDiskThresholdException.class);
+                .isInstanceOf(ExceededDiskThresholdException.class);
     }
 
     @Test
@@ -452,7 +452,7 @@ public class DirectoriesTest
             doReturn(1L).when(dir).getTotalSpace();
         }
         assertThatThrownBy(Directories::verifyDiskHasEnoughUsableSpace)
-                .hasRootCauseInstanceOf(ExceededDiskThresholdException.class);
+                .isInstanceOf(ExceededDiskThresholdException.class);
     }
 
     @Test
@@ -463,7 +463,7 @@ public class DirectoriesTest
             doReturn(1L).when(dir).getTotalSpace();
         }
         Runnable check = Directories.getVerifyDiskHasEnoughUsableSpaceRunnable();
-        assertThatThrownBy(check::run).hasRootCauseInstanceOf(ExceededDiskThresholdException.class);
+        assertThatThrownBy(check::run).isInstanceOf(ExceededDiskThresholdException.class);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/DirectoriesTest.java
+++ b/test/unit/org/apache/cassandra/db/DirectoriesTest.java
@@ -54,6 +54,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 public class DirectoriesTest
 {
@@ -86,7 +87,7 @@ public class DirectoriesTest
     @Before
     public void before() throws IOException
     {
-        Directories.overrideDataDirectoriesForTest(tempDataDir.getPath());
+        overrideDataDirectoriesForTest(tempDataDir.getPath());
         // Create two fake data dir for tests, one using CF directories, one that do not.
         createTestFiles();
         DatabaseDescriptor.setMaxDiskUtilizationThreshold(0.99);
@@ -516,6 +517,12 @@ public class DirectoriesTest
 
         Directories.verifyDiskHasEnoughUsableSpace();
         assertThat(StorageService.instance.isNodeDisabled()).isTrue();
+    }
+
+    static void overrideDataDirectoriesForTest(String loc)
+    {
+        for (int i = 0; i < Directories.dataDirectories.length; ++i)
+            Directories.dataDirectories[i] = spy(new DataDirectory(new File(loc)));
     }
 
     private List<Directories.DataDirectoryCandidate> getWriteableDirectories(DataDirectory[] dataDirectories, long writeSize)

--- a/test/unit/org/apache/cassandra/db/DirectoriesTest.java
+++ b/test/unit/org/apache/cassandra/db/DirectoriesTest.java
@@ -481,8 +481,9 @@ public class DirectoriesTest
     @Test
     public void testVerifyDiskHasEnoughUsableSpaceEnablesNodeIfReturnsUnderThreshold()
     {
+        StorageService.instance.clearTransientErrors();
         StorageService.instance.clearNonTransientErrors();
-        StorageService.instance.recordNonTransientError(StorageServiceMBean.NonTransientError.EXCEEDED_DISK_THRESHOLD,
+        StorageService.instance.recordTransientError(StorageServiceMBean.TransientError.EXCEEDED_DISK_THRESHOLD,
                                                         ImmutableMap.of("path", "/test"));
         StorageService.instance.disableNode();
         assertThat(StorageService.instance.isNodeDisabled()).isTrue();
@@ -500,7 +501,7 @@ public class DirectoriesTest
     }
 
     @Test
-    public void testVerifyDiskHasEnoughUsableSpaceDoesNotEnableNodeIfReturnsUnderThresholdAndMoreNonTransientErrors()
+    public void testVerifyDiskHasEnoughUsableSpaceDoesNotEnableNodeIfReturnsUnderThresholdAndNonTransientErrors()
     {
         StorageService.instance.clearNonTransientErrors();
         StorageService.instance.recordNonTransientError(StorageServiceMBean.NonTransientError.SSTABLE_CORRUPTION,

--- a/test/unit/org/apache/cassandra/db/ExceededDiskThresholdTest.java
+++ b/test/unit/org/apache/cassandra/db/ExceededDiskThresholdTest.java
@@ -63,7 +63,7 @@ public class ExceededDiskThresholdTest
         tempDataDir = File.createTempFile("cassandra", "unittest");
         tempDataDir.delete(); // hack to create a temp dir
         tempDataDir.mkdir();
-        Directories.overrideDataDirectoriesForTest(tempDataDir.getPath());
+        DirectoriesTest.overrideDataDirectoriesForTest(tempDataDir.getPath());
         SchemaLoader.prepareServer();
         SchemaLoader.createKeyspace(KEYSPACE_1,
                                     SimpleStrategy.class,
@@ -79,7 +79,7 @@ public class ExceededDiskThresholdTest
     @Before
     public void before()
     {
-        Directories.overrideDataDirectoriesForTest(tempDataDir.getPath());
+        DirectoriesTest.overrideDataDirectoriesForTest(tempDataDir.getPath());
     }
 
     @After

--- a/test/unit/org/apache/cassandra/db/ExceededDiskThresholdTest.java
+++ b/test/unit/org/apache/cassandra/db/ExceededDiskThresholdTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.OrderedJUnit4ClassRunner;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.concurrent.JMXEnabledThreadPoolExecutor;
+import org.apache.cassandra.concurrent.NamedThreadFactory;
+import org.apache.cassandra.concurrent.StageManager;
+import org.apache.cassandra.config.KSMetaData;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.compaction.CompactionsTest;
+import org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy;
+import org.apache.cassandra.io.ExceededDiskThresholdException;
+import org.apache.cassandra.io.FSErrorHandler;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.locator.SimpleStrategy;
+import org.apache.cassandra.service.DefaultFSErrorHandler;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(OrderedJUnit4ClassRunner.class)
+public class ExceededDiskThresholdTest
+{
+
+    private static final String KEYSPACE_1 = "ExceededDiskThresholdTest1";
+    private static final String KEYSPACE_2 = "ExceededDiskThresholdTest2";
+    private static final String CF_STANDARD = "CF_STANDARD";
+    private static File tempDataDir;
+
+    @BeforeClass
+    public static void beforeClass() throws IOException
+    {
+        tempDataDir = File.createTempFile("cassandra", "unittest");
+        tempDataDir.delete(); // hack to create a temp dir
+        tempDataDir.mkdir();
+        Directories.overrideDataDirectoriesForTest(tempDataDir.getPath());
+        SchemaLoader.prepareServer();
+        SchemaLoader.createKeyspace(KEYSPACE_1,
+                                    SimpleStrategy.class,
+                                    KSMetaData.optsWithRF(1),
+                                    SchemaLoader.standardCFMD(KEYSPACE_1, CF_STANDARD));
+        SchemaLoader.createKeyspace(KEYSPACE_2,
+                                    SimpleStrategy.class,
+                                    KSMetaData.optsWithRF(1),
+                                    SchemaLoader.standardCFMD(KEYSPACE_2, CF_STANDARD));
+    }
+
+
+    @Before
+    public void before()
+    {
+        Directories.overrideDataDirectoriesForTest(tempDataDir.getPath());
+    }
+
+    @After
+    public void after() throws NoSuchFieldException, IllegalAccessException
+    {
+        resetPostFlushExecutor();
+    }
+
+    @AfterClass
+    public static void afterClass() throws IOException
+    {
+        Directories.resetDataDirectoriesAfterTest();
+        FileUtils.deleteRecursive(tempDataDir);
+        SchemaLoader.cleanupAndLeaveDirs();
+    }
+
+    @Test
+    public void testHandleExceededDiskThresholdIsInvokedByDefaultUncaughtExceptionHandler() throws InterruptedException
+    {
+        FSErrorHandler spyHandler = spy(new DefaultFSErrorHandler());
+        FileUtils.setFSErrorHandler(spyHandler);
+        FileUtils.setDefaultUncaughtExceptionHandler();
+
+        Thread testThread = new Thread(() -> {
+            throw new ExceededDiskThresholdException(null, 0, 0);
+        });
+        testThread.start();
+        testThread.join();
+
+        verify(spyHandler).handleExceededDiskThreshold(any());
+    }
+
+    @Test
+    public void testExceededDiskThrowsOnFlush()
+    {
+        Keyspace keyspace = Keyspace.open(KEYSPACE_1);
+        ColumnFamilyStore store = keyspace.getColumnFamilyStore(CF_STANDARD);
+        store.clearUnsafe();
+        store.metadata.gcGraceSeconds(1);
+
+        store.disableAutoCompaction();
+        CompactionsTest.populate(KEYSPACE_1, CF_STANDARD, 0, 1, 3);
+
+        // 412 bytes to be flushed. Mock so there are 412 available bytes, but we're still above the allowed threshold
+        long total = 100000L;
+        long available = 500L;
+        doReturn(available).when(Directories.dataDirectories[0]).getAvailableSpace();
+        doReturn(total).when(Directories.dataDirectories[0]).getTotalSpace();
+        assertThatThrownBy(store::forceBlockingFlush).hasRootCauseInstanceOf(ExceededDiskThresholdException.class);
+    }
+
+    @Test
+    public void testExceededDiskThrowsOnCompaction()
+    {
+        Keyspace keyspace = Keyspace.open(KEYSPACE_2);
+        ColumnFamilyStore store = keyspace.getColumnFamilyStore(CF_STANDARD);
+        store.clearUnsafe();
+        store.metadata.gcGraceSeconds(1);
+        store.setCompactionStrategyClass(SizeTieredCompactionStrategy.class.getCanonicalName());
+
+        store.disableAutoCompaction();
+        CompactionsTest.populate(KEYSPACE_2, CF_STANDARD, 0, 1, 3);
+        store.forceBlockingFlush();
+
+        // 498 bytes to be written
+        long total = 100000L;
+        long available = 500L;
+        for (Directories.DataDirectory dir : Directories.dataDirectories)
+        {
+            doReturn(total, available).when(dir).getAvailableSpace();
+            doReturn(total).when(dir).getTotalSpace();
+        }
+        store.enableAutoCompaction();
+
+        assertThatThrownBy(() -> CompactionManager.instance.performMaximal(store, false))
+                .hasRootCauseInstanceOf(ExceededDiskThresholdException.class);
+    }
+
+    private void resetPostFlushExecutor() throws NoSuchFieldException, IllegalAccessException
+    {
+        // Without this only 1 test can throw an error during flush since the others will be rejected until restart
+        ColumnFamilyStore.previousFlushFailure = null;
+        JMXEnabledThreadPoolExecutor executor = (JMXEnabledThreadPoolExecutor) ColumnFamilyStore.postFlushExecutor;
+        executor.shutdown();
+        Field field = ColumnFamilyStore.class.getDeclaredField("postFlushExecutor");
+        field.setAccessible(true);
+
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+        field.set(null, new JMXEnabledThreadPoolExecutor(1,
+                                                         StageManager.KEEPALIVE,
+                                                         TimeUnit.SECONDS,
+                                                         new LinkedBlockingQueue<Runnable>(),
+                                                         new NamedThreadFactory("MemtablePostFlush"),
+                                                         "internal"));
+    }
+
+}

--- a/test/unit/org/apache/cassandra/db/ExceededDiskThresholdTest.java
+++ b/test/unit/org/apache/cassandra/db/ExceededDiskThresholdTest.java
@@ -42,16 +42,11 @@ import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.compaction.CompactionsTest;
 import org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy;
 import org.apache.cassandra.io.ExceededDiskThresholdException;
-import org.apache.cassandra.io.FSErrorHandler;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.locator.SimpleStrategy;
-import org.apache.cassandra.service.DefaultFSErrorHandler;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 @RunWith(OrderedJUnit4ClassRunner.class)
 public class ExceededDiskThresholdTest

--- a/test/unit/org/apache/cassandra/db/ExceededDiskThresholdTest.java
+++ b/test/unit/org/apache/cassandra/db/ExceededDiskThresholdTest.java
@@ -102,22 +102,6 @@ public class ExceededDiskThresholdTest
     }
 
     @Test
-    public void testHandleExceededDiskThresholdIsInvokedByDefaultUncaughtExceptionHandler() throws InterruptedException
-    {
-        FSErrorHandler spyHandler = spy(new DefaultFSErrorHandler());
-        FileUtils.setFSErrorHandler(spyHandler);
-        FileUtils.setDefaultUncaughtExceptionHandler();
-
-        Thread testThread = new Thread(() -> {
-            throw new ExceededDiskThresholdException(null, 0, 0);
-        });
-        testThread.start();
-        testThread.join();
-
-        verify(spyHandler).handleExceededDiskThreshold(any());
-    }
-
-    @Test
     public void testExceededDiskThrowsOnFlush()
     {
         Keyspace keyspace = Keyspace.open(KEYSPACE_1);

--- a/test/unit/org/apache/cassandra/service/DefaultFSErrorHandlerTest.java
+++ b/test/unit/org/apache/cassandra/service/DefaultFSErrorHandlerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service;
+
+import org.junit.Test;
+
+import org.apache.cassandra.io.ExceededDiskThresholdException;
+import org.apache.cassandra.io.FSErrorHandler;
+import org.apache.cassandra.io.util.FileUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class DefaultFSErrorHandlerTest
+{
+    @Test
+    public void testHandleExceededDiskThresholdIsInvoked() throws InterruptedException
+    {
+        FSErrorHandler spyHandler = spy(new DefaultFSErrorHandler());
+        FileUtils.setFSErrorHandler(spyHandler);
+        FileUtils.setDefaultUncaughtExceptionHandler();
+
+        Thread testThread = new Thread(() -> {
+            throw new ExceededDiskThresholdException(null, 0, 0);
+        });
+        testThread.start();
+        testThread.join();
+
+        verify(spyHandler).handleExceededDiskThreshold(any());
+    }
+
+    @Test
+    public void testHandleExceededDiskDoesNotRecordErrorAfterNodeDisabled() throws InterruptedException
+    {
+        DefaultFSErrorHandler spyHandler = spy(new DefaultFSErrorHandler());
+        FileUtils.setFSErrorHandler(spyHandler);
+        FileUtils.setDefaultUncaughtExceptionHandler();
+        StorageService.instance.disableNode();
+
+        Thread testThread = new Thread(() -> {
+            throw new ExceededDiskThresholdException(null, 0, 0);
+        });
+        testThread.start();
+        testThread.join();
+
+        verify(spyHandler, never()).handleExceededDiskThresholdInternal(any());
+    }
+}


### PR DESCRIPTION
Previously if a node was using too much disk space it would have to be manually monitored and shut down. Replacing this by triggering a shutdown with a configurable `max_disk_utilization` threshold increases safety.