### PR TITLE
Add transient errors to api

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1656,6 +1656,11 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         return ImmutableSet.copyOf(nonTransientErrors);
     }
 
+    @Override
+    public Set<Map<String, String>> getTransientErrors() {
+        throw new UnsupportedOperationException("Transient errors not currently supported in Cassandra 3");
+    }
+
     public void recordNonTransientError(NonTransientError nonTransientError, Map<String, String> attributes) {
         setMode(Mode.NON_TRANSIENT_ERROR, String.format("None transient error of type %s", nonTransientError.toString()), true);
         ImmutableMap<String, String> attributesWithErrorType = ImmutableMap.<String, String>builder()

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -51,6 +51,21 @@ public interface StorageServiceMBean extends NotificationEmitter
     }
 
     /**
+     * Transient error type key.
+     *
+     * @see TransientError
+     * @see #getTransientErrors()
+     */
+    static final String TRANSIENT_ERROR_TYPE_KEY = "type";
+
+    /**
+     * Type of transient errors.
+     */
+    public enum TransientError {
+        EXCEEDED_DISK_THRESHOLD
+    }
+
+    /**
      * Retrieve the list of live nodes in the cluster, where "liveness" is
      * determined by the failure detector of the node being queried.
      *
@@ -786,6 +801,31 @@ public interface StorageServiceMBean extends NotificationEmitter
      * @return a map of all recorded non transient errors.
      */
     public Set<Map<String, String>> getNonTransientErrors();
+
+    /**
+     * Retrieve a set of unique errors. every error is represented as a map from an attribute name to a value.
+     *
+     * Each map representing an error is guarenteed to have the key {@link #TRANSIENT_ERROR_TYPE_KEY} and the
+     * matching value from {@link TransientError} representing the type of the transient error.
+     * <p>
+     * Transient errors:
+     * <ul>
+     *      <li>{@link TransientError#EXCEEDED_DISK_THRESHOLD}
+     *          <ul>
+     *              <li>attributes:
+     *                  <ul>
+     *                      <li> {@code path} - field representing path of the highest utilized disk.</li>
+     *                      <li> {@code utilization} - the current percentage of disk being used.</li>
+     *                      <li> {@code threshold} - the threshold specified by Config.max_disk_utilization.</li>
+     *                  </ul>
+     *              </li>
+     *          </ul>
+     *      </li>
+     * </ul>
+     *
+     * @return a map of all recorded transient errors.
+     */
+    public Set<Map<String, String>> getTransientErrors();
 
     /** Every read request sent to this node from another node will result in a delay of the specified value, in seconds
      */


### PR DESCRIPTION
`sls-cassandra-sidecar` consumes `palantir-cassandra-jmx-api` 3.11.6. #235 introduced transient errors that need to be added to the API for health checks. Actual mirror implementation of #235 for cassandra 3 will follow at some later date.