### PR TITLE
make allowedToBootstrap volatile

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4877,7 +4877,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     @VisibleForTesting
     static class BootstrapManager {
 
-        private boolean allowedToBootstrap = false;
+        private volatile boolean allowedToBootstrap = false;
         private final Monitor monitor = new Monitor();
         private final Monitor.Guard isAllowedToBootstrap = getNewGuard(monitor);
 


### PR DESCRIPTION
If we do not have the state be volatile, there is a chance we perform a dirty read when we re-check the variable. This becomes extra annoying, as Montior#enterWhen only enters when signaled (aka monitor#enter, monitor#leave), so it's very likely that we read the bad value, and then wait forever again until we re-set the variable. 