### PR TITLE
Fix snapshot race condition

### DIFF
--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -799,7 +799,7 @@ public class Directories
      * @return  Return a map of all snapshots to space being used
      * The pair for a snapshot has size on disk and true size.
      */
-    public Map<String, Pair<Long, Long>> getSnapshotDetails()
+    public synchronized Map<String, Pair<Long, Long>> getSnapshotDetails()
     {
         final Map<String, Pair<Long, Long>> snapshotSpaceMap = new HashMap<>();
         for (File snapshot : listSnapshots())
@@ -817,7 +817,7 @@ public class Directories
     }
 
 
-    public List<String> listEphemeralSnapshots()
+    public synchronized List<String> listEphemeralSnapshots()
     {
         final List<String> ephemeralSnapshots = new LinkedList<>();
         for (File snapshot : listSnapshots())
@@ -872,7 +872,7 @@ public class Directories
         return false;
     }
 
-    public static void clearSnapshot(String snapshotName, List<File> snapshotDirectories)
+    public synchronized static void clearSnapshot(String snapshotName, List<File> snapshotDirectories)
     {
         // If snapshotName is empty or null, we will delete the entire snapshot directory
         String tag = snapshotName == null ? "" : snapshotName;


### PR DESCRIPTION
context: https://github.palantir.build/foundry/sls-cassandra-sidecar/issues/1098
The race condition seems to occur when these two methods are called at the same time. If a thread calls getSnapshotDetails, then another thread calls clearSnapshot, the original thread will then fail to get the size of the snapshot on disk because it has been cleared by the other thread. Making these synchronized will fix this issue, as the 2nd thread won't be able to execute until the 1st is done.