### PR TITLE
Make repair statements more legible

### DIFF
--- a/src/java/org/apache/cassandra/repair/RepairRunnable.java
+++ b/src/java/org/apache/cassandra/repair/RepairRunnable.java
@@ -329,7 +329,7 @@ public class RepairRunnable extends WrappedRunnable implements ProgressEventNoti
             {
                 String duration = DurationFormatUtils.formatDurationWords(System.currentTimeMillis() - startTime,
                                                                           true, true);
-                String message = String.format("Repair command #%d finished in %s", cmd, duration);
+                String message = String.format("Repair command #%d finished in %s for keyspace", cmd, duration, keyspace);
                 fireProgressEvent(tag, new ProgressEvent(ProgressEventType.COMPLETE, progress.get(), totalProgress, message));
                 logger.info(message);
                 if (options.isTraced() && traceState != null)


### PR DESCRIPTION
Add keyspace in to prevent annoyance of manually mapping repair command number <> keyspace