### PR TITLE
Prevent bootstraping if previous bootstrap failure is detected

### DIFF
--- a/src/java/com/palantir/cassandra/db/BootstrappingSafetyException.java
+++ b/src/java/com/palantir/cassandra/db/BootstrappingSafetyException.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.db;
+
+import org.apache.cassandra.db.SystemKeyspace;
+
+/**
+ * There is a risk of a node crashing during the bootstrapping process. On the next start the node will detect
+ * it has already started to bootstrap via {@link SystemKeyspace#bootstrapInProgress()}. Continuing to bootstrap
+ * after a previous failure poses risk of filling up the node's storage device(s). To prevent this a system var can
+ * be supplied in the form of <code>palantir_cassandra.bootstrap_disk_usage_threshold_percentage</code> that represents
+ * a threshold of how filled data dirs can be, before bootstrapping is prevented if previous failures are detected.
+ *
+ * If current data dir utilization exceeds the safety threshold, the <code>BootstrappingSafetyException</code> is
+ * thrown which case the server is disabled and remains in <code>Mode.NON_TRANSIENT_ERROR</code>.
+ *
+ * @author lyubent
+ */
+public class BootstrappingSafetyException extends RuntimeException {
+
+    private String mode;
+    private String mostUtilizedDataDir;
+    private Double utilization;
+    private Double threshold;
+
+    public BootstrappingSafetyException(String mode, String mostUtilizedDataDir, Double utilization, Double threshold)
+    {
+        this.mode = mode;
+        this.mostUtilizedDataDir = mostUtilizedDataDir;
+        this.utilization = utilization;
+        this.threshold = threshold;
+    }
+
+    public String getLocalizedMessage()
+    {
+        return getMessage();
+    }
+
+    public String getMessage()
+    {
+        String msg = "Preventing node from continuing after failed bootstrap as most utilized data_file_dir (%s) " +
+                     "is too full (%f) and exceeds palantir_cassandra.bootstrap_disk_usage_threshold_percentage (%f). " +
+                     "Node will stay in %s mode.";
+        return String.format(msg, mostUtilizedDataDir, utilization, threshold, mode);
+    }
+}

--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -349,17 +349,7 @@ public class Directories
         return underThreshold && nodeCanBeReEnabled && zeroNonTransientErrors && onlyExceededDiskThresholdTransientError;
     }
 
-    /**
-     * Finds busiest data directory and returns its utilization as a percentage.
-     *
-     * @return Map.Entry<DataDirectory, Double> where the key represents the directory
-     *         and the value represents percentage utilization of the directory.
-     */
-    public static Map.Entry<DataDirectory, Double> getMostUtilizedDataDir() {
-        return getMaxPathToUtilization();
-    }
-
-    private static Map.Entry<DataDirectory, Double> getMaxPathToUtilization()
+    public static Map.Entry<DataDirectory, Double> getMaxPathToUtilization()
     {
         Map<DataDirectory, Double> dirsToUtilization = Arrays.stream(dataDirectories)
                                                              .collect(Collectors.toMap(

--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -349,6 +349,16 @@ public class Directories
         return underThreshold && nodeCanBeReEnabled && zeroNonTransientErrors && onlyExceededDiskThresholdTransientError;
     }
 
+    /**
+     * Finds busiest data directory and returns its utilization as a percentage.
+     *
+     * @return Map.Entry<DataDirectory, Double> where the key represents the directory
+     *         and the value represents percentage utilization of the directory.
+     */
+    public static Map.Entry<DataDirectory, Double> getMostUtilizedDataDir() {
+        return getMaxPathToUtilization();
+    }
+
     private static Map.Entry<DataDirectory, Double> getMaxPathToUtilization()
     {
         Map<DataDirectory, Double> dirsToUtilization = Arrays.stream(dataDirectories)

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -59,6 +59,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
 
 import com.palantir.cassandra.concurrent.LocalReadRunnableTimeoutWatcher;
+import com.palantir.cassandra.db.BootstrappingSafetyException;
 import org.apache.cassandra.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -315,6 +316,11 @@ public class CassandraDaemon
         try
         {
             StorageService.instance.initServer();
+        }
+        catch (BootstrappingSafetyException e)
+        {
+            System.out.println(e.getMessage() + "\nNon-fatal bootstrap error. Server will continue but is disabled and without metrics.");
+            return;
         }
         catch (ConfigurationException e)
         {

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -319,12 +319,12 @@ public class CassandraDaemon
         }
         catch (BootstrappingSafetyException e)
         {
-            System.out.println(e.getMessage() + "\nNon-fatal bootstrap error. Server will continue but is disabled and without metrics.");
+            logger.error("Non-fatal bootstrap error. Server will continue but is disabled and without metrics.", e);
             return;
         }
         catch (ConfigurationException e)
         {
-            System.err.println(e.getMessage() + "\nFatal configuration error; unable to start server.  See log for stacktrace.");
+            logger.error("Fatal configuration error; unable to start server.  See log for stacktrace.", e);
             exitOrFail(1, "Fatal configuration error", e);
         }
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -93,6 +93,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 {
     private static final Logger logger = LoggerFactory.getLogger(StorageService.class);
     private static final boolean DISABLE_WAIT_TO_BOOTSTRAP = Boolean.getBoolean("palantir_cassandra.disable_wait_to_bootstrap");
+    private static final Integer BOOTSTRAP_DISK_USAGE_THRESHOLD = Integer.getInteger("palantir_cassandra.bootstrap_disk_usage_threshold_percentage");
 
     public static final int RING_DELAY = getRingDelay(); // delay after which we assume ring has stablized
 
@@ -872,25 +873,26 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             {
                 // on detection of previous bootstrap failure prevent boostrap from proceeding if data directories are
                 // filled up beyond palantir_cassandra.bootstrap_disk_usage_threshold_percentage
-                Integer threshold = Integer.getInteger("palantir_cassandra.bootstrap_disk_usage_threshold_percentage");
-                Entry<Directories.DataDirectory, Double> mostUtilizedDataDir = Directories.getMostUtilizedDataDir();
+                Entry<Directories.DataDirectory, Double> mostUtilizedDataDir = Directories.getMaxPathToUtilization();
                 Double percentageDataDirUtilization = mostUtilizedDataDir.getValue() * 100;
 
-                if (threshold != null && percentageDataDirUtilization > Double.valueOf(threshold))
+                if (BOOTSTRAP_DISK_USAGE_THRESHOLD != null && percentageDataDirUtilization > Double.valueOf(BOOTSTRAP_DISK_USAGE_THRESHOLD))
                 {
                     // disable node preventing bootstrap continuation.
-                    setMode(Mode.NON_TRANSIENT_ERROR, "Detected previous bootstrap failure, data dir too full to proceed.", true);
+                    recordNonTransientError(NonTransientError.BOOTSTRAP_ERROR,
+                                            ImmutableMap.of("directory", mostUtilizedDataDir.getKey().location.toString(),
+                                                            "percentageDataDirUtilization", percentageDataDirUtilization.toString(),
+                                                            "threshold", BOOTSTRAP_DISK_USAGE_THRESHOLD.toString()));
                     logger.error("Preventing node from continuing after failed bootstrap as data_file_dirs are too full ({}%) " +
                                  "and exceed palantir_cassandra.bootstrap_disk_usage_threshold_percentage ({}%) ",
                                  percentageDataDirUtilization,
-                                 threshold);
+                                 BOOTSTRAP_DISK_USAGE_THRESHOLD);
                     unsafeDisableNode();
                     // leave node in non-transient error state and prevent it from bootstrapping into the cluster
-                    // throw new IllegalStateException("Preventing node from continuing after failed bootstrap as data_file_dirs are too full.");
                     throw new BootstrappingSafetyException(Mode.NON_TRANSIENT_ERROR.toString(),
                                                           mostUtilizedDataDir.getKey().location.toString(),
                                                           percentageDataDirUtilization,
-                                                          Double.valueOf(threshold));
+                                                          Double.valueOf(BOOTSTRAP_DISK_USAGE_THRESHOLD));
                 }
                 else
                 {

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -47,7 +47,8 @@ public interface StorageServiceMBean extends NotificationEmitter
     public enum NonTransientError {
         COMMIT_LOG_CORRUPTION,
         SSTABLE_CORRUPTION,
-        FS_ERROR
+        FS_ERROR,
+        BOOTSTRAP_ERROR
     }
 
     /**


### PR DESCRIPTION
Prevents node from starting up if the most filled `data_file_directories` directory’s utilization exceeds the `palantir_cassandra.bootstrap_disk_usage_threshold_percentage` system var. If the threshold is exceeded the node will be disabled and placed into `NON_TRANSIENT_ERROR` mode stating that an unrecoverable error was hit. The node will stay up with JMX being available but will not respond to any client requests (as it is disabled).  

The sequence of expected node states would be:
STARTING -> WAITING_TO_BOOTSTRAP -> NON_TRANSIENT_ERROR

Important notes:
- the path at which bootstrapping terminates is before metrics get started, thus metrics will be unavailable
- seed nodes bypass this path

Sample log:

```
INFO  13:57:39 NON_TRANSIENT_ERROR: Detected previous bootstrap failure, data dir too full to proceed.
ERROR 13:57:39 Preventing node from continuing after failed bootstrap as data_file_dirs are too full (7.534545527230836%) and exceed palantir_cassandra.bootstrap_disk_usage_threshold_percentage (0%) 
INFO  13:57:39 Stopping transports and disabling auto compaction
ERROR 13:57:39 Stopping gossiper
WARN  13:57:39 Stopping gossip by operator request
WARN  13:57:39 No local state, state is in silent shutdown, or node hasn't joined, not announcing shutdown
Preventing node from continuing after failed bootstrap as most utilized data_file_dir (<redacted path>) is too full (7.534546) and exceeds palantir_cassandra.bootstrap_disk_usage_threshold_percentage (5.000000).  Node will stay in NON_TRANSIENT_ERROR mode.
Non-fatal bootstrap error. Server will continue but is disabled and without metrics.
```