### PR TITLE
Stop current compactions disk threshold

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -1671,6 +1671,14 @@ public class CompactionManager implements CompactionManagerMBean
         }
     }
 
+    public void stopAllCompactions() {
+        for (OperationType type : OperationType.values()) {
+            logger.info("Stopping compactions of type {}", type.name());
+            stopCompaction(type.name());
+        }
+        logger.info("All compactions stopped");
+    }
+
     public void stopCompaction(String type)
     {
         OperationType operation = OperationType.valueOf(type);

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -80,6 +80,13 @@ public class CompactionManager implements CompactionManagerMBean
     public static final int NO_GC = Integer.MIN_VALUE;
     public static final int GC_ALL = Integer.MAX_VALUE;
 
+    public static final EnumSet<OperationType> STOPPABLE_COMPACTION_TYPES = EnumSet.of(OperationType.COMPACTION,
+                                                                                       OperationType.VALIDATION,
+                                                                                       OperationType.CLEANUP,
+                                                                                       OperationType.SCRUB,
+                                                                                       OperationType.INDEX_BUILD);
+
+
     // A thread local that tells us if the current thread is owned by the compaction manager. Used
     // by CounterContext to figure out if it should log a warning for invalid counter shards.
     public static final ThreadLocal<Boolean> isCompactionManager = new ThreadLocal<Boolean>()
@@ -1672,7 +1679,7 @@ public class CompactionManager implements CompactionManagerMBean
     }
 
     public void stopAllCompactions() {
-        for (OperationType type : OperationType.values()) {
+        for (OperationType type : STOPPABLE_COMPACTION_TYPES) {
             logger.info("Stopping compactions of type {}", type.name());
             stopCompaction(type.name());
         }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManagerMBean.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManagerMBean.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.db.compaction;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import javax.management.openmbean.TabularData;
 
 public interface CompactionManagerMBean

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4806,9 +4806,10 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     // Unsafe as does not check state before disabling the node
     public void unsafeDisableNode() {
-        logger.info("Stopping transports and disabling auto compaction");
+        logger.info("Stopping transports, disabling auto compactions, stopping in-progress compactions");
         instance.stopTransports();
         disableAutoCompaction();
+        CompactionManager.instance.stopAllCompactions();
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.db.compaction;
 import org.junit.Test;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -31,7 +32,11 @@ public class CompactionManagerTest
         CompactionManager manager = spy(CompactionManager.instance);
         manager.stopAllCompactions();
         for (OperationType type : OperationType.values()) {
-            verify(manager).stopCompaction(eq(type.name()));
+            if (CompactionManager.STOPPABLE_COMPACTION_TYPES.contains(type)) {
+                verify(manager).stopCompaction(eq(type.name()));
+            } else {
+                verify(manager, never()).stopCompaction(eq(type.name()));
+            }
         }
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionManagerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction;
+
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class CompactionManagerTest
+{
+    @Test
+    public void stopAllCompactions_stopsInProgressCompactions() {
+        CompactionManager manager = spy(CompactionManager.instance);
+        manager.stopAllCompactions();
+        for (OperationType type : OperationType.values()) {
+            verify(manager).stopCompaction(eq(type.name()));
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
@@ -173,7 +173,7 @@ public class StorageServiceServerTest
     }
 
     @Test
-    public void testSnapshotJoiningNode() throws InterruptedException, IOException
+    public void testSnapshotJoiningNode() throws IOException
     {
         StorageService ss = StorageService.instance;
         ss.setOperationMode(StorageService.Mode.JOINING);


### PR DESCRIPTION
Previously if we exceeded our set disk thresholds we would stop scheduling new compactions / executing pending compactions. This is still dangerous as large in-progress compactions were allowed to continue beyond the thresholds. Now, after passing the configured max disk utilization we stop all in-progress compactions to prevent this dangerous behavior.

Throttling compaction throughput and checking compactionstats in a loop yields the following upon exceeding the disk threshold:

With compaction shutdown:


![image](https://user-images.githubusercontent.com/21185532/116744744-b62eb600-a9c8-11eb-91a8-60320ac04f47.png)
The in-progress compaction is stopped when the shutdown is announced. Once disk usage returns underneath the threshold compactions may be scheduled again.


Without compaction shutdown:
![image](https://user-images.githubusercontent.com/21185532/116726671-9a6be580-a9b1-11eb-91ff-2a26ed670097.png)
The in-progress compaction continues until completion after the shutdown is announced.
