### PR TITLE
Add paxos threadpool

### DIFF
--- a/src/java/org/apache/cassandra/concurrent/Stage.java
+++ b/src/java/org/apache/cassandra/concurrent/Stage.java
@@ -35,7 +35,8 @@ public enum Stage
     MISC,
     TRACING,
     INTERNAL_RESPONSE,
-    READ_REPAIR;
+    READ_REPAIR,
+    PAXOS;
 
     public static Iterable<Stage> jmxEnabledStages()
     {
@@ -64,6 +65,7 @@ public enum Stage
             case READ:
             case READ_CHEAP:
             case REQUEST_RESPONSE:
+            case PAXOS:
             case READ_REPAIR:
                 return "request";
             default:

--- a/src/java/org/apache/cassandra/concurrent/StageManager.java
+++ b/src/java/org/apache/cassandra/concurrent/StageManager.java
@@ -49,6 +49,7 @@ public class StageManager
         stages.put(Stage.MUTATION, multiThreadedLowSignalStage(Stage.MUTATION, getConcurrentWriters()));
         stages.put(Stage.COUNTER_MUTATION, multiThreadedLowSignalStage(Stage.COUNTER_MUTATION, getConcurrentCounterWriters()));
         stages.put(Stage.READ, multiThreadedLowSignalStage(Stage.READ, getConcurrentReaders()));
+        stages.put(Stage.PAXOS, multiThreadedLowSignalStage(Stage.PAXOS, getConcurrentWriters()));
         stages.put(Stage.READ_CHEAP, readStage(Stage.READ_CHEAP, getConcurrentReaders()));
         stages.put(Stage.REQUEST_RESPONSE, multiThreadedLowSignalStage(Stage.REQUEST_RESPONSE, FBUtilities.getAvailableProcessors()));
         stages.put(Stage.INTERNAL_RESPONSE, multiThreadedStage(Stage.INTERNAL_RESPONSE, FBUtilities.getAvailableProcessors()));

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -40,7 +40,6 @@ import org.cliffc.high_scale_lib.NonBlockingHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.concurrent.ExecutorLocal;
 import org.apache.cassandra.concurrent.ExecutorLocals;
 import org.apache.cassandra.concurrent.ScheduledExecutors;
 import org.apache.cassandra.concurrent.Stage;
@@ -149,9 +148,9 @@ public final class MessagingService implements MessagingServiceMBean
         put(Verb.COUNTER_MUTATION, Stage.COUNTER_MUTATION);
         put(Verb.READ_REPAIR, Stage.MUTATION);
         put(Verb.TRUNCATE, Stage.MUTATION);
-        put(Verb.PAXOS_PREPARE, Stage.MUTATION);
-        put(Verb.PAXOS_PROPOSE, Stage.MUTATION);
-        put(Verb.PAXOS_COMMIT, Stage.MUTATION);
+        put(Verb.PAXOS_PREPARE, Stage.PAXOS);
+        put(Verb.PAXOS_PROPOSE, Stage.PAXOS);
+        put(Verb.PAXOS_COMMIT, Stage.PAXOS);
 
         put(Verb.READ, Stage.READ);
         put(Verb.RANGE_SLICE, Stage.READ);


### PR DESCRIPTION
This would be useful for SND, as the paxos threadpool shares the mutation threadpool, and performs both a read and the write. 

In the case that the data drive is slow, this will block all writes from proceeding, even though there may not be any degradation on the commitlog. 