### PR TITLE
Enable sni headers

### DIFF
--- a/src/java/org/apache/cassandra/security/SSLFactory.java
+++ b/src/java/org/apache/cassandra/security/SSLFactory.java
@@ -173,6 +173,8 @@ public final class SSLFactory
 
     private static void maybeAddSni(InetAddress endpoint, SSLParameters sslParameters)
     {
+        logger.trace(
+                "Maybe adding SNI header to socket for {}/{}", endpoint.getHostName(), endpoint.getHostAddress());
         if (endpoint.getHostName() != null)
         {
             SNIServerName name = new SNIHostName(endpoint.getHostName());

--- a/src/java/org/apache/cassandra/security/SSLFactory.java
+++ b/src/java/org/apache/cassandra/security/SSLFactory.java
@@ -28,8 +28,11 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Optional;
 
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
@@ -39,10 +42,14 @@ import javax.net.ssl.TrustManagerFactory;
 
 import org.apache.cassandra.config.EncryptionOptions;
 import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.Pair;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
@@ -54,7 +61,7 @@ import com.google.common.collect.Sets;
 public final class SSLFactory
 {
     private static final Logger logger = LoggerFactory.getLogger(SSLFactory.class);
-    public static final String[] ACCEPTED_PROTOCOLS = new String[] {"SSLv2Hello", "TLSv1", "TLSv1.1", "TLSv1.2"};
+    public static final String[] ACCEPTED_PROTOCOLS = new String[]{"TLSv1", "TLSv1.1", "TLSv1.2"};
     private static boolean checkedExpiry = false;
 
     public static SSLServerSocket getServerSocket(EncryptionOptions options, InetAddress address, int port) throws IOException
@@ -72,7 +79,7 @@ public final class SSLFactory
     {
         SSLContext ctx = createSSLContext(options, true);
         SSLSocket socket = (SSLSocket) ctx.getSocketFactory().createSocket(address, port, localAddress, localPort);
-        prepareSocket(socket, options);
+        prepareSocket(socket, options, address);
         return socket;
     }
 
@@ -81,11 +88,11 @@ public final class SSLFactory
     {
         SSLContext ctx = createSSLContext(options, true);
         SSLSocket socket = (SSLSocket) ctx.getSocketFactory().createSocket(address, port);
-        prepareSocket(socket, options);
+        prepareSocket(socket, options, address);
         return socket;
     }
 
-    /** Just create a socket */
+    /** Just create a socket. Note that no SNI headeers are added. */
     public static SSLSocket getSocket(EncryptionOptions options) throws IOException
     {
         SSLContext ctx = createSSLContext(options, true);
@@ -136,7 +143,6 @@ public final class SSLFactory
             kmf.init(ks, options.keystore_password.toCharArray());
 
             ctx.init(kmf.getKeyManagers(), trustManagers, null);
-
         }
         catch (Exception e)
         {
@@ -163,6 +169,16 @@ public final class SSLFactory
             logger.warn("Filtering out {} as it isn't supported by the socket", Iterables.toString(missing));
         }
         return ret;
+    }
+
+    private static void maybeAddSni(InetAddress endpoint, SSLParameters sslParameters)
+    {
+        if (endpoint.getHostName() != null)
+        {
+            SNIServerName name = new SNIHostName(endpoint.getHostName());
+            List<SNIServerName> sniHostNames = ImmutableList.of(name);
+            sslParameters.setServerNames(sniHostNames);
+        }
     }
 
     /** Sets relevant socket options specified in encryption settings */
@@ -192,5 +208,20 @@ public final class SSLFactory
         }
         socket.setEnabledCipherSuites(suites);
         socket.setEnabledProtocols(ACCEPTED_PROTOCOLS);
+    }
+
+    /**
+     * Sets relevant socket options specified in encryption settings. May add SNI headers to the socket's SSLParameters
+     * if the given endpoint includes a hostname.
+     */
+    private static void prepareSocket(SSLSocket socket, EncryptionOptions options, InetAddress endpoint)
+    {
+        prepareSocket(socket, options);
+        if (options.require_endpoint_verification)
+        {
+            SSLParameters sslParameters = socket.getSSLParameters();
+            maybeAddSni(endpoint, sslParameters);
+            socket.setSSLParameters(sslParameters);
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/security/SSLFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/SSLFactoryTest.java
@@ -92,7 +92,6 @@ public class SSLFactoryTest
         InetAddress endpoint = FBUtilities.getLocalAddress();
         assertThat(endpoint.getHostName()).isNotNull();
         try (SSLServerSocket server = SSLFactory.getServerSocket(getServerEncryptionOptions(), endpoint, PORT)) {
-            // TODO: does server need SNI..?
             SSLSocket client = SSLFactory.getSocket(getClientEncryptionOptions(), endpoint, PORT);
             assertThat(client.getSSLParameters().getServerNames()).isNotEmpty();
             server.close();

--- a/test/unit/org/apache/cassandra/security/SSLFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/SSLFactoryTest.java
@@ -18,16 +18,25 @@
 */
 package org.apache.cassandra.security;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.util.List;
 
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.net.InetAddresses;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.EncryptionOptions;
 import org.apache.cassandra.config.EncryptionOptions.ServerEncryptionOptions;
 import org.apache.cassandra.utils.FBUtilities;
@@ -35,6 +44,7 @@ import org.junit.Test;
 
 public class SSLFactoryTest
 {
+    private static final int PORT = 55123;
 
     @Test
     public void testFilterCipherSuites()
@@ -50,19 +60,10 @@ public class SSLFactoryTest
     @Test
     public void testServerSocketCiphers() throws IOException
     {
-        ServerEncryptionOptions options = new EncryptionOptions.ServerEncryptionOptions();
-        options.keystore = "test/conf/keystore.jks";
-        options.keystore_password = "cassandra";
-        options.truststore = options.keystore;
-        options.truststore_password = options.keystore_password;
-        options.cipher_suites = new String[] {
-            "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA",
-            "TLS_DHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
-        };
+        EncryptionOptions options = getServerEncryptionOptions();
 
         // enabled ciphers must be a subset of configured ciphers with identical order
-        try (SSLServerSocket socket = SSLFactory.getServerSocket(options, FBUtilities.getLocalAddress(), 55123))
+        try (SSLServerSocket socket = SSLFactory.getServerSocket(options, FBUtilities.getLocalAddress(), PORT))
         {
             String[] enabled = socket.getEnabledCipherSuites();
             String[] wanted = Iterables.toArray(Iterables.filter(Lists.newArrayList(options.cipher_suites),
@@ -72,4 +73,57 @@ public class SSLFactoryTest
         }
     }
 
+    @Test
+    public void getSocket_sniHeadersIfHostnamePresent_oneEndpoint() throws IOException
+    {
+        InetAddress endpoint = FBUtilities.getLocalAddress();
+        assertThat(endpoint.getHostName()).isNotNull();
+        try (SSLServerSocket server = SSLFactory.getServerSocket(getServerEncryptionOptions(), endpoint, PORT)) {
+            SSLSocket client = SSLFactory.getSocket(getClientEncryptionOptions(), endpoint, PORT);
+            assertThat(client.getSSLParameters().getServerNames()).isNotEmpty();
+            server.close();
+            client.close();
+        }
+    }
+
+    @Test
+    public void getSocket_noSniHeadersIfHostnameAbsent_oneEndpoint() throws IOException
+    {
+        InetAddress endpoint = FBUtilities.getLocalAddress();
+        assertThat(endpoint.getHostName()).isNotNull();
+        try (SSLServerSocket server = SSLFactory.getServerSocket(getServerEncryptionOptions(), endpoint, PORT)) {
+            // TODO: does server need SNI..?
+            SSLSocket client = SSLFactory.getSocket(getClientEncryptionOptions(), endpoint, PORT);
+            assertThat(client.getSSLParameters().getServerNames()).isNotEmpty();
+            server.close();
+            client.close();
+        }
+    }
+
+    private static EncryptionOptions getClientEncryptionOptions()
+    {
+        EncryptionOptions options = new EncryptionOptions.ClientEncryptionOptions();
+        return setOptions(options);
+    }
+
+    private static EncryptionOptions getServerEncryptionOptions()
+    {
+        EncryptionOptions options = new EncryptionOptions.ServerEncryptionOptions();
+        return setOptions(options);
+    }
+
+    private static EncryptionOptions setOptions(EncryptionOptions options)
+    {
+        options.keystore = "test/conf/keystore.jks";
+        options.keystore_password = "cassandra";
+        options.truststore = options.keystore;
+        options.truststore_password = options.keystore_password;
+        options.require_endpoint_verification = true;
+        options.cipher_suites = new String[] {
+        "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_DHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
+        };
+        return options;
+    }
 }


### PR DESCRIPTION
SNI is needed for pcloud -> k8s network connectivity. SSL does not seem to be capable of including extensions in requests, so had to remove the SSLv2Hello  from the list of accepted protocols as well as actually adding the SNI header when possible.
