### PR TITLE
Enable sni (non-breaking)

### DIFF
--- a/src/java/org/apache/cassandra/config/EncryptionOptions.java
+++ b/src/java/org/apache/cassandra/config/EncryptionOptions.java
@@ -28,7 +28,7 @@ public abstract class EncryptionOptions
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA" 
     };
-    public String protocol = "TLSv1.2";
+    public String protocol = "TLS";
     public String algorithm = "SunX509";
     public String store_type = "JKS";
     public boolean require_client_auth = false;

--- a/src/java/org/apache/cassandra/config/EncryptionOptions.java
+++ b/src/java/org/apache/cassandra/config/EncryptionOptions.java
@@ -28,7 +28,7 @@ public abstract class EncryptionOptions
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA" 
     };
-    public String protocol = "TLS";
+    public String protocol = "TLSv1.2";
     public String algorithm = "SunX509";
     public String store_type = "JKS";
     public boolean require_client_auth = false;

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -987,9 +987,12 @@ public final class MessagingService implements MessagingServiceMBean
                 try
                 {
                     socket = server.accept();
+                    InetAddress remote = socket.getInetAddress();
+                    logger.trace("Attempting to accept incoming connection from {}", remote);
+
                     if (!authenticate(socket))
                     {
-                        logger.trace("remote failed to authenticate");
+                        logger.trace("remote {} failed to authenticate", remote);
                         socket.close();
                         continue;
                     }
@@ -1010,6 +1013,7 @@ public final class MessagingService implements MessagingServiceMBean
                                   : new IncomingTcpConnection(version, MessagingService.getBits(header, 2, 1) == 1, socket, connections);
                     thread.start();
                     connections.add((Closeable) thread);
+                    logger.trace("Successfully accepted incoming connection from {}", remote);
                 }
                 catch (AsynchronousCloseException e)
                 {

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
@@ -497,6 +497,7 @@ public class OutboundTcpConnection extends Thread
                     }
                 }
 
+                logger.trace("Successfully connected to {}", poolReference.endPoint());
                 return true;
             }
             catch (SSLHandshakeException e)

--- a/src/java/org/apache/cassandra/security/SSLFactory.java
+++ b/src/java/org/apache/cassandra/security/SSLFactory.java
@@ -64,8 +64,8 @@ public final class SSLFactory
     // removing support entirely causes a breaking change while upgrading (the upgraded node will reject the
     // initial SSLv2Hello message from the non-upgraded nodes, failing to connect and causing downtime). Consequently
     // we stop only clients from sending SSLv2Hello messages (and may later stop servers from accepting them as well).
-    public static final String[] ACCEPTED_SERVER_PROTOCOLS = new String[]{ "SSLv2Hello", "TLSv1", "TLSv1.1", "TLSv1.2"};
-    public static final String[] ACCEPTED_CLIENT_PROTOCOLS = new String[]{ "TLSv1", "TLSv1.1", "TLSv1.2"};
+    public static final String[] ACCEPTED_INCOMING_PROTOCOLS = new String[]{ "SSLv2Hello", "TLSv1", "TLSv1.1", "TLSv1.2"};
+    public static final String[] ACCEPTED_OUTGOING_PROTOCOLS = new String[]{ "TLSv1", "TLSv1.1", "TLSv1.2"};
 
     private static boolean checkedExpiry = false;
 
@@ -201,7 +201,7 @@ public final class SSLFactory
         }
         serverSocket.setEnabledCipherSuites(suites);
         serverSocket.setNeedClientAuth(options.require_client_auth);
-        serverSocket.setEnabledProtocols(ACCEPTED_SERVER_PROTOCOLS);
+        serverSocket.setEnabledProtocols(ACCEPTED_INCOMING_PROTOCOLS);
     }
 
     /** Sets relevant socket options specified in encryption settings */
@@ -215,7 +215,7 @@ public final class SSLFactory
             socket.setSSLParameters(sslParameters);
         }
         socket.setEnabledCipherSuites(suites);
-        socket.setEnabledProtocols(ACCEPTED_CLIENT_PROTOCOLS);
+        socket.setEnabledProtocols(ACCEPTED_OUTGOING_PROTOCOLS);
     }
 
     /**

--- a/src/java/org/apache/cassandra/security/SSLFactory.java
+++ b/src/java/org/apache/cassandra/security/SSLFactory.java
@@ -60,8 +60,8 @@ public final class SSLFactory
     private static final Logger logger = LoggerFactory.getLogger(SSLFactory.class);
 
     // Clients will send SSLv2Hello `Client Hello` messages during the SSL/TLS handshake to initiate SSL/TLS version
-    // protocol with the server. We want to get rid of SSLv2Hello because it does not support SNI headers, but
-    // getting rid of support entirely causes a breaking change while upgrading (the upgraded node will reject the
+    // negotiation with the server. We want to get rid of SSLv2Hello because it does not support SNI headers, but
+    // removing support entirely causes a breaking change while upgrading (the upgraded node will reject the
     // initial SSLv2Hello message from the non-upgraded nodes, failing to connect and causing downtime). Consequently
     // we stop only clients from sending SSLv2Hello messages (and may later stop servers from accepting them as well).
     public static final String[] ACCEPTED_SERVER_PROTOCOLS = new String[]{ "SSLv2Hello", "TLSv1", "TLSv1.1", "TLSv1.2"};

--- a/src/java/org/apache/cassandra/security/SSLFactory.java
+++ b/src/java/org/apache/cassandra/security/SSLFactory.java
@@ -171,11 +171,13 @@ public final class SSLFactory
         return ret;
     }
 
-    private static void maybeAddSni(InetAddress endpoint, SSLParameters sslParameters)
+    private static void maybeAddSni(InetAddress addr, SSLParameters sslParameters)
     {
-        if (endpoint.getHostName() != null)
+        logger.trace(
+            "Adding SNI header to socket if hostname present for {}/{}", addr.getHostName(), addr.getHostAddress());
+        if (addr.getHostName() != null)
         {
-            SNIServerName name = new SNIHostName(endpoint.getHostName());
+            SNIServerName name = new SNIHostName(addr.getHostName());
             List<SNIServerName> sniHostNames = ImmutableList.of(name);
             sslParameters.setServerNames(sniHostNames);
         }

--- a/src/java/org/apache/cassandra/security/SSLFactory.java
+++ b/src/java/org/apache/cassandra/security/SSLFactory.java
@@ -28,8 +28,11 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Optional;
 
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
@@ -39,10 +42,14 @@ import javax.net.ssl.TrustManagerFactory;
 
 import org.apache.cassandra.config.EncryptionOptions;
 import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.Pair;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
@@ -54,7 +61,7 @@ import com.google.common.collect.Sets;
 public final class SSLFactory
 {
     private static final Logger logger = LoggerFactory.getLogger(SSLFactory.class);
-    public static final String[] ACCEPTED_PROTOCOLS = new String[] {"SSLv2Hello", "TLSv1", "TLSv1.1", "TLSv1.2"};
+    public static final String[] ACCEPTED_PROTOCOLS = new String[]{"TLSv1", "TLSv1.1", "TLSv1.2"};
     private static boolean checkedExpiry = false;
 
     public static SSLServerSocket getServerSocket(EncryptionOptions options, InetAddress address, int port) throws IOException
@@ -72,7 +79,7 @@ public final class SSLFactory
     {
         SSLContext ctx = createSSLContext(options, true);
         SSLSocket socket = (SSLSocket) ctx.getSocketFactory().createSocket(address, port, localAddress, localPort);
-        prepareSocket(socket, options);
+        prepareSocket(socket, options, address);
         return socket;
     }
 
@@ -81,11 +88,11 @@ public final class SSLFactory
     {
         SSLContext ctx = createSSLContext(options, true);
         SSLSocket socket = (SSLSocket) ctx.getSocketFactory().createSocket(address, port);
-        prepareSocket(socket, options);
+        prepareSocket(socket, options, address);
         return socket;
     }
 
-    /** Just create a socket */
+    /** Just create a socket. Note that no SNI headeers are added. */
     public static SSLSocket getSocket(EncryptionOptions options) throws IOException
     {
         SSLContext ctx = createSSLContext(options, true);
@@ -136,7 +143,6 @@ public final class SSLFactory
             kmf.init(ks, options.keystore_password.toCharArray());
 
             ctx.init(kmf.getKeyManagers(), trustManagers, null);
-
         }
         catch (Exception e)
         {
@@ -163,6 +169,16 @@ public final class SSLFactory
             logger.warn("Filtering out {} as it isn't supported by the socket", Iterables.toString(missing));
         }
         return ret;
+    }
+
+    private static void maybeAddSni(InetAddress endpoint, SSLParameters sslParameters)
+    {
+        if (endpoint.getHostName() != null)
+        {
+            SNIServerName name = new SNIHostName(endpoint.getHostName());
+            List<SNIServerName> sniHostNames = ImmutableList.of(name);
+            sslParameters.setServerNames(sniHostNames);
+        }
     }
 
     /** Sets relevant socket options specified in encryption settings */
@@ -192,5 +208,20 @@ public final class SSLFactory
         }
         socket.setEnabledCipherSuites(suites);
         socket.setEnabledProtocols(ACCEPTED_PROTOCOLS);
+    }
+
+    /**
+     * Sets relevant socket options specified in encryption settings. May add SNI headers to the socket's SSLParameters
+     * if the given endpoint includes a hostname.
+     */
+    private static void prepareSocket(SSLSocket socket, EncryptionOptions options, InetAddress endpoint)
+    {
+        prepareSocket(socket, options);
+        if (options.require_endpoint_verification)
+        {
+            SSLParameters sslParameters = socket.getSSLParameters();
+            maybeAddSni(endpoint, sslParameters);
+            socket.setSSLParameters(sslParameters);
+        }
     }
 }

--- a/src/java/org/apache/cassandra/thrift/CustomTThreadPoolServer.java
+++ b/src/java/org/apache/cassandra/thrift/CustomTThreadPoolServer.java
@@ -264,7 +264,7 @@ public class CustomTThreadPoolServer extends TServer
                         sslServerSocket.setSSLParameters(sslParameters);
                     }
                     sslServerSocket.setEnabledCipherSuites(suites);
-                    sslServerSocket.setEnabledProtocols(SSLFactory.ACCEPTED_SERVER_PROTOCOLS);
+                    sslServerSocket.setEnabledProtocols(SSLFactory.ACCEPTED_INCOMING_PROTOCOLS);
                     serverTransport = new TCustomServerSocket(sslServer.getServerSocket(), args.keepAlive, args.sendBufferSize, args.recvBufferSize);
                 }
                 else

--- a/src/java/org/apache/cassandra/thrift/CustomTThreadPoolServer.java
+++ b/src/java/org/apache/cassandra/thrift/CustomTThreadPoolServer.java
@@ -264,7 +264,7 @@ public class CustomTThreadPoolServer extends TServer
                         sslServerSocket.setSSLParameters(sslParameters);
                     }
                     sslServerSocket.setEnabledCipherSuites(suites);
-                    sslServerSocket.setEnabledProtocols(SSLFactory.ACCEPTED_PROTOCOLS);
+                    sslServerSocket.setEnabledProtocols(SSLFactory.ACCEPTED_SERVER_PROTOCOLS);
                     serverTransport = new TCustomServerSocket(sslServer.getServerSocket(), args.keepAlive, args.sendBufferSize, args.recvBufferSize);
                 }
                 else

--- a/src/java/org/apache/cassandra/transport/Server.java
+++ b/src/java/org/apache/cassandra/transport/Server.java
@@ -381,7 +381,7 @@ public class Server implements CassandraDaemon.Server
             }
             sslEngine.setEnabledCipherSuites(suites);
             sslEngine.setNeedClientAuth(encryptionOptions.require_client_auth);
-            sslEngine.setEnabledProtocols(SSLFactory.ACCEPTED_PROTOCOLS);
+            sslEngine.setEnabledProtocols(SSLFactory.ACCEPTED_SERVER_PROTOCOLS);
             return new SslHandler(sslEngine);
         }
     }

--- a/src/java/org/apache/cassandra/transport/Server.java
+++ b/src/java/org/apache/cassandra/transport/Server.java
@@ -381,7 +381,7 @@ public class Server implements CassandraDaemon.Server
             }
             sslEngine.setEnabledCipherSuites(suites);
             sslEngine.setNeedClientAuth(encryptionOptions.require_client_auth);
-            sslEngine.setEnabledProtocols(SSLFactory.ACCEPTED_SERVER_PROTOCOLS);
+            sslEngine.setEnabledProtocols(SSLFactory.ACCEPTED_INCOMING_PROTOCOLS);
             return new SslHandler(sslEngine);
         }
     }

--- a/src/java/org/apache/cassandra/transport/SimpleClient.java
+++ b/src/java/org/apache/cassandra/transport/SimpleClient.java
@@ -300,7 +300,7 @@ public class SimpleClient implements Closeable
                 sslEngine.setSSLParameters(sslParameters);
             }
             sslEngine.setEnabledCipherSuites(suites);
-            sslEngine.setEnabledProtocols(SSLFactory.ACCEPTED_PROTOCOLS);
+            sslEngine.setEnabledProtocols(SSLFactory.ACCEPTED_CLIENT_PROTOCOLS);
             channel.pipeline().addFirst("ssl", new SslHandler(sslEngine));
         }
     }

--- a/src/java/org/apache/cassandra/transport/SimpleClient.java
+++ b/src/java/org/apache/cassandra/transport/SimpleClient.java
@@ -300,7 +300,7 @@ public class SimpleClient implements Closeable
                 sslEngine.setSSLParameters(sslParameters);
             }
             sslEngine.setEnabledCipherSuites(suites);
-            sslEngine.setEnabledProtocols(SSLFactory.ACCEPTED_CLIENT_PROTOCOLS);
+            sslEngine.setEnabledProtocols(SSLFactory.ACCEPTED_OUTGOING_PROTOCOLS);
             channel.pipeline().addFirst("ssl", new SslHandler(sslEngine));
         }
     }

--- a/test/unit/org/apache/cassandra/security/SSLFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/SSLFactoryTest.java
@@ -92,7 +92,6 @@ public class SSLFactoryTest
         InetAddress endpoint = FBUtilities.getLocalAddress();
         assertThat(endpoint.getHostName()).isNotNull();
         try (SSLServerSocket server = SSLFactory.getServerSocket(getServerEncryptionOptions(), endpoint, PORT)) {
-            // TODO: does server need SNI..?
             SSLSocket client = SSLFactory.getSocket(getClientEncryptionOptions(), endpoint, PORT);
             assertThat(client.getSSLParameters().getServerNames()).isNotEmpty();
             server.close();

--- a/test/unit/org/apache/cassandra/security/SSLFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/SSLFactoryTest.java
@@ -18,16 +18,25 @@
 */
 package org.apache.cassandra.security;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.util.List;
 
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.net.InetAddresses;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.EncryptionOptions;
 import org.apache.cassandra.config.EncryptionOptions.ServerEncryptionOptions;
 import org.apache.cassandra.utils.FBUtilities;
@@ -35,6 +44,7 @@ import org.junit.Test;
 
 public class SSLFactoryTest
 {
+    private static final int PORT = 55123;
 
     @Test
     public void testFilterCipherSuites()
@@ -50,19 +60,10 @@ public class SSLFactoryTest
     @Test
     public void testServerSocketCiphers() throws IOException
     {
-        ServerEncryptionOptions options = new EncryptionOptions.ServerEncryptionOptions();
-        options.keystore = "test/conf/keystore.jks";
-        options.keystore_password = "cassandra";
-        options.truststore = options.keystore;
-        options.truststore_password = options.keystore_password;
-        options.cipher_suites = new String[] {
-            "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA",
-            "TLS_DHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
-        };
+        EncryptionOptions options = getServerEncryptionOptions();
 
         // enabled ciphers must be a subset of configured ciphers with identical order
-        try (SSLServerSocket socket = SSLFactory.getServerSocket(options, FBUtilities.getLocalAddress(), 55123))
+        try (SSLServerSocket socket = SSLFactory.getServerSocket(options, FBUtilities.getLocalAddress(), PORT))
         {
             String[] enabled = socket.getEnabledCipherSuites();
             String[] wanted = Iterables.toArray(Iterables.filter(Lists.newArrayList(options.cipher_suites),
@@ -72,4 +73,57 @@ public class SSLFactoryTest
         }
     }
 
+    @Test
+    public void getSocket_sniHeadersIfHostnamePresent_oneEndpoint() throws IOException
+    {
+        InetAddress endpoint = FBUtilities.getLocalAddress();
+        assertThat(endpoint.getHostName()).isNotNull();
+        try (SSLServerSocket server = SSLFactory.getServerSocket(getServerEncryptionOptions(), endpoint, PORT)) {
+            SSLSocket client = SSLFactory.getSocket(getClientEncryptionOptions(), endpoint, PORT);
+            assertThat(client.getSSLParameters().getServerNames()).isNotEmpty();
+            server.close();
+            client.close();
+        }
+    }
+
+    @Test
+    public void getSocket_noSniHeadersIfHostnameAbsent_oneEndpoint() throws IOException
+    {
+        InetAddress endpoint = FBUtilities.getLocalAddress();
+        assertThat(endpoint.getHostName()).isNotNull();
+        try (SSLServerSocket server = SSLFactory.getServerSocket(getServerEncryptionOptions(), endpoint, PORT)) {
+            // TODO: does server need SNI..?
+            SSLSocket client = SSLFactory.getSocket(getClientEncryptionOptions(), endpoint, PORT);
+            assertThat(client.getSSLParameters().getServerNames()).isNotEmpty();
+            server.close();
+            client.close();
+        }
+    }
+
+    private static EncryptionOptions getClientEncryptionOptions()
+    {
+        EncryptionOptions options = new EncryptionOptions.ClientEncryptionOptions();
+        return setOptions(options);
+    }
+
+    private static EncryptionOptions getServerEncryptionOptions()
+    {
+        EncryptionOptions options = new EncryptionOptions.ServerEncryptionOptions();
+        return setOptions(options);
+    }
+
+    private static EncryptionOptions setOptions(EncryptionOptions options)
+    {
+        options.keystore = "test/conf/keystore.jks";
+        options.keystore_password = "cassandra";
+        options.truststore = options.keystore;
+        options.truststore_password = options.keystore_password;
+        options.require_endpoint_verification = true;
+        options.cipher_suites = new String[] {
+        "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_DHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
+        };
+        return options;
+    }
 }


### PR DESCRIPTION
#281 resulted in a breaking change as SSLv2Hello was no longer accepted by both server and client sockets. During the upgrade, previous versions attempted to connect to the new version using the SSLv2Hello protocol, so they were rejected and could not connect.

Making client sockets no longer accept SSLv2Hello but allowing server sockets to continue accepting it fixes this break during the rolling upgrade. Nodes running the new version send `Client Hello` requests using TLS (which allows for SNI headers while SSL does not) and their server sockets will still be able to accept the SSL `Hello`'s from the old-version client sockets.


![during_upgrade](https://user-images.githubusercontent.com/21185532/131349940-79fa4f18-a988-4dc0-a895-7d8d8041a84e.png)
The first `Client Hello` in the picture is from the non-upgraded host to the upgraded host. The second `Client Hello` is the opposite direction (and correctly TLS)