### PR TITLE
Fix: Unable to run with periodic commitlog_sync due to broken config validation

### DIFF
--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -316,10 +316,6 @@ public class DatabaseDescriptor
         }
         else
         {
-            if (conf.commitlog_sync_batch_window_in_ms == null)
-            {
-                throw new ConfigurationException("Missing value for commitlog_sync_batch_window_in_ms: Double expected.", false);
-            }
             if (conf.commitlog_sync_period_in_ms == null)
             {
                 throw new ConfigurationException("Missing value for commitlog_sync_period_in_ms: Integer expected", false);


### PR DESCRIPTION
**Summary**
It's currently impossible to run cassandra with `commitlog_sync: periodic`. The root-cause is broken config-validation. This PR reverts the config-validation to be the [same as used in cassandra-2.2](https://github.com/apache/cassandra/blob/2e547dfbc40e6b500db506353bced161c66f3113/src/java/org/apache/cassandra/config/DatabaseDescriptor.java#L311)


**Current state**

When running cassandra with the following cassandra.yaml:

```yml
commitlog_sync: periodic
commitlog_sync_period_in_ms: 10000
```

cassandra fails on startup with the following error:
```
Exception (org.apache.cassandra.exceptions.ConfigurationException) encountered during startup: Missing value for commitlog_sync_batch_window_in_ms: Double expected.
```

This is unexpected, as `commitlog_sync_batch_window_in_ms` is expected to be absent when running with `commitlog_sync: periodic`. 

The current code checks for `commitlog_sync_batch_window_in_ms` to both be absent and present, making running in periodic mode impossible.


