### PR TITLE
Add tracking for keyspaces that have completed streaming ranges

### DIFF
--- a/src/java/org/apache/cassandra/dht/RangeStreamer.java
+++ b/src/java/org/apache/cassandra/dht/RangeStreamer.java
@@ -19,16 +19,19 @@ package org.apache.cassandra.dht;
 
 import java.net.InetAddress;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.antlr.analysis.SemanticContext;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.gms.EndpointState;
@@ -356,9 +359,7 @@ public class RangeStreamer
             String keyspace = entry.getKey();
             InetAddress source = entry.getValue().getKey();
             InetAddress preferred = SystemKeyspace.getPreferredIP(source);
-            Collection<Range<Token>> ranges = entry.getValue().getValue();
-
-            removeAvailableRanges(entry, true);
+            Collection<Range<Token>> ranges = removeAvailableRanges(entry, true);
 
             if (logger.isTraceEnabled())
                 logger.trace("{}ing from {} ranges {}", description, source, StringUtils.join(ranges, ", "));
@@ -374,24 +375,28 @@ public class RangeStreamer
         boolean allPresent = true;
         for (Map.Entry<String, Map.Entry<InetAddress, Collection<Range<Token>>>> entry : toFetch.entries())
         {
-            removeAvailableRanges(entry, false);
-            Collection<Range<Token>> ranges = entry.getValue().getValue();
+            Collection<Range<Token>> ranges = removeAvailableRanges(entry, false);
             allPresent &= ranges.isEmpty();
         }
         return allPresent;
     }
 
     @VisibleForTesting
-    void removeAvailableRanges(Map.Entry<String, Map.Entry<InetAddress, Collection<Range<Token>>>> entry, boolean log)
+    Set<Range<Token>> removeAvailableRanges(Map.Entry<String, Map.Entry<InetAddress, Collection<Range<Token>>>> entry, boolean log)
     {
         String keyspace = entry.getKey();
-        Collection<Range<Token>> ranges = entry.getValue().getValue();
+        Collection<Range<Token>> ranges = ImmutableSet.copyOf(entry.getValue().getValue());
 
         // filter out already streamed ranges
         Set<Range<Token>> availableRanges = stateStore.getAvailableRanges(keyspace, StorageService.getPartitioner());
-        if (ranges.removeAll(availableRanges) && log)
+        Set<Range<Token>> unavailableRanges = ranges.stream()
+                                                    .filter(range -> !availableRanges.contains(range))
+                                                    .collect(Collectors.toSet());
+        if (!availableRanges.equals(unavailableRanges) && log)
         {
             logger.info("Some ranges of {} are already available. Skipping streaming those ranges.", availableRanges);
         }
+        entry.getValue().setValue(ranges);
+        return unavailableRanges;
     }
 }

--- a/src/java/org/apache/cassandra/dht/RangeStreamer.java
+++ b/src/java/org/apache/cassandra/dht/RangeStreamer.java
@@ -392,11 +392,11 @@ public class RangeStreamer
         Set<Range<Token>> unavailableRanges = ranges.stream()
                                                     .filter(range -> !availableRanges.contains(range))
                                                     .collect(Collectors.toSet());
+        entry.getValue().getValue().removeAll(availableRanges);
         if (!availableRanges.equals(unavailableRanges) && log)
         {
             logger.info("Some ranges of {} are already available. Skipping streaming those ranges.", availableRanges);
         }
-        entry.getValue().setValue(ranges);
         return unavailableRanges;
     }
 }

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -590,6 +590,16 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
      */
     public void rebuild(String sourceDc, String keyspace);
 
+    /**
+     * To be used after issuing a rebuild to verify whether all relevant data has been successfully streamed to this
+     * node from the source datacenter.
+     *
+     * @param sourceDc Name of DC from which to select sources for ranges or null to pick any node
+     * @return the names of keyspaces for which this node holds all ranges from the source DC. Note that this does not
+     * include system keyspaces or keyspaces that do not have follow NetworkTopologyStrategy
+     */
+    public Set<String> getKeyspacesWithAllRangesAvailable(String sourceDc);
+
     /** Starts a bulk load and blocks until it completes. */
     public void bulkLoad(String directory);
 

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -596,7 +596,7 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
      *
      * @param sourceDc Name of DC from which to select sources for ranges or null to pick any node
      * @return the names of keyspaces for which this node holds all ranges from the source DC. Note that this does not
-     * include system keyspaces or keyspaces that do not have follow NetworkTopologyStrategy
+     * include system keyspaces or keyspaces that do not follow NetworkTopologyStrategy
      */
     public Set<String> getKeyspacesWithAllRangesAvailable(String sourceDc);
 

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1095,6 +1095,11 @@ public class NodeProbe implements AutoCloseable
         ssProxy.rebuild(sourceDc, keyspace);
     }
 
+    public Set<String> getKeyspacesWithAllRangesAvailable(String sourceDc)
+    {
+        return ssProxy.getKeyspacesWithAllRangesAvailable(sourceDc);
+    }
+
     public List<String> sampleKeyRange()
     {
         return ssProxy.sampleKeyRange();

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -113,6 +113,7 @@ public class NodeTool
                 ResumeHandoff.class,
                 ProxyHistograms.class,
                 Rebuild.class,
+                GetKeyspacesWithAllRangesAvailable.class,
                 Refresh.class,
                 RemoveNode.class,
                 Assassinate.class,

--- a/src/java/org/apache/cassandra/tools/nodetool/GetKeyspacesWithAllRangesAvailable.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetKeyspacesWithAllRangesAvailable.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import java.util.Set;
+
+import io.airlift.command.Arguments;
+import io.airlift.command.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
+
+@Command(name = "getkeyspaceswithallrangesavailable", description = "Rebuild data by streaming from other nodes (similarly to bootstrap)")
+public class GetKeyspacesWithAllRangesAvailable extends NodeToolCmd
+{
+    @Arguments(usage = "<src-dc-name>", description = "Name of DC from which to select sources for range checks. By default, pick any DC")
+    private String sourceDataCenterName = null;
+
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        try
+        {
+            Set<String> keyspaces = probe.getKeyspacesWithAllRangesAvailable(sourceDataCenterName);
+            System.out.print(keyspaces);
+        }
+        catch (Exception e)
+        {
+            System.out.print("Failed to retrieve keyspaces with all ranges available. Check logs for details");
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/dht/RangeStreamerTest.java
+++ b/test/unit/org/apache/cassandra/dht/RangeStreamerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.sun.tools.javac.util.List;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.Schema;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.locator.TokenMetadata;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class RangeStreamerTest
+{
+    private final String keyspace = Schema.instance.getNonSystemKeyspaces().get(0);
+
+    @BeforeClass
+    public static void setup() throws ConfigurationException
+    {
+        SchemaLoader.startGossiper();
+        SchemaLoader.prepareServer();
+        SchemaLoader.schemaDefinition("RangeStreamerTest");
+    }
+
+    @Test
+    public void removeAvailableRanges_removesAlreadyStreamedRanges() throws UnknownHostException
+    {
+        IPartitioner p = StorageService.getPartitioner();
+        Token.TokenFactory factory = p.getTokenFactory();
+        Range<Token> availableRange = new Range<>(factory.fromString("0"), factory.fromString("100"));
+        Range<Token> expectedToStream = new Range<>(factory.fromString("100"), factory.fromString("200"));
+        Collection<Range<Token>> totalRange = ImmutableSet.of(
+                                                    new Range<>(factory.fromString("0"), factory.fromString("100")),
+                                                    expectedToStream);
+        RangeStreamer streamer = mockRangeStreamer(totalRange, availableRange);
+        streamer.addRanges(keyspace, totalRange);
+
+        streamer.toFetch().entries().forEach(entry -> streamer.removeAvailableRanges(entry, false));
+        Collection<Map.Entry<InetAddress, Collection<Range<Token>>>> values = streamer.toFetch().values();
+        assertThat(values).hasSize(1);
+        Collection<Range<Token>> toFetchRanges = values.iterator().next().getValue();
+        assertThat(toFetchRanges).containsOnly(expectedToStream);
+    }
+
+    @Test
+    public void areAllRangesPresent_trueWhenAllPresent() throws UnknownHostException
+    {
+        IPartitioner p = StorageService.getPartitioner();
+        Token.TokenFactory factory = p.getTokenFactory();
+        Range<Token> availableRange = new Range<>(factory.fromString("0"), factory.fromString("100"));
+        RangeStreamer streamer = mockRangeStreamer(ImmutableSet.of(availableRange), availableRange);
+        streamer.addRanges(keyspace, List.of(availableRange));
+        assertThat(streamer.areAllRangesPresent()).isTrue();
+    }
+
+    @Test
+    public void areAllRangesPresent_falseWhenAnyAbsent() throws UnknownHostException
+    {
+        IPartitioner p = StorageService.getPartitioner();
+        Token.TokenFactory factory = p.getTokenFactory();
+        Range<Token> availableRange = new Range<>(factory.fromString("0"), factory.fromString("100"));
+        Collection<Range<Token>> totalRange = ImmutableSet.of(
+                                                    new Range<>(factory.fromString("0"), factory.fromString("100")),
+                                                    new Range<>(factory.fromString("100"), factory.fromString("200")));
+        RangeStreamer streamer = mockRangeStreamer(totalRange, availableRange);
+        streamer.addRanges(keyspace, totalRange);
+        assertThat(streamer.areAllRangesPresent()).isFalse();
+    }
+
+    private RangeStreamer mockRangeStreamer(Collection<Range<Token>> totalRange, Range<Token> availableRange) throws UnknownHostException
+    {
+        TokenMetadata tmd = StorageService.instance.getTokenMetadata();
+        tmd.clearUnsafe();
+        Set<Token> total = new HashSet<>();
+        totalRange.forEach(range -> {
+            total.add(range.left);
+            total.add(range.right);
+        });
+        tmd.updateNormalTokens(total, InetAddress.getByName("127.0.0.2"));
+
+        StreamStateStore streamStateStore = mock(StreamStateStore.class);
+        doReturn(ImmutableSet.of(availableRange)).when(streamStateStore).getAvailableRanges(anyString(), any());
+        return new RangeStreamer(tmd,
+                                 null,
+                                 FBUtilities.getBroadcastAddress(),
+                                 "Rebuild",
+                                 false,
+                                 DatabaseDescriptor.getEndpointSnitch(),
+                                 streamStateStore);
+    }
+}

--- a/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
@@ -24,6 +24,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.*;
 
 import com.google.common.collect.HashMultimap;
@@ -47,13 +48,13 @@ import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.WindowsFailedSnapshotTracker;
 import org.apache.cassandra.db.SystemKeyspace;
-import org.apache.cassandra.dht.ByteOrderedPartitioner;
-import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.dht.OrderPreservingPartitioner.StringToken;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.dht.Murmur3Partitioner.LongToken;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.locator.IEndpointSnitch;
 import org.apache.cassandra.locator.PropertyFileSnitch;
 import org.apache.cassandra.locator.TokenMetadata;
@@ -773,5 +774,49 @@ public class StorageServiceServerTest
         TokenMetadata tmd = new TokenMetadata();
         StorageService.instance.setTokenMetadataUnsafe(tmd);
         assertThat(StorageService.instance.getLocalHostId()).isNull();
+    }
+
+    @Test
+    public void getRebuiltKeyspaces_removesKeyspacesWithUnavailableRanges() throws UnknownHostException
+    {
+        Map<String, String> configOptions = new HashMap<>();
+        configOptions.put("DC1", "1");
+        configOptions.put("DC2", "1");
+
+        Keyspace.clear("Keyspace1");
+        KSMetaData meta = KSMetaData.newKeyspace("Keyspace1", "NetworkTopologyStrategy", configOptions, false);
+        Schema.instance.setKeyspaceDefinition(meta);
+
+        TokenMetadata metadata = StorageService.instance.getTokenMetadata();
+        metadata.clearUnsafe();
+
+        Token.TokenFactory factory = StorageService.getPartitioner().getTokenFactory();
+
+        // DC1
+        metadata.updateNormalToken(factory.fromString("A"), InetAddress.getByName("127.0.0.1"));
+        metadata.updateNormalToken(factory.fromString("C"), InetAddress.getByName("127.0.0.2"));
+
+        // DC2
+        metadata.updateNormalToken(factory.fromString("B"), InetAddress.getByName("127.0.0.4"));
+        metadata.updateNormalToken(factory.fromString("D"), InetAddress.getByName("127.0.0.5"));
+
+        // If nodes aren't up RangeStreamer's FailureDetectorSourceFilter will remove the endpoints
+        // from streaming consideration
+        InetAddress h2 = InetAddress.getByName("127.0.0.2");
+        InetAddress h4 = InetAddress.getByName("127.0.0.4");
+        InetAddress h5 = InetAddress.getByName("127.0.0.5");
+        Gossiper.instance.initializeNodeUnsafe(h2, UUID.randomUUID(), 1);
+        Gossiper.instance.initializeNodeUnsafe(h4, UUID.randomUUID(), 1);
+        Gossiper.instance.initializeNodeUnsafe(h5, UUID.randomUUID(), 1);
+        Gossiper.instance.realMarkAlive(h2, Gossiper.instance.getEndpointStateForEndpoint(h2));
+        Gossiper.instance.realMarkAlive(h4, Gossiper.instance.getEndpointStateForEndpoint(h4));
+        Gossiper.instance.realMarkAlive(h5, Gossiper.instance.getEndpointStateForEndpoint(h5));
+
+        Set<String> res1 = StorageService.instance.getKeyspacesWithAllRangesAvailable("DC2");
+        assertThat(res1).isEmpty();
+
+        SystemKeyspace.updateAvailableRanges("Keyspace1", StorageService.instance.getLocalRanges("Keyspace1"));
+        Set<String> res2 = StorageService.instance.getKeyspacesWithAllRangesAvailable("DC2");
+        assertThat(res2).containsOnly("Keyspace1");
     }
 }


### PR DESCRIPTION
Adds a JMX endpoint and nodetool command to see the set of keyspaces that do not have any token ranges that need to be streamed to the given node. This can be used to check the status of a rebuild programmatically rather than looking through logs.

```
Datacenter: DC11
================
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address      Load       Tokens       Owns    Host ID                               Rack
UN  10.0.20.213  11.4 GB    512          ?       c58ec2b2-1729-4944-af37-968c03698090  RAC1
UN  10.0.23.42   11.4 GB    512          ?       12e52712-6072-47e2-bcb2-db954dc4b10e  RAC1
UN  10.0.23.45   11.38 GB   512          ?       88c2f28d-a24d-448e-a7dd-d94e45df3826  RAC1
Datacenter: DC12
================
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address      Load       Tokens       Owns    Host ID                               Rack
UN  10.0.20.157  9.88 MB    512          ?       d8cc048c-193d-4408-9164-f31c8189ba7a  RAC1


$ ./service/bin/nodetool getkeyspaceswithallrangesavailable | grep foundry_email
$ ./service/bin/nodetool rebuild -ks foundry_email -- DC11
$ ./service/bin/nodetool getkeyspaceswithallrangesavailable | grep foundry_email
[...foundry_email...]
```