### PR TITLE
[Cell-CAS for Transactions 3] Part 1: Bump libthrift to 0.9.3-1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -391,7 +391,7 @@
             <exclusion groupId="org.slf4j" artifactId="slf4j-log4j12"/>
           </dependency>
           <dependency groupId="org.yaml" artifactId="snakeyaml" version="1.11"/>
-          <dependency groupId="org.apache.thrift" artifactId="libthrift" version="0.9.2">
+          <dependency groupId="org.apache.thrift" artifactId="libthrift" version="0.9.3-1">
 	         <exclusion groupId="commons-logging" artifactId="commons-logging"/>
           </dependency>
           <dependency groupId="junit" artifactId="junit" version="4.6" />
@@ -1336,7 +1336,7 @@
         <pathelement location="${test.classes}" />
         <pathelement location="${build.dir}/${ant.project.name}-clientutil-${version}.jar" />
         <pathelement location="${build.dir}/${ant.project.name}-thrift-${version}.jar" />
-        <pathelement location="${build.lib}/libthrift-0.9.0.jar" />
+        <pathelement location="${build.lib}/libthrift-0.9.3-1.jar" />
         <pathelement location="${build.lib}/slf4j-api-1.7.7.jar" />
         <pathelement location="${build.lib}/log4j-over-slf4j.jar" />
         <pathelement location="${build.lib}/logback-core-1.1.3.jar" />


### PR DESCRIPTION
This fixes some CVEs that were present in previous versions of libthrift (https://issues.apache.org/jira/browse/CASSANDRA-15420).