### PR TITLE
stream rebuild for range from paired rack

### DIFF
--- a/src/java/com/palantir/cassandra/dht/SingleRackFilter.java
+++ b/src/java/com/palantir/cassandra/dht/SingleRackFilter.java
@@ -31,12 +31,18 @@ import java.util.stream.IntStream;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.palantir.cassandra.utils.LockKeyspaceUtils;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.dht.RangeStreamer;
 import org.assertj.core.util.VisibleForTesting;
 
 public class SingleRackFilter implements RangeStreamer.ISourceFilter
 {
+
+    private static final Logger log = LoggerFactory.getLogger(SingleRackFilter.class);
 
     private final Optional<String> maybeRack;
 
@@ -51,7 +57,8 @@ public class SingleRackFilter implements RangeStreamer.ISourceFilter
     }
 
     @VisibleForTesting
-    Optional<String> getMaybeRack() {
+    Optional<String> getMaybeRack()
+    {
         return maybeRack;
     }
 
@@ -69,6 +76,7 @@ public class SingleRackFilter implements RangeStreamer.ISourceFilter
                                                              .collect(Collectors.toMap(_i -> localRacksIterator.next(), _i -> sourceRacksIterator.next()));
             maybeRack = Optional.of(localToSourceRack.get(localRack));
         }
+        log.info("Mapped current rack {} from current datacenter {} to source rack {} from source datacenter {}.", localRack, localDatacenter, maybeRack, sourceDatacenter);
 
         return new SingleRackFilter(maybeRack);
     }

--- a/src/java/com/palantir/cassandra/dht/SingleRackFilter.java
+++ b/src/java/com/palantir/cassandra/dht/SingleRackFilter.java
@@ -20,10 +20,13 @@ package com.palantir.cassandra.dht;
 
 import java.net.InetAddress;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
@@ -61,15 +64,10 @@ public class SingleRackFilter implements RangeStreamer.ISourceFilter
         {
             Iterator<String> sourceRacksIterator = sourceRacks.iterator();
             Iterator<String> localRacksIterator = localRacks.iterator();
-            while (sourceRacksIterator.hasNext())
-            {
-                String sourceRack = sourceRacksIterator.next();
-                if (localRack.equals(localRacksIterator.next()))
-                {
-                    maybeRack = Optional.of(sourceRack);
-                    break;
-                }
-            }
+            Map<String, String> localToSourceRack = IntStream.range(0, localRacks.size())
+                                                             .boxed()
+                                                             .collect(Collectors.toMap(_i -> localRacksIterator.next(), _i -> sourceRacksIterator.next()));
+            maybeRack = Optional.of(localToSourceRack.get(localRack));
         }
 
         return new SingleRackFilter(maybeRack);

--- a/src/java/com/palantir/cassandra/dht/SingleRackFilter.java
+++ b/src/java/com/palantir/cassandra/dht/SingleRackFilter.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.dht;
+
+import java.net.InetAddress;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Function;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.dht.RangeStreamer;
+import org.assertj.core.util.VisibleForTesting;
+
+public class SingleRackFilter implements RangeStreamer.ISourceFilter
+{
+
+    private final Optional<String> maybeRack;
+
+    public SingleRackFilter(Optional<String> maybeRack)
+    {
+        this.maybeRack = maybeRack;
+    }
+
+    public boolean shouldInclude(InetAddress endpoint)
+    {
+        return maybeRack.map(rack -> rack.equals(DatabaseDescriptor.getEndpointSnitch().getRack(endpoint))).orElse(true);
+    }
+
+    @VisibleForTesting
+    Optional<String> getMaybeRack() {
+        return maybeRack;
+    }
+
+    public static SingleRackFilter create(SetMultimap<String, String> datacenterRacks, String sourceDatacenter, String localDatacenter, String localRack)
+    {
+        Set<String> localRacks = new TreeSet<>(datacenterRacks.get(localDatacenter));
+        Set<String> sourceRacks = new TreeSet<>(datacenterRacks.get(sourceDatacenter));
+        Optional<String> maybeRack = Optional.empty();
+        if (localRacks.size() == sourceRacks.size())
+        {
+            Iterator<String> sourceRacksIterator = sourceRacks.iterator();
+            Iterator<String> localRacksIterator = localRacks.iterator();
+            while (sourceRacksIterator.hasNext())
+            {
+                String sourceRack = sourceRacksIterator.next();
+                if (localRack.equals(localRacksIterator.next()))
+                {
+                    maybeRack = Optional.of(sourceRack);
+                    break;
+                }
+            }
+        }
+
+        return new SingleRackFilter(maybeRack);
+    }
+}

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1313,6 +1313,12 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         if (sourceDc != null)
         {
             streamer.addSourceFilter(new RangeStreamer.SingleDatacenterFilter(DatabaseDescriptor.getEndpointSnitch(), sourceDc));
+            /**
+             * Given RF 3, with 3 abritrary racks, this will result in a fully consistent rebuild.
+             * This is due to the simple fact that, our topology will be mirrored identically across datacenters.
+             * As a result, the only way for our destination datacenter to have inconsistent data, is for our
+             * source datacenter to have inconsistent data.
+             */
             HashMultimap<String, String> topology = HashMultimap.create();
             Gossiper.instance.getEndpointStates().stream()
                              .map(Entry::getKey)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1326,7 +1326,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                                                               DatabaseDescriptor.getEndpointSnitch().getRack(address)));
             String localDc = DatabaseDescriptor.getEndpointSnitch().getDatacenter(FBUtilities.getBroadcastAddress());
             String localRack = DatabaseDescriptor.getEndpointSnitch().getRack(FBUtilities.getBroadcastAddress());
-            streamer.addSourceFilter(SingleRackFilter.create(topology, sourceDc, localDc, localRack));
+            AbstractReplicationStrategy replicationStrategy = Keyspace.open(keyspace).getReplicationStrategy();
+            streamer.addSourceFilter(SingleRackFilter.create(topology, sourceDc, localDc, localRack, replicationStrategy));
         }
 
         if (keyspace == null)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1313,21 +1313,23 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         if (sourceDc != null)
         {
             streamer.addSourceFilter(new RangeStreamer.SingleDatacenterFilter(DatabaseDescriptor.getEndpointSnitch(), sourceDc));
-            /**
-             * Given RF 3, with 3 abritrary racks, this will result in a fully consistent rebuild.
-             * This is due to the simple fact that, our topology will be mirrored identically across datacenters.
-             * As a result, the only way for our destination datacenter to have inconsistent data, is for our
-             * source datacenter to have inconsistent data.
-             */
-            HashMultimap<String, String> topology = HashMultimap.create();
-            Gossiper.instance.getEndpointStates().stream()
-                             .map(Entry::getKey)
-                             .forEach(address -> topology.put(DatabaseDescriptor.getEndpointSnitch().getDatacenter(address),
-                                                              DatabaseDescriptor.getEndpointSnitch().getRack(address)));
-            String localDc = DatabaseDescriptor.getEndpointSnitch().getDatacenter(FBUtilities.getBroadcastAddress());
-            String localRack = DatabaseDescriptor.getEndpointSnitch().getRack(FBUtilities.getBroadcastAddress());
-            AbstractReplicationStrategy replicationStrategy = Keyspace.open(keyspace).getReplicationStrategy();
-            streamer.addSourceFilter(SingleRackFilter.create(topology, sourceDc, localDc, localRack, replicationStrategy));
+            if (keyspace != null) {
+                /**
+                 * Given RF 3, with 3 abritrary racks, this will result in a fully consistent rebuild.
+                 * This is due to the simple fact that, our topology will be mirrored identically across datacenters.
+                 * As a result, the only way for our destination datacenter to have inconsistent data, is for our
+                 * source datacenter to have inconsistent data.
+                 */
+                HashMultimap<String, String> topology = HashMultimap.create();
+                Gossiper.instance.getEndpointStates().stream()
+                                 .map(Entry::getKey)
+                                 .forEach(address -> topology.put(DatabaseDescriptor.getEndpointSnitch().getDatacenter(address),
+                                                                  DatabaseDescriptor.getEndpointSnitch().getRack(address)));
+                String localDc = DatabaseDescriptor.getEndpointSnitch().getDatacenter(FBUtilities.getBroadcastAddress());
+                String localRack = DatabaseDescriptor.getEndpointSnitch().getRack(FBUtilities.getBroadcastAddress());
+                AbstractReplicationStrategy replicationStrategy = Keyspace.open(keyspace).getReplicationStrategy();
+                streamer.addSourceFilter(SingleRackFilter.create(topology, sourceDc, localDc, localRack, replicationStrategy));
+            }
         }
 
         if (keyspace == null)

--- a/test/unit/com/palantir/cassandra/dht/SingleRackFilterTest.java
+++ b/test/unit/com/palantir/cassandra/dht/SingleRackFilterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.dht;
+
+import com.google.common.collect.HashMultimap;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SingleRackFilterTest
+{
+
+    private static final String SOURCE_DC = "dc1";
+    private static final String LOCAL_DC = "dc2";
+
+    @Test
+    public void create_sortsRacksLexographically()
+    {
+        HashMultimap<String, String> topology = HashMultimap.create();
+        topology.put(SOURCE_DC, "c");
+        topology.put(SOURCE_DC, "a");
+        topology.put(SOURCE_DC, "b");
+        topology.put(LOCAL_DC, "f");
+        topology.put(LOCAL_DC, "d");
+        topology.put(LOCAL_DC, "e");
+
+        assertThat(SingleRackFilter.create(topology, "dc1", "dc2", "d").getMaybeRack()).isNotEmpty().contains("a");
+    }
+
+    @Test
+    public void create_rackEmptyWhenMismatchedTopologies()
+    {
+        HashMultimap<String, String> topology = HashMultimap.create();
+        topology.put(SOURCE_DC, "c");
+        topology.put(SOURCE_DC, "a");
+        topology.put(SOURCE_DC, "b");
+        topology.put(LOCAL_DC, "f");
+
+        assertThat(SingleRackFilter.create(topology, "dc1", "dc2", "f").getMaybeRack()).isEmpty();
+    }
+}


### PR DESCRIPTION
Currently, rebuilds are not strictly consistent, as the "closest" rack in the neighboring datacenter is used for streaming, which is more/less arbitrary. 

To resolve, we deterministically map racks across datacenters if their topologies match, and then stream only from replicas from that datacenter/rack. 

To deterministically map, we simply lexicographically sort the racks within each datacenter, and the map them directly by their ordinal index. 

I.e.:
DC1 [A,B,C] - DC2 [F,E,D]

Would map to:
DC1 A -> DC2 D
DC1 B -> DC2 E
DC1 C -> DC2 F