### PR TITLE
Expose migration mode endpoint

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4964,6 +4964,12 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
     }
 
+    @Override
+    public boolean isMigrating()
+    {
+        return Boolean.getBoolean("palantir_cassandra.migration_mode");
+    }
+
     public boolean isNodeDisabled() {
         return instance.areAllTransportsStopped() && isAutoCompactionDisabled();
     }

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -833,4 +833,6 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
      * Sets the persistent setting that disables client interfaces, and stops the Native Transport and Thrift servers.
      */
     public void persistentDisableClientInterfaces();
+
+    public boolean isMigrating();
 }


### PR DESCRIPTION
So health/readiness checks can account for migrations