### PR TITLE
Add hiccup meter

### DIFF
--- a/src/java/org/apache/cassandra/metrics/HiccupMeter.java
+++ b/src/java/org/apache/cassandra/metrics/HiccupMeter.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import com.codahale.metrics.Timer;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.time.Duration;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A meter for counting server hiccups; periods where a trivial thread cannot get scheduled (implying that application
+ * threads also cannot get scheduled). This is adapted from https://github.com/clojure-goes-fast/jvm-hiccup-meter.
+ * <p>
+ * Overhead is very low (per second, should represent significantly less CPU time than a single request).
+ * <p>
+ * It is anticipated that at a high enough resolution, this information can be used both as telemetry, and also to
+ * advise QoS systems as to whether the system is under stress.
+ */
+public final class HiccupMeter {
+    private static final Logger log = LoggerFactory.getLogger(HiccupMeter.class);
+    private static final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+    .setNameFormat("hiccup-meter-%d")
+    .setDaemon(true)
+    .build();
+
+    private final HiccupMeterTask task;
+
+    public HiccupMeter() {
+        this.task = new HiccupMeterTask(JvmMetrics.hiccups);
+    }
+
+    public void start() {
+        threadFactory.newThread(task).start();
+    }
+
+    private static final class HiccupMeterTask implements Runnable {
+        private final Timer results;
+        private final long resolution;
+
+        private HiccupMeterTask(Timer results) {
+            this(results, Duration.ofMillis(10));
+        }
+
+        private HiccupMeterTask(Timer results, Duration resolution) {
+            this.results = results;
+            this.resolution = resolution.toNanos();
+        }
+
+        @Override
+        public void run() {
+            try {
+                long shortestObservedDelta = Long.MAX_VALUE;
+                long timeBeforeMeasurement = Long.MAX_VALUE;
+                while (true) {
+                    TimeUnit.NANOSECONDS.sleep(resolution);
+                    long timeAfterMeasurement = System.nanoTime();
+                    long delta = timeAfterMeasurement - timeBeforeMeasurement;
+                    timeBeforeMeasurement = timeAfterMeasurement;
+
+                    boolean notOnFirstIteration = delta > 0;
+                    if (notOnFirstIteration) {
+                        shortestObservedDelta = Math.min(delta, shortestObservedDelta);
+                        long hiccup = delta - shortestObservedDelta;
+                        results.update(hiccup, TimeUnit.NANOSECONDS);
+                    }
+                }
+            } catch (InterruptedException e) {
+                log.info("Shutting down HiccupMeter thread due to interruption", e);
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/JvmMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/JvmMetrics.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import com.codahale.metrics.Timer;
+
+import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
+
+public class JvmMetrics
+{
+    private static final MetricNameFactory factory = new DefaultNameFactory("JVM");
+
+    public static final Timer hiccups = Metrics.timer(factory.createMetricName("jvm.threads.hiccup"));
+
+    private JvmMetrics()
+    {
+    }
+}

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -76,6 +76,7 @@ import org.apache.cassandra.exceptions.StartupException;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.DefaultNameFactory;
+import org.apache.cassandra.metrics.HiccupMeter;
 import org.apache.cassandra.service.StorageServiceMBean.NonTransientError;
 import org.apache.cassandra.thrift.ThriftServer;
 import org.apache.cassandra.utils.*;
@@ -380,6 +381,7 @@ public class CassandraDaemon
                 logger.warn("Failed to load metrics-reporter-config, metric sinks will not be activated", e);
             }
         }
+        new HiccupMeter().start();
 
         if (!FBUtilities.getBroadcastAddress().equals(InetAddress.getLoopbackAddress()))
             waitForGossipToSettle();

--- a/test/unit/org/apache/cassandra/metrics/HiccupMeterTest.java
+++ b/test/unit/org/apache/cassandra/metrics/HiccupMeterTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.Timer;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public final class HiccupMeterTest {
+
+    @Test
+    public void testHiccupMeter() throws InterruptedException {
+        HiccupMeter hiccupMeter = new HiccupMeter();
+        Timer timer = JvmMetrics.hiccups;
+        hiccupMeter.start();
+        TimeUnit.SECONDS.sleep(1);
+        assertThat(timer.getCount()).isGreaterThan(90);
+        assertThat(timer.getSnapshot().get75thPercentile())
+        .isGreaterThan(0)
+        .isLessThan(TimeUnit.MILLISECONDS.toNanos(10));
+    }
+}


### PR DESCRIPTION
Copied from our internal implementation.  Provides a metric that informs us how long threads are waiting before running.