### PR TITLE
Cross-VPC handshake all nodes

### DIFF
--- a/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
+++ b/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
@@ -173,7 +173,7 @@ public class CrossVpcIpMappingHandshaker
         return Optional.ofNullable(ipHostnameMappings.get(ip));
     }
 
-    public void triggerHandshakeWithSeeds()
+    public void triggerHandshakeWithAllNodes()
     {
         if (!DatabaseDescriptor.isCrossVpcInternodeCommunicationEnabled()) {
             return;
@@ -184,14 +184,13 @@ public class CrossVpcIpMappingHandshaker
                 logger.trace("Ignoring handshake request as last handshake is too recent");
                 return;
             }
-            // seeds should be provided via config by hostname with our setup. Could probably get fancier with deciding
-            // who we currently are going to handshake with like the Gossiper does
-            Set<InetAddress> seeds = DatabaseDescriptor.getSeeds()
+            // nodes should be provided via config by hostname with our setup
+            Set<InetAddress> allNodes = DatabaseDescriptor.getAllHosts()
                                                        .stream()
-                                                       .filter(seed -> !seed.equals(FBUtilities.getBroadcastAddress()))
+                                                       .filter(host -> !host.equals(FBUtilities.getBroadcastAddress()))
                                                        .collect(Collectors.toSet());
 
-            triggerHandshakeFromSelf(seeds);
+            triggerHandshakeFromSelf(allNodes);
         }
         catch (Exception e)
         {
@@ -254,7 +253,7 @@ public class CrossVpcIpMappingHandshaker
         scheduledCVIMTask = executor.scheduleWithFixedDelay(() -> {
             try
             {
-                triggerHandshakeWithSeeds();
+                triggerHandshakeWithAllNodes();
             }
             catch (Exception e)
             {

--- a/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
+++ b/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
@@ -173,7 +173,7 @@ public class CrossVpcIpMappingHandshaker
         return Optional.ofNullable(ipHostnameMappings.get(ip));
     }
 
-    public void triggerHandshakeWithAllNodes()
+    public void triggerHandshakeWithAllPeers()
     {
         if (!DatabaseDescriptor.isCrossVpcInternodeCommunicationEnabled()) {
             return;
@@ -184,13 +184,13 @@ public class CrossVpcIpMappingHandshaker
                 logger.trace("Ignoring handshake request as last handshake is too recent");
                 return;
             }
-            // nodes should be provided via config by hostname with our setup
-            Set<InetAddress> allNodes = DatabaseDescriptor.getAllHosts()
+            // peers should be provided via config by hostname with our setup
+            Set<InetAddress> allPeers = DatabaseDescriptor.getAllHosts()
                                                        .stream()
                                                        .filter(host -> !host.equals(FBUtilities.getBroadcastAddress()))
                                                        .collect(Collectors.toSet());
 
-            triggerHandshakeFromSelf(allNodes);
+            triggerHandshakeFromSelf(allPeers);
         }
         catch (Exception e)
         {
@@ -253,7 +253,7 @@ public class CrossVpcIpMappingHandshaker
         scheduledCVIMTask = executor.scheduleWithFixedDelay(() -> {
             try
             {
-                triggerHandshakeWithAllNodes();
+                triggerHandshakeWithAllPeers();
             }
             catch (Exception e)
             {

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.base.Supplier;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import org.slf4j.Logger;
@@ -136,6 +137,8 @@ public class Config
     public Boolean cross_vpc_sni_substitution_enabled = false;
     // Max amount of time a socket will attempt to connect to remote before terminating
     public Long cross_vpc_connect_timeout_in_ms = 3000L;
+    // All cassandra hosts. Should be supplied by hostname for Cross VPC mapping to succeed.
+    public Set<String> all_hosts = ImmutableSet.of();
 
     /* intentionally left set to true, despite being set to false in stock 2.2 cassandra.yaml
        we don't want to surprise Thrift users who have the setting blank in the yaml during 2.1->2.2 upgrade */

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.base.Supplier;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import org.slf4j.Logger;
@@ -137,8 +136,6 @@ public class Config
     public Boolean cross_vpc_sni_substitution_enabled = false;
     // Max amount of time a socket will attempt to connect to remote before terminating
     public Long cross_vpc_connect_timeout_in_ms = 3000L;
-    // All cassandra hosts. Should be supplied by hostname for Cross VPC mapping to succeed.
-    public Set<String> all_hosts = ImmutableSet.of();
 
     /* intentionally left set to true, despite being set to false in stock 2.2 cassandra.yaml
        we don't want to surprise Thrift users who have the setting blank in the yaml during 2.1->2.2 upgrade */

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1311,6 +1311,25 @@ public class DatabaseDescriptor
         return ImmutableSet.<InetAddress>builder().addAll(seedProvider.getSeeds()).build();
     }
 
+    public static Set<InetAddress> getAllHosts()
+    {
+        ImmutableSet.Builder<InetAddress> builder = ImmutableSet.<InetAddress>builder();
+        for (String hostname : conf.all_hosts)
+        {
+            try
+            {
+                builder.add(InetAddress.getByName(hostname));
+            }
+            catch (UnknownHostException ex)
+            {
+                logger.warn(
+                        "Could not find host {}, presumably because that pod/host isn't online or DNS is not working",
+                        hostname, ex);
+            }
+        }
+        return builder.build();
+    }
+
     public static InetAddress getListenAddress()
     {
         return listenAddress;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1313,12 +1314,15 @@ public class DatabaseDescriptor
 
     public static Set<InetAddress> getAllHosts()
     {
-        if (conf.all_hosts.isEmpty()) {
+        String allHostsRaw = System.getProperty("palantir_cassandra.all_hosts", "");
+        if (StringUtils.isBlank(allHostsRaw)) {
             logger.warn("all_hosts config was empty. Defaulting to providing only seeds");
             return getSeeds();
         }
-        ImmutableSet.Builder<InetAddress> builder = ImmutableSet.<InetAddress>builder();
-        for (String hostname : conf.all_hosts)
+        String[] allHosts = allHostsRaw.split(",", -1);
+
+        ImmutableSet.Builder<InetAddress> builder = ImmutableSet.builder();
+        for (String hostname : allHosts)
         {
             try
             {

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -105,6 +105,8 @@ public class DatabaseDescriptor
     private static Comparator<InetAddress> localComparator;
     private static boolean hasLoggedConfig;
 
+    private static final String allHostsRaw = System.getProperty("palantir_cassandra.all_hosts", "");
+
     private static boolean daemonInitialized;
 
     public static boolean isDaemonInitialized()
@@ -1314,7 +1316,6 @@ public class DatabaseDescriptor
 
     public static Set<InetAddress> getAllHosts()
     {
-        String allHostsRaw = System.getProperty("palantir_cassandra.all_hosts", "");
         if (StringUtils.isBlank(allHostsRaw)) {
             logger.warn("all_hosts config was empty. Defaulting to providing only seeds");
             return getSeeds();

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1313,11 +1313,11 @@ public class DatabaseDescriptor
 
     public static Set<InetAddress> getAllHosts()
     {
-        ImmutableSet.Builder<InetAddress> builder = ImmutableSet.<InetAddress>builder();
         if (conf.all_hosts.isEmpty()) {
             logger.warn("all_hosts config was empty. Defaulting to providing only seeds");
             return getSeeds();
         }
+        ImmutableSet.Builder<InetAddress> builder = ImmutableSet.<InetAddress>builder();
         for (String hostname : conf.all_hosts)
         {
             try

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1314,6 +1314,10 @@ public class DatabaseDescriptor
     public static Set<InetAddress> getAllHosts()
     {
         ImmutableSet.Builder<InetAddress> builder = ImmutableSet.<InetAddress>builder();
+        if (conf.all_hosts.isEmpty()) {
+            logger.warn("all_hosts config was empty. Defaulting to providing only seeds");
+            return getSeeds();
+        }
         for (String hostname : conf.all_hosts)
         {
             try

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -1333,7 +1333,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
      */
     public synchronized Map<InetAddress, EndpointState> doShadowRound()
     {
-        CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithAllNodes();
+        CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithAllPeers();
         buildSeedsList();
         // it may be that the local address is the only entry in the seed
         // list in which case, attempting a shadow round is pointless

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -1333,7 +1333,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
      */
     public synchronized Map<InetAddress, EndpointState> doShadowRound()
     {
-        CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithSeeds();
+        CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithAllNodes();
         buildSeedsList();
         // it may be that the local address is the only entry in the seed
         // list in which case, attempting a shadow round is pointless

--- a/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshakerTest.java
+++ b/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshakerTest.java
@@ -235,10 +235,10 @@ public class CrossVpcIpMappingHandshakerTest
     {
         DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
         long first = System.currentTimeMillis();
-        CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithSeeds();
+        CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithAllNodes();
         Thread.sleep(1);
         long second = System.currentTimeMillis();
-        CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithSeeds();
+        CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithAllNodes();
         assertThat(CrossVpcIpMappingHandshaker.instance.getLastTriggeredHandshakeMillis()).isGreaterThan(first);
         assertThat(CrossVpcIpMappingHandshaker.instance.getLastTriggeredHandshakeMillis()).isLessThan(second);
     }

--- a/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshakerTest.java
+++ b/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshakerTest.java
@@ -43,6 +43,7 @@ public class CrossVpcIpMappingHandshakerTest
         CrossVpcIpMappingHandshaker.instance.stop();
         CrossVpcIpMappingHandshaker.instance.clearMappings();
         CrossVpcIpMappingHandshaker.instance.setLastTriggeredHandshakeMillis(0);
+        System.setProperty("palantir_cassandra.all_hosts", "localhost,");
     }
 
     @Test
@@ -236,7 +237,7 @@ public class CrossVpcIpMappingHandshakerTest
         DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
         long first = System.currentTimeMillis();
         CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithAllNodes();
-        Thread.sleep(1);
+        Thread.sleep(2);
         long second = System.currentTimeMillis();
         CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithAllNodes();
         assertThat(CrossVpcIpMappingHandshaker.instance.getLastTriggeredHandshakeMillis()).isGreaterThan(first);

--- a/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshakerTest.java
+++ b/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshakerTest.java
@@ -43,7 +43,6 @@ public class CrossVpcIpMappingHandshakerTest
         CrossVpcIpMappingHandshaker.instance.stop();
         CrossVpcIpMappingHandshaker.instance.clearMappings();
         CrossVpcIpMappingHandshaker.instance.setLastTriggeredHandshakeMillis(0);
-        System.setProperty("palantir_cassandra.all_hosts", "localhost,");
     }
 
     @Test
@@ -236,10 +235,10 @@ public class CrossVpcIpMappingHandshakerTest
     {
         DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
         long first = System.currentTimeMillis();
-        CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithAllNodes();
+        CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithAllPeers();
         Thread.sleep(1);
         long second = System.currentTimeMillis();
-        CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithAllNodes();
+        CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithAllPeers();
         assertThat(CrossVpcIpMappingHandshaker.instance.getLastTriggeredHandshakeMillis()).isGreaterThanOrEqualTo(first);
         assertThat(CrossVpcIpMappingHandshaker.instance.getLastTriggeredHandshakeMillis()).isLessThan(second);
     }

--- a/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshakerTest.java
+++ b/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshakerTest.java
@@ -237,10 +237,10 @@ public class CrossVpcIpMappingHandshakerTest
         DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
         long first = System.currentTimeMillis();
         CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithAllNodes();
-        Thread.sleep(2);
+        Thread.sleep(1);
         long second = System.currentTimeMillis();
         CrossVpcIpMappingHandshaker.instance.triggerHandshakeWithAllNodes();
-        assertThat(CrossVpcIpMappingHandshaker.instance.getLastTriggeredHandshakeMillis()).isGreaterThan(first);
+        assertThat(CrossVpcIpMappingHandshaker.instance.getLastTriggeredHandshakeMillis()).isGreaterThanOrEqualTo(first);
         assertThat(CrossVpcIpMappingHandshaker.instance.getLastTriggeredHandshakeMillis()).isLessThan(second);
     }
 


### PR DESCRIPTION
Only handshaking seeds is problematic when we have more than 3 nodes in a DC, so we want to separately provide all hostnames and handshake each one of them.