### PR TITLE
If node bootstraps to join the cluster, truncate all old data before it does

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1449,6 +1449,17 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         {
             logger.info("Resetting bootstrap progress to start fresh");
             SystemKeyspace.resetAvailableRanges();
+
+            logger.info("Truncating all keyspaces/CFs before joining");
+            for (String keyspaceName : Schema.instance.getNonSystemKeyspaces())
+            {
+                Keyspace keyspace = Keyspace.open(keyspaceName);
+                for (ColumnFamilyStore store : keyspace.getColumnFamilyStores())
+                {
+                    logger.info("Truncating {}.{}", keyspaceName, store.name);
+                    store.truncateBlocking(false);
+                }
+            }
         }
 
         setMode(Mode.JOINING, "Starting to bootstrap...", true);


### PR DESCRIPTION
If node bootstraps to join the cluster, truncate all old data before it does. 

I think this is relatively safe to do, seeing as if a node that already has tons of data attempts to join the cluster, it will cause corruption (thus effectively data loss). 