### PR TITLE
Lock tokens when removing endpoints to prevent race condition

### DIFF
--- a/src/java/org/apache/cassandra/locator/TokenMetadata.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadata.java
@@ -141,6 +141,7 @@ public class TokenMetadata
     {
         int n = 0;
         Collection<Range<Token>> sourceRanges = getPrimaryRangesFor(getTokens(source));
+        publicLock.readLock().lock();
         lock.readLock().lock();
         try
         {
@@ -152,6 +153,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
         return n;
     }
@@ -232,8 +234,8 @@ public class TokenMetadata
         assert hostId != null;
         assert endpoint != null;
 
-        lock.writeLock().lock();
         publicLock.readLock().lock();
+        lock.writeLock().lock();
         try
         {
             InetAddress storedEp = endpointToHostIdMap.inverse().get(hostId);
@@ -265,8 +267,8 @@ public class TokenMetadata
     /** Return the unique host ID for an end-point. */
     public UUID getHostId(InetAddress endpoint)
     {
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             return endpointToHostIdMap.get(endpoint);
@@ -281,8 +283,8 @@ public class TokenMetadata
     /** Return the end-point for a unique host ID */
     public InetAddress getEndpointForHostId(UUID hostId)
     {
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             return endpointToHostIdMap.inverse().get(hostId);
@@ -297,8 +299,8 @@ public class TokenMetadata
     /** @return a copy of the endpoint-to-id map for read-only operations */
     public Map<InetAddress, UUID> getEndpointToHostIdMapForReading()
     {
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             Map<InetAddress, UUID> readMap = new HashMap<>();
@@ -328,8 +330,8 @@ public class TokenMetadata
         assert tokens != null && !tokens.isEmpty();
         assert endpoint != null;
 
-        lock.writeLock().lock();
         publicLock.readLock().lock();
+        lock.writeLock().lock();
         try
         {
             InetAddress oldEndpoint;
@@ -362,8 +364,8 @@ public class TokenMetadata
         assert replacingTokens != null && !replacingTokens.isEmpty();
         assert newNode != null && oldNode != null;
 
-        lock.writeLock().lock();
         publicLock.readLock().lock();
+        lock.writeLock().lock();
         try
         {
             Collection<Token> oldNodeTokens = tokenToEndpointMap.inverse().get(oldNode);
@@ -400,8 +402,8 @@ public class TokenMetadata
     {
         assert tokens != null && !tokens.isEmpty();
 
-        lock.writeLock().lock();
         publicLock.readLock().lock();
+        lock.writeLock().lock();
         try
         {
             for (Token token : tokens)
@@ -418,8 +420,8 @@ public class TokenMetadata
     {
         assert endpoint != null;
 
-        lock.writeLock().lock();
         publicLock.readLock().lock();
+        lock.writeLock().lock();
         try
         {
             leavingEndpoints.add(endpoint);
@@ -440,8 +442,8 @@ public class TokenMetadata
     {
         assert endpoint != null;
 
-        lock.writeLock().lock();
         publicLock.readLock().lock();
+        lock.writeLock().lock();
 
         try
         {
@@ -458,8 +460,9 @@ public class TokenMetadata
     {
         assert endpoint != null;
 
-        lock.writeLock().lock();
         publicLock.readLock().lock();
+        lock.writeLock().lock();
+
         try
         {
             bootstrapTokens.removeValue(endpoint);
@@ -488,8 +491,9 @@ public class TokenMetadata
     {
         assert endpoint != null;
 
-        lock.writeLock().lock();
         publicLock.readLock().lock();
+        lock.writeLock().lock();
+
         try
         {
             logger.info("Updating topology for {}", endpoint);
@@ -509,8 +513,8 @@ public class TokenMetadata
      */
     public void updateTopology()
     {
-        lock.writeLock().lock();
         publicLock.readLock().lock();
+        lock.writeLock().lock();
         try
         {
             logger.info("Updating topology for all endpoints that have changed");
@@ -532,8 +536,8 @@ public class TokenMetadata
     {
         assert endpoint != null;
 
-        lock.writeLock().lock();
         publicLock.readLock().lock();
+        lock.writeLock().lock();
         try
         {
             for (Pair<Token, InetAddress> pair : movingEndpoints)
@@ -559,8 +563,8 @@ public class TokenMetadata
         assert endpoint != null;
         assert isMember(endpoint); // don't want to return nulls
 
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             return new ArrayList<>(tokenToEndpointMap.inverse().get(endpoint));
@@ -582,8 +586,8 @@ public class TokenMetadata
     {
         assert endpoint != null;
 
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             return tokenToEndpointMap.inverse().containsKey(endpoint);
@@ -599,8 +603,8 @@ public class TokenMetadata
     {
         assert endpoint != null;
 
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             return leavingEndpoints.contains(endpoint);
@@ -616,8 +620,8 @@ public class TokenMetadata
     {
         assert endpoint != null;
 
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
 
         try
         {
@@ -644,8 +648,8 @@ public class TokenMetadata
      */
     public TokenMetadata cloneOnlyTokenMap()
     {
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             return new TokenMetadata(SortedBiMultiValMap.create(tokenToEndpointMap, null, inetaddressCmp),
@@ -697,8 +701,8 @@ public class TokenMetadata
      */
     public TokenMetadata cloneAfterAllLeft()
     {
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             return removeEndpoints(cloneOnlyTokenMap(), leavingEndpoints);
@@ -726,7 +730,8 @@ public class TokenMetadata
      */
     public TokenMetadata cloneAfterAllSettled()
     {
-        lock.readLock().lock(); publicLock.readLock().lock();
+        publicLock.readLock().lock();
+        lock.readLock().lock();
 
         try
         {
@@ -750,8 +755,8 @@ public class TokenMetadata
 
     public InetAddress getEndpoint(Token token)
     {
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             return tokenToEndpointMap.get(token);
@@ -869,8 +874,8 @@ public class TokenMetadata
                 Set<Pair<Token, InetAddress>> movingEndpoints = new HashSet<>();
                 TokenMetadata metadata;
 
-                lock.readLock().lock();
                 publicLock.readLock().lock();
+                lock.readLock().lock();
                 try
                 {
                     bootstrapTokens.putAll(this.bootstrapTokens);
@@ -1017,8 +1022,8 @@ public class TokenMetadata
     /** @return a copy of the bootstrapping tokens map */
     public BiMultiValMap<Token, InetAddress> getBootstrapTokens()
     {
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             return new BiMultiValMap<Token, InetAddress>(bootstrapTokens);
@@ -1032,8 +1037,8 @@ public class TokenMetadata
 
     public Set<InetAddress> getAllEndpoints()
     {
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             return ImmutableSet.copyOf(endpointToHostIdMap.keySet());
@@ -1048,8 +1053,8 @@ public class TokenMetadata
     /** caller should not modify leavingEndpoints */
     public Set<InetAddress> getLeavingEndpoints()
     {
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             return ImmutableSet.copyOf(leavingEndpoints);
@@ -1067,8 +1072,8 @@ public class TokenMetadata
      */
     public Set<Pair<Token, InetAddress>> getMovingEndpoints()
     {
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             return ImmutableSet.copyOf(movingEndpoints);
@@ -1143,8 +1148,8 @@ public class TokenMetadata
     /** used by tests */
     public void clearUnsafe()
     {
-        lock.writeLock().lock();
         publicLock.readLock().lock();
+        lock.writeLock().lock();
         try
         {
             tokenToEndpointMap.clear();
@@ -1167,8 +1172,8 @@ public class TokenMetadata
     public String toString()
     {
         StringBuilder sb = new StringBuilder();
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             Set<InetAddress> eps = tokenToEndpointMap.inverse().keySet();
@@ -1256,8 +1261,8 @@ public class TokenMetadata
     /** @return an endpoint to token multimap representation of tokenToEndpointMap (a copy) */
     public Multimap<InetAddress, Token> getEndpointToTokenMapForReading()
     {
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             Multimap<InetAddress, Token> cloned = HashMultimap.create();
@@ -1278,8 +1283,8 @@ public class TokenMetadata
      */
     public Map<Token, InetAddress> getNormalAndBootstrappingTokenToEndpointMap()
     {
-        lock.readLock().lock();
         publicLock.readLock().lock();
+        lock.readLock().lock();
         try
         {
             Map<Token, InetAddress> map = new HashMap<>(tokenToEndpointMap.size() + bootstrapTokens.size());

--- a/src/java/org/apache/cassandra/locator/TokenMetadata.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadata.java
@@ -92,6 +92,7 @@ public class TokenMetadata
 
     /* Use this lock for manipulating the token map */
     private final ReadWriteLock lock = new ReentrantReadWriteLock(true);
+    private final ReadWriteLock publicLock = new ReentrantReadWriteLock(true);
     private volatile ArrayList<Token> sortedTokens;
 
     private final Topology topology;
@@ -125,6 +126,14 @@ public class TokenMetadata
     private ArrayList<Token> sortTokens()
     {
         return new ArrayList<>(tokenToEndpointMap.keySet());
+    }
+
+    public void lock() {
+        publicLock.writeLock().lock();
+    }
+
+    public void unlock() {
+        publicLock.writeLock().unlock();
     }
 
     /** @return the number of nodes bootstrapping into source's primary range */
@@ -174,6 +183,7 @@ public class TokenMetadata
         if (endpointTokens.isEmpty())
             return;
 
+        publicLock.readLock().lock();
         lock.writeLock().lock();
         try
         {
@@ -209,6 +219,7 @@ public class TokenMetadata
         finally
         {
             lock.writeLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -222,6 +233,7 @@ public class TokenMetadata
         assert endpoint != null;
 
         lock.writeLock().lock();
+        publicLock.readLock().lock();
         try
         {
             InetAddress storedEp = endpointToHostIdMap.inverse().get(hostId);
@@ -245,6 +257,7 @@ public class TokenMetadata
         finally
         {
             lock.writeLock().unlock();
+            publicLock.readLock().unlock();
         }
 
     }
@@ -253,6 +266,7 @@ public class TokenMetadata
     public UUID getHostId(InetAddress endpoint)
     {
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             return endpointToHostIdMap.get(endpoint);
@@ -260,6 +274,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -267,6 +282,7 @@ public class TokenMetadata
     public InetAddress getEndpointForHostId(UUID hostId)
     {
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             return endpointToHostIdMap.inverse().get(hostId);
@@ -274,6 +290,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -281,6 +298,7 @@ public class TokenMetadata
     public Map<InetAddress, UUID> getEndpointToHostIdMapForReading()
     {
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             Map<InetAddress, UUID> readMap = new HashMap<>();
@@ -290,6 +308,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -310,6 +329,7 @@ public class TokenMetadata
         assert endpoint != null;
 
         lock.writeLock().lock();
+        publicLock.readLock().lock();
         try
         {
             InetAddress oldEndpoint;
@@ -333,6 +353,7 @@ public class TokenMetadata
         finally
         {
             lock.writeLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -342,6 +363,7 @@ public class TokenMetadata
         assert newNode != null && oldNode != null;
 
         lock.writeLock().lock();
+        publicLock.readLock().lock();
         try
         {
             Collection<Token> oldNodeTokens = tokenToEndpointMap.inverse().get(oldNode);
@@ -360,6 +382,7 @@ public class TokenMetadata
         finally
         {
             lock.writeLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -378,6 +401,7 @@ public class TokenMetadata
         assert tokens != null && !tokens.isEmpty();
 
         lock.writeLock().lock();
+        publicLock.readLock().lock();
         try
         {
             for (Token token : tokens)
@@ -386,6 +410,7 @@ public class TokenMetadata
         finally
         {
             lock.writeLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -394,6 +419,7 @@ public class TokenMetadata
         assert endpoint != null;
 
         lock.writeLock().lock();
+        publicLock.readLock().lock();
         try
         {
             leavingEndpoints.add(endpoint);
@@ -401,6 +427,7 @@ public class TokenMetadata
         finally
         {
             lock.writeLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -414,6 +441,7 @@ public class TokenMetadata
         assert endpoint != null;
 
         lock.writeLock().lock();
+        publicLock.readLock().lock();
 
         try
         {
@@ -422,6 +450,7 @@ public class TokenMetadata
         finally
         {
             lock.writeLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -430,6 +459,7 @@ public class TokenMetadata
         assert endpoint != null;
 
         lock.writeLock().lock();
+        publicLock.readLock().lock();
         try
         {
             bootstrapTokens.removeValue(endpoint);
@@ -447,6 +477,7 @@ public class TokenMetadata
         finally
         {
             lock.writeLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -458,6 +489,7 @@ public class TokenMetadata
         assert endpoint != null;
 
         lock.writeLock().lock();
+        publicLock.readLock().lock();
         try
         {
             logger.info("Updating topology for {}", endpoint);
@@ -467,6 +499,7 @@ public class TokenMetadata
         finally
         {
             lock.writeLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -477,6 +510,7 @@ public class TokenMetadata
     public void updateTopology()
     {
         lock.writeLock().lock();
+        publicLock.readLock().lock();
         try
         {
             logger.info("Updating topology for all endpoints that have changed");
@@ -486,6 +520,7 @@ public class TokenMetadata
         finally
         {
             lock.writeLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -498,6 +533,7 @@ public class TokenMetadata
         assert endpoint != null;
 
         lock.writeLock().lock();
+        publicLock.readLock().lock();
         try
         {
             for (Pair<Token, InetAddress> pair : movingEndpoints)
@@ -514,6 +550,7 @@ public class TokenMetadata
         finally
         {
             lock.writeLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -523,6 +560,7 @@ public class TokenMetadata
         assert isMember(endpoint); // don't want to return nulls
 
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             return new ArrayList<>(tokenToEndpointMap.inverse().get(endpoint));
@@ -530,6 +568,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -544,6 +583,7 @@ public class TokenMetadata
         assert endpoint != null;
 
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             return tokenToEndpointMap.inverse().containsKey(endpoint);
@@ -551,6 +591,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -559,6 +600,7 @@ public class TokenMetadata
         assert endpoint != null;
 
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             return leavingEndpoints.contains(endpoint);
@@ -566,6 +608,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -574,6 +617,7 @@ public class TokenMetadata
         assert endpoint != null;
 
         lock.readLock().lock();
+        publicLock.readLock().lock();
 
         try
         {
@@ -588,6 +632,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -600,6 +645,7 @@ public class TokenMetadata
     public TokenMetadata cloneOnlyTokenMap()
     {
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             return new TokenMetadata(SortedBiMultiValMap.create(tokenToEndpointMap, null, inetaddressCmp),
@@ -609,6 +655,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -621,19 +668,24 @@ public class TokenMetadata
      */
     public TokenMetadata cachedOnlyTokenMap()
     {
-        TokenMetadata tm = cachedTokenMap.get();
-        if (tm != null)
-            return tm;
-
-        // synchronize to prevent thundering herd (CASSANDRA-6345)
-        synchronized (this)
-        {
-            if ((tm = cachedTokenMap.get()) != null)
+        publicLock.readLock().lock();
+        try {
+            TokenMetadata tm = cachedTokenMap.get();
+            if (tm != null)
                 return tm;
 
-            tm = cloneOnlyTokenMap();
-            cachedTokenMap.set(tm);
-            return tm;
+            // synchronize to prevent thundering herd (CASSANDRA-6345)
+            synchronized (this)
+            {
+                if ((tm = cachedTokenMap.get()) != null)
+                    return tm;
+
+                tm = cloneOnlyTokenMap();
+                cachedTokenMap.set(tm);
+                return tm;
+            }
+        } finally {
+            publicLock.readLock().unlock();
         }
     }
 
@@ -646,6 +698,7 @@ public class TokenMetadata
     public TokenMetadata cloneAfterAllLeft()
     {
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             return removeEndpoints(cloneOnlyTokenMap(), leavingEndpoints);
@@ -653,6 +706,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -672,7 +726,7 @@ public class TokenMetadata
      */
     public TokenMetadata cloneAfterAllSettled()
     {
-        lock.readLock().lock();
+        lock.readLock().lock(); publicLock.readLock().lock();
 
         try
         {
@@ -690,12 +744,14 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
     public InetAddress getEndpoint(Token token)
     {
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             return tokenToEndpointMap.get(token);
@@ -703,6 +759,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -813,6 +870,7 @@ public class TokenMetadata
                 TokenMetadata metadata;
 
                 lock.readLock().lock();
+                publicLock.readLock().lock();
                 try
                 {
                     bootstrapTokens.putAll(this.bootstrapTokens);
@@ -823,6 +881,7 @@ public class TokenMetadata
                 finally
                 {
                     lock.readLock().unlock();
+                    publicLock.readLock().unlock();
                 }
 
                 pendingRanges.put(keyspaceName, calculatePendingRanges(strategy, metadata, bootstrapTokens,
@@ -959,6 +1018,7 @@ public class TokenMetadata
     public BiMultiValMap<Token, InetAddress> getBootstrapTokens()
     {
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             return new BiMultiValMap<Token, InetAddress>(bootstrapTokens);
@@ -966,12 +1026,14 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
     public Set<InetAddress> getAllEndpoints()
     {
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             return ImmutableSet.copyOf(endpointToHostIdMap.keySet());
@@ -979,6 +1041,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -986,6 +1049,7 @@ public class TokenMetadata
     public Set<InetAddress> getLeavingEndpoints()
     {
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             return ImmutableSet.copyOf(leavingEndpoints);
@@ -993,6 +1057,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -1003,6 +1068,7 @@ public class TokenMetadata
     public Set<Pair<Token, InetAddress>> getMovingEndpoints()
     {
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             return ImmutableSet.copyOf(movingEndpoints);
@@ -1010,6 +1076,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -1077,6 +1144,7 @@ public class TokenMetadata
     public void clearUnsafe()
     {
         lock.writeLock().lock();
+        publicLock.readLock().lock();
         try
         {
             tokenToEndpointMap.clear();
@@ -1092,6 +1160,7 @@ public class TokenMetadata
         finally
         {
             lock.writeLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -1099,6 +1168,7 @@ public class TokenMetadata
     {
         StringBuilder sb = new StringBuilder();
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             Set<InetAddress> eps = tokenToEndpointMap.inverse().keySet();
@@ -1148,6 +1218,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
 
         return sb.toString();
@@ -1186,6 +1257,7 @@ public class TokenMetadata
     public Multimap<InetAddress, Token> getEndpointToTokenMapForReading()
     {
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             Multimap<InetAddress, Token> cloned = HashMultimap.create();
@@ -1196,6 +1268,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 
@@ -1206,6 +1279,7 @@ public class TokenMetadata
     public Map<Token, InetAddress> getNormalAndBootstrappingTokenToEndpointMap()
     {
         lock.readLock().lock();
+        publicLock.readLock().lock();
         try
         {
             Map<Token, InetAddress> map = new HashMap<>(tokenToEndpointMap.size() + bootstrapTokens.size());
@@ -1216,6 +1290,7 @@ public class TokenMetadata
         finally
         {
             lock.readLock().unlock();
+            publicLock.readLock().unlock();
         }
     }
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2255,7 +2255,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
      *
      * @param endpoint node
      */
-    private void handleStateNormal(final InetAddress endpoint, final String status)
+    private synchronized void handleStateNormal(final InetAddress endpoint, final String status)
     {
         Collection<Token> tokens = getTokensFor(endpoint);
         Set<Token> tokensToUpdateInMetadata = new HashSet<>();

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2296,105 +2296,117 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         // Order Matters, TM.updateHostID() should be called before TM.updateNormalToken(), (see CASSANDRA-4300).
         UUID hostId = Gossiper.instance.getHostId(endpoint);
         InetAddress existing = tokenMetadata.getEndpointForHostId(hostId);
-        if (replacing && isReplacingSameAddress() && Gossiper.instance.getEndpointStateForEndpoint(DatabaseDescriptor.getReplaceAddress()) != null
-            && (hostId.equals(Gossiper.instance.getHostId(DatabaseDescriptor.getReplaceAddress()))))
-            logger.warn("Not updating token metadata for {} because I am replacing it", endpoint);
-        else
-        {
-            if (existing != null && !existing.equals(endpoint))
+        boolean acquiredTokenLock = false;
+        try {
+            if (replacing && isReplacingSameAddress() && Gossiper.instance.getEndpointStateForEndpoint(DatabaseDescriptor.getReplaceAddress()) != null
+                && (hostId.equals(Gossiper.instance.getHostId(DatabaseDescriptor.getReplaceAddress()))))
+                logger.warn("Not updating token metadata for {} because I am replacing it", endpoint);
+            else
             {
-                if (existing.equals(FBUtilities.getBroadcastAddress()))
+                if (existing != null && !existing.equals(endpoint))
                 {
-                    logger.warn("Not updating host ID {} for {} because it's mine", hostId, endpoint);
-                    tokenMetadata.removeEndpoint(endpoint);
-                    endpointsToRemove.add(endpoint);
+                    // It's safe for us to say we acquired the lock before we've, as this is simply used for calling unlock.
+                    // Unlock will throw if a separate thread that is not holding it tries to unlock it.
+                    acquiredTokenLock = true;
+                    tokenMetadata.lock();
+                    if (existing.equals(FBUtilities.getBroadcastAddress()))
+                    {
+                        logger.warn("Not updating host ID {} for {} because it's mine", hostId, endpoint);
+                        tokenMetadata.removeEndpoint(endpoint);
+                        endpointsToRemove.add(endpoint);
+                    }
+                    else if (Gossiper.instance.compareEndpointStartup(endpoint, existing) > 0)
+                    {
+                        logger.warn("Host ID collision for {} between {} and {}; {} is the new owner", hostId, existing, endpoint, endpoint);
+                        tokenMetadata.removeEndpoint(existing);
+                        endpointsToRemove.add(existing);
+                        tokenMetadata.updateHostId(hostId, endpoint);
+                    }
+                    else
+                    {
+                        logger.warn("Host ID collision for {} between {} and {}; ignored {}", hostId, existing, endpoint, endpoint);
+                        tokenMetadata.removeEndpoint(endpoint);
+                        endpointsToRemove.add(endpoint);
+                    }
                 }
-                else if (Gossiper.instance.compareEndpointStartup(endpoint, existing) > 0)
-                {
-                    logger.warn("Host ID collision for {} between {} and {}; {} is the new owner", hostId, existing, endpoint, endpoint);
-                    tokenMetadata.removeEndpoint(existing);
-                    endpointsToRemove.add(existing);
+                else
                     tokenMetadata.updateHostId(hostId, endpoint);
+            }
+
+            for (final Token token : tokens)
+            {
+                // we don't want to update if this node is responsible for the token and it has a later startup time than endpoint.
+                InetAddress currentOwner = tokenMetadata.getEndpoint(token);
+                if (currentOwner == null)
+                {
+                    logger.debug("New node {} at token {}", endpoint, token);
+                    tokensToUpdateInMetadata.add(token);
+                    tokensToUpdateInSystemKeyspace.add(token);
+                }
+                else if (endpoint.equals(currentOwner))
+                {
+                    // set state back to normal, since the node may have tried to leave, but failed and is now back up
+                    tokensToUpdateInMetadata.add(token);
+                    tokensToUpdateInSystemKeyspace.add(token);
+                }
+                else if (Gossiper.instance.compareEndpointStartup(endpoint, currentOwner) > 0)
+                {
+                    tokensToUpdateInMetadata.add(token);
+                    tokensToUpdateInSystemKeyspace.add(token);
+
+                    // currentOwner is no longer current, endpoint is.  Keep track of these moves, because when
+                    // a host no longer has any tokens, we'll want to remove it.
+                    Multimap<InetAddress, Token> epToTokenCopy = getTokenMetadata().getEndpointToTokenMapForReading();
+                    epToTokenCopy.get(currentOwner).remove(token);
+                    if (epToTokenCopy.get(currentOwner).size() < 1)
+                        endpointsToRemove.add(currentOwner);
+
+                    logger.info(String.format("Nodes %s and %s have the same token %s.  %s is the new owner",
+                                              endpoint,
+                                              currentOwner,
+                                              token,
+                                              endpoint));
                 }
                 else
                 {
-                    logger.warn("Host ID collision for {} between {} and {}; ignored {}", hostId, existing, endpoint, endpoint);
-                    tokenMetadata.removeEndpoint(endpoint);
-                    endpointsToRemove.add(endpoint);
+                    logger.info(String.format("Nodes %s and %s have the same token %s.  Ignoring %s",
+                                              endpoint,
+                                              currentOwner,
+                                              token,
+                                              endpoint));
                 }
             }
-            else
-                tokenMetadata.updateHostId(hostId, endpoint);
-        }
 
-        for (final Token token : tokens)
+            // capture because updateNormalTokens clears moving and member status
+            boolean isMember = tokenMetadata.isMember(endpoint);
+            boolean isMoving = tokenMetadata.isMoving(endpoint);
+            tokenMetadata.updateNormalTokens(tokensToUpdateInMetadata, endpoint);
+            for (InetAddress ep : endpointsToRemove)
+            {
+                removeEndpoint(ep);
+                if (replacing && DatabaseDescriptor.getReplaceAddress().equals(ep))
+                    Gossiper.instance.replacementQuarantine(ep); // quarantine locally longer than normally; see CASSANDRA-8260
+            }
+            if (!tokensToUpdateInSystemKeyspace.isEmpty())
+                SystemKeyspace.updateTokens(endpoint, tokensToUpdateInSystemKeyspace);
+
+            if (isMoving || operationMode == Mode.MOVING)
+            {
+                tokenMetadata.removeFromMoving(endpoint);
+                notifyMoved(endpoint);
+            }
+            else if (!isMember) // prior to this, the node was not a member
+            {
+                notifyJoined(endpoint);
+            }
+
+            PendingRangeCalculatorService.instance.update();
+        } finally
         {
-            // we don't want to update if this node is responsible for the token and it has a later startup time than endpoint.
-            InetAddress currentOwner = tokenMetadata.getEndpoint(token);
-            if (currentOwner == null)
-            {
-                logger.debug("New node {} at token {}", endpoint, token);
-                tokensToUpdateInMetadata.add(token);
-                tokensToUpdateInSystemKeyspace.add(token);
-            }
-            else if (endpoint.equals(currentOwner))
-            {
-                // set state back to normal, since the node may have tried to leave, but failed and is now back up
-                tokensToUpdateInMetadata.add(token);
-                tokensToUpdateInSystemKeyspace.add(token);
-            }
-            else if (Gossiper.instance.compareEndpointStartup(endpoint, currentOwner) > 0)
-            {
-                tokensToUpdateInMetadata.add(token);
-                tokensToUpdateInSystemKeyspace.add(token);
-
-                // currentOwner is no longer current, endpoint is.  Keep track of these moves, because when
-                // a host no longer has any tokens, we'll want to remove it.
-                Multimap<InetAddress, Token> epToTokenCopy = getTokenMetadata().getEndpointToTokenMapForReading();
-                epToTokenCopy.get(currentOwner).remove(token);
-                if (epToTokenCopy.get(currentOwner).size() < 1)
-                    endpointsToRemove.add(currentOwner);
-
-                logger.info(String.format("Nodes %s and %s have the same token %s.  %s is the new owner",
-                                          endpoint,
-                                          currentOwner,
-                                          token,
-                                          endpoint));
-            }
-            else
-            {
-                logger.info(String.format("Nodes %s and %s have the same token %s.  Ignoring %s",
-                                           endpoint,
-                                           currentOwner,
-                                           token,
-                                           endpoint));
+            if (acquiredTokenLock) {
+                tokenMetadata.unlock();
             }
         }
-
-        // capture because updateNormalTokens clears moving and member status
-        boolean isMember = tokenMetadata.isMember(endpoint);
-        boolean isMoving = tokenMetadata.isMoving(endpoint);
-        tokenMetadata.updateNormalTokens(tokensToUpdateInMetadata, endpoint);
-        for (InetAddress ep : endpointsToRemove)
-        {
-            removeEndpoint(ep);
-            if (replacing && DatabaseDescriptor.getReplaceAddress().equals(ep))
-                Gossiper.instance.replacementQuarantine(ep); // quarantine locally longer than normally; see CASSANDRA-8260
-        }
-        if (!tokensToUpdateInSystemKeyspace.isEmpty())
-            SystemKeyspace.updateTokens(endpoint, tokensToUpdateInSystemKeyspace);
-
-        if (isMoving || operationMode == Mode.MOVING)
-        {
-            tokenMetadata.removeFromMoving(endpoint);
-            notifyMoved(endpoint);
-        }
-        else if (!isMember) // prior to this, the node was not a member
-        {
-            notifyJoined(endpoint);
-        }
-
-        PendingRangeCalculatorService.instance.update();
     }
 
     /**


### PR DESCRIPTION
Locks all changes to token metadata when an old endpoint is removed from the storage ring. 

Only affects clusters where nodes > RF. 

This is to prevent a race condition where: 
1- A node changes IP addresses, thus the endpoint is removed from the storage ring. 
2- A new in-bound request comes in after this, and when calculating which endpoints to contact, it chooses the next closest (via token value) node in the rack, as we deleted the previous endpoint, but did not add it's new endpoint. 
3- We re-add the _new_ endpoint to the storage ring. However, the cached token map is not invalidated at this juncture.
4- Only after the next gossip round (from a topology change) will we detect the new endpoint. At this time, we will start to read/write from the correct node. 

This change effectively makings the deletion/addition into a single atomic statement. 