### PR TITLE
Probe endpoint to inspect if sstables need cleanup

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1717,6 +1717,14 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
         return CompactionManager.instance.performCleanup(ColumnFamilyStore.this, jobs);
     }
 
+    /** Returns true if all sstables in this CF do not need to be cleaned, or false if one or more need to be cleaned
+     * or their status cannot be determined.
+     */
+    public boolean isFullyClean(int jobs) throws ExecutionException, InterruptedException
+    {
+        return CompactionManager.instance.checkIfFullyClean(ColumnFamilyStore.this, jobs);
+    }
+
     public CompactionManager.AllSSTableOpStatus scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, boolean reinsertOverflowedTTLRows, int jobs) throws ExecutionException, InterruptedException
     {
         return scrub(disableSnapshot, skipCorrupted, false, checkData, reinsertOverflowedTTLRows, jobs);

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -370,7 +370,7 @@ public class CompactionManager implements CompactionManagerMBean
                         return callable.execute(txn);
                     }
                 };
-                Future<T> fut = (ListenableFuture<T>) executor.submitIfRunning(callableGeneric, "paralell sstable callable operation");
+                Future<T> fut = (ListenableFuture<T>) executor.submitIfRunning(callableGeneric, "parallel sstable callable operation");
                 if (!fut.isCancelled())
                     futures.add(fut);
                 else

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -333,10 +333,77 @@ public class CompactionManager implements CompactionManagerMBean
         }
     }
 
+    /**
+     * Run an operation over all sstables using jobs threads
+     *
+     * @param cfs the column family store to run the operation on
+     * @param callable the callable operation to run
+     * @param jobs the number of threads to use - 0 means use all available. It never uses more than concurrent_compactors threads
+     * @return status of the operation
+     * @throws ExecutionException
+     * @throws InterruptedException
+     */
+    @SuppressWarnings("resource")
+    private <T> Optional<List<T>> parallelAllSSTableCallable(final ColumnFamilyStore cfs, final OneSSTableCallable<T> callable, int jobs, OperationType operationType) throws ExecutionException, InterruptedException
+    {
+        List<LifecycleTransaction> transactions = new ArrayList<>();
+        try (LifecycleTransaction compacting = cfs.markAllCompacting(operationType))
+        {
+            Iterable<SSTableReader> sstables = compacting != null ? Lists.newArrayList(callable.filterSSTables(compacting)) : Collections.<SSTableReader>emptyList();
+            if (Iterables.isEmpty(sstables))
+            {
+                logger.info("No sstables for {}.{}", cfs.keyspace.getName(), cfs.name);
+                return Optional.of(ImmutableList.of());
+            }
+
+            List<Future<T>> futures = new ArrayList<>();
+
+            for (final SSTableReader sstable : sstables)
+            {
+                final LifecycleTransaction txn = compacting.split(singleton(sstable));
+                transactions.add(txn);
+                Callable<T> callableGeneric = new Callable<T>()
+                {
+                    @Override
+                    public T call() throws Exception
+                    {
+                        return callable.execute(txn);
+                    }
+                };
+                Future<T> fut = (ListenableFuture<T>) executor.submitIfRunning(callableGeneric, "paralell sstable callable operation");
+                if (!fut.isCancelled())
+                    futures.add(fut);
+                else
+                    return Optional.empty();
+
+                if (jobs > 0 && futures.size() == jobs)
+                {
+                    FBUtilities.waitOnFutures(futures);
+                    futures.clear();
+                }
+            }
+            List<T> results = FBUtilities.waitOnFutures(futures);
+            assert compacting.originals().isEmpty();
+            return Optional.of(results);
+        }
+        finally
+        {
+            Throwable fail = Throwables.close(null, transactions);
+            if (fail != null)
+                logger.error("Failed to cleanup lifecycle transactions {}", fail);
+        }
+    }
+
     private static interface OneSSTableOperation
     {
         Iterable<SSTableReader> filterSSTables(LifecycleTransaction transaction);
         void execute(LifecycleTransaction input) throws IOException;
+    }
+
+    private static interface OneSSTableCallable<T>
+    {
+        Iterable<SSTableReader> filterSSTables(LifecycleTransaction transaction);
+        T execute(LifecycleTransaction input) throws IOException;
     }
 
     public enum AllSSTableOpStatus { ABORTED(1), SUCCESSFUL(0);
@@ -458,6 +525,50 @@ public class CompactionManager implements CompactionManagerMBean
                 doCleanupOne(cfStore, txn, cleanupStrategy, ranges, hasIndexes);
             }
         }, jobs, OperationType.CLEANUP);
+    }
+
+    public boolean checkIfFullyClean(final ColumnFamilyStore cfStore, int jobs) throws InterruptedException, ExecutionException
+    {
+        assert !cfStore.isIndex();
+        Keyspace keyspace = cfStore.keyspace;
+        if (!StorageService.instance.isJoined())
+        {
+            logger.info("Cleanup cannot run before a node has joined the ring");
+            return false;
+        }
+        final Collection<Range<Token>> ranges = StorageService.instance.getLocalRanges(keyspace.getName());
+        if (ranges.isEmpty())
+        {
+            logger.info("Node owns no data for keyspace {}", keyspace.getName());
+            return true;
+        }
+        final boolean hasIndexes = cfStore.indexManager.hasIndexes();
+
+        Optional<List<Boolean>> result = parallelAllSSTableCallable(cfStore, new OneSSTableCallable<Boolean>()
+        {
+            @Override
+            public Iterable<SSTableReader> filterSSTables(LifecycleTransaction transaction)
+            {
+                List<SSTableReader> sortedSSTables = Lists.newArrayList(transaction.originals());
+                Collections.sort(sortedSSTables, new SSTableReader.SizeComparator());
+                return sortedSSTables;
+            }
+
+            @Override
+            public Boolean execute(LifecycleTransaction txn) throws IOException
+            {
+                return checksIfCleanupNeededOne(txn, ranges, hasIndexes);
+            }
+        }, jobs, OperationType.CLEANUP);
+
+        if (!result.isPresent())
+        {
+            logger.warn("Could not determine if cleanup is required.");
+            return false;
+        }
+
+        // If even one sstable requires cleanup, then we consider this entire cf to require cleanup
+        return !result.get().contains(true);
     }
 
     /**
@@ -845,6 +956,23 @@ public class CompactionManager implements CompactionManagerMBean
         return false;
     }
 
+    private boolean checksIfCleanupNeededOne(LifecycleTransaction txn, Collection<Range<Token>> ranges, boolean hasIndexes)
+    {
+        SSTableReader sstable = txn.onlyOne();
+        if (!hasIndexes && !new Bounds<>(sstable.first.getToken(), sstable.last.getToken()).intersects(ranges))
+        {
+            txn.obsoleteOriginals();
+            txn.finish();
+            return false;
+        }
+        if (!needsCleanup(sstable, ranges))
+        {
+            logger.trace("Skipping {} for cleanup; all rows should be kept", sstable);
+            return false;
+        }
+        return true;
+    }
+
     /**
      * This function goes over a file and removes the keys that the node is not responsible for
      * and only keeps keys that this node is responsible for.
@@ -856,19 +984,10 @@ public class CompactionManager implements CompactionManagerMBean
     {
         assert !cfs.isIndex();
 
+        if (!checksIfCleanupNeededOne(txn, ranges, hasIndexes)) {
+            return;
+        }
         SSTableReader sstable = txn.onlyOne();
-
-        if (!hasIndexes && !new Bounds<>(sstable.first.getToken(), sstable.last.getToken()).intersects(ranges))
-        {
-            txn.obsoleteOriginals();
-            txn.finish();
-            return;
-        }
-        if (!needsCleanup(sstable, ranges))
-        {
-            logger.trace("Skipping {} for cleanup; all rows should be kept", sstable);
-            return;
-        }
 
         long start = System.nanoTime();
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2996,10 +2996,10 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public boolean isKeyspaceFullyClean(int jobs, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException
     {
         if (getJoiningNodes().size() > 0)
-            throw new RuntimeException("Cleanup operation not permitted: triggering cleanups while at least one node is bootstrapping can cause corruption");
+            throw new RuntimeException("Cannot check if a keyspace is clean while at least one node is bootstrapping.");
 
         if (keyspaceName.equals(SystemKeyspace.NAME))
-            throw new RuntimeException("Cleanup of the system keyspace is neither necessary nor wise");
+            return true; // Cleanup of a system keyspace is never required
 
         for (ColumnFamilyStore cfStore : getValidColumnFamilies(false, false, keyspaceName, columnFamilies))
         {

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2966,8 +2966,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     public int forceKeyspaceCleanup(int jobs, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException
     {
-        if (getJoiningNodes().size() > 0)
-            throw new RuntimeException("Cleanup operation not permitted: triggering cleanups while at least one node is bootstrapping can cause corruption");
+        if (getJoiningNodes().size() > 0 || getLeavingNodes().size() > 0)
+            throw new RuntimeException("Cleanup operation not permitted: triggering cleanups while at least one node is bootstrapping/leaving can cause corruption");
 
         if (keyspaceName.equals(SystemKeyspace.NAME))
             throw new RuntimeException("Cleanup of the system keyspace is neither necessary nor wise");
@@ -2995,8 +2995,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     public boolean isKeyspaceFullyClean(int jobs, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException
     {
-        if (getJoiningNodes().size() > 0)
-            throw new RuntimeException("Cannot check if a keyspace is clean while at least one node is bootstrapping.");
+        if (getJoiningNodes().size() > 0 || getLeavingNodes().size() > 0)
+            throw new RuntimeException("Cannot check if a keyspace is clean while at least one node is bootstrapping or leaving.");
 
         if (keyspaceName.equals(SystemKeyspace.NAME))
             return true; // Cleanup of a system keyspace is never required

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -336,6 +336,8 @@ public interface StorageServiceMBean extends NotificationEmitter
     public int forceKeyspaceCleanup(String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
     public int forceKeyspaceCleanup(int jobs, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
 
+    public boolean isKeyspaceFullyClean(int jobs, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
+
     /**
      * Scrub (deserialize + reserialize at the latest version, skipping bad rows if any) the given keyspace.
      * If columnFamilies array is empty, all CFs are scrubbed.

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -246,6 +246,11 @@ public class NodeProbe implements AutoCloseable
         jmxc.close();
     }
 
+    public boolean isKeyspaceFullyClean(int jobs, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException
+    {
+        return ssProxy.isKeyspaceFullyClean(jobs, keyspaceName, columnFamilies);
+    }
+
     public int forceKeyspaceCleanup(int jobs, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException
     {
         return ssProxy.forceKeyspaceCleanup(jobs, keyspaceName, columnFamilies);


### PR DESCRIPTION
We have found evidence that running a decommission while nodes require cleanup can result in data corruption, when ghost data is pulled back into a token range.

As a shortcut, the cleanup function checks if sstables need to be cleaned before performing the compaction.  This PR leverages that codepath to create a separate endpoint which _only_ performs the check.

For the sake of keeping the code paths similar, I leverage the CompactionManager abstractions and I use the compaction executor to run this check.  It should be pretty fast, and isn't on any critical path.

The intention is that any user who wishes to run a decommission should first run this check against all nodes.  We can add this check to our internal tooling.