### PR TITLE
Fix CleanupStateTrackerTest flaky test

### DIFF
--- a/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
+++ b/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
@@ -95,7 +95,7 @@ public class CleanupStateTrackerTest
     @Test
     public void recordSuccessfulCleanupForTableUpdatesEntry()
     {
-        Instant instant1 = Instant.now();
+        Instant instant1 = Instant.now().minusSeconds(30);
         KeyspaceTableOpStatePersister persister = new KeyspaceTableOpStatePersister(stateFilePath);
         KeyspaceTableOpStateCache state =
             new KeyspaceTableOpStateCache(ImmutableMap.of(OpStateTestConstants.KEYSPACE_TABLE_KEY_1, instant1));


### PR DESCRIPTION
Current theory: When the test runs too fast, Instant values before and after the updates are the same, causing the test to fail