### PR TITLE
Fix expansions

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2265,7 +2265,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
      *
      * @param endpoint node
      */
-    private synchronized void handleStateNormal(final InetAddress endpoint, final String status)
+    private void handleStateNormal(final InetAddress endpoint, final String status)
     {
         Collection<Token> tokens = getTokensFor(endpoint);
         Set<Token> tokensToUpdateInMetadata = new HashSet<>();


### PR DESCRIPTION
Synchronizing `handleStateNormal()`  in https://github.com/palantir/cassandra/pull/336 may end up blocking gossip on bootstrapping nodes. 

main takes out a lock on the StorageService instance while initializing + bootstrapping "this" node. Then, the gossip thread will block on acquiring a lock on the StorageService instance after beginning gossip w/ another node in the cluster and attempting to notify subscribers (one of which is the StorageService) of the change. As the lock is already taken out by the main thread we block and may be prevented from contacting any seeds successfully (then crash).

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/21185532/172248015-73c0f3da-c6c7-4bcf-bce8-66adea9dc79d.png">

<img width="1209" alt="image (4)" src="https://user-images.githubusercontent.com/21185532/172250165-ee9d8e06-3760-47e9-a1c9-b3ae647573d1.png">

