### PR TITLE
Make cleanup state file writes atomic

### DIFF
--- a/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
+++ b/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
@@ -140,7 +140,7 @@ public class KeyspaceTableOpStatePersister
         }
     }
 
-    private void atomicWritetoFile(File file, String content) throws IOException
+    private synchronized void atomicWritetoFile(File file, String content) throws IOException
     {
         String tmpFilePath = file.getAbsolutePath() + ".tmp";
         File tmpFile = new File(tmpFilePath);

--- a/test/unit/org/apache/cassandra/service/opstate/OpStateTestConstants.java
+++ b/test/unit/org/apache/cassandra/service/opstate/OpStateTestConstants.java
@@ -23,6 +23,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 public class OpStateTestConstants
 {
     public static final String TEST_STATE_FILE_NAME = "test_node_op_state.json";
+    public static final String TEST_TMP_STATE_FILE_NAME = "test_node_op_state.json.tmp";
     public static final String TEST_DIRECTORY_NAME = "test-dir";
 
     public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();


### PR DESCRIPTION
Writes to the cleanup state persistent location have been seen failing mid-air, leaving the file in an unparsable state. This PR makes sure writes are now atomic.