### PR TITLE
Ignore obsolete entries in getMinimumTs for cleanup state

### DIFF
--- a/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
+++ b/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
@@ -98,12 +98,11 @@ public class CleanupStateTracker
     void updateTsForEntry(KeyspaceTableKey key, Instant value) throws IllegalArgumentException
     {
         Map<KeyspaceTableKey, Instant> updatedEntries = state.updateTsForEntry(key, value);
-        if (!persister.updateStateInPersistentLocation(updatedEntries))
+        updateCacheIfHasNotYetSuccessfullyReadFromPersister();
+        if (!successfulReadFromPersister || !persister.updateStateInPersistentLocation(updatedEntries))
         {
             log.warn("Failed to update persistant cleanup state, but cache has been updated. Will retry at next update.");
-            return;
         }
-        updateCacheIfHasNotYetSuccessfullyReadFromPersister();
     }
 
     private void updateCacheIfHasNotYetSuccessfullyReadFromPersister()

--- a/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
+++ b/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
@@ -86,7 +86,7 @@ public class CleanupStateTracker
     }
 
     /** Returns min ts for this node, null if no entry exists. */
-    public Instant getLastSuccessfulCleanupTsForNode()
+    public synchronized Instant getLastSuccessfulCleanupTsForNode()
     {
         updateCacheIfHasNotYetSuccessfullyReadFromPersister();
         return state.getMinimumTsOfAllEntries().orElse(MIN_TS);

--- a/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
+++ b/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
@@ -75,9 +75,7 @@ public class CleanupStateTracker
     {
         KeyspaceTableKey entryKey = KeyspaceTableKey.of(keyspaceName, columnFamily);
         if (!state.entryExists(entryKey))
-        {
             updateTsForEntry(entryKey, MIN_TS);
-        }
     }
 
     /** Updates ts for table entry */
@@ -100,9 +98,7 @@ public class CleanupStateTracker
         Map<KeyspaceTableKey, Instant> updatedEntries = state.updateTsForEntry(key, value);
         updateCacheIfHasNotYetSuccessfullyReadFromPersister();
         if (!successfulReadFromPersister || !persister.updateStateInPersistentLocation(updatedEntries))
-        {
             log.warn("Failed to update persistant cleanup state, but cache has been updated. Will retry at next update.");
-        }
     }
 
     private void updateCacheIfHasNotYetSuccessfullyReadFromPersister()

--- a/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStateCache.java
+++ b/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStateCache.java
@@ -80,14 +80,12 @@ public class KeyspaceTableOpStateCache
 
     @VisibleForTesting
     Set<KeyspaceTableKey> getValidKeyspaceTableEntries(){
-        Set<KeyspaceTableKey> validEntries = new HashSet<>();
-        Schema.instance.getKeyspaces().forEach(keyspace -> {
-            Set<KeyspaceTableKey> keyspaceEntries = Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores()
-                                                                   .stream()
-                                                                   .map(cf -> KeyspaceTableKey.of(keyspace, cf.getColumnFamilyName()))
-                                                                   .collect(Collectors.toSet());
-            validEntries.addAll(keyspaceEntries);
-        });
-        return validEntries;
+return Schema.instance.getKeyspaces().stream()
+                              .map(keyspace -> Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores()
+                                                              .stream()
+                                                              .map(cf -> KeyspaceTableKey.of(keyspace, cf.getColumnFamilyName()))
+                                                              .collect(Collectors.toSet()))
+                              .flatMap(Set::stream)
+                              .collect(Collectors.toSet());
     }
 }

--- a/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStateCache.java
+++ b/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStateCache.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.service.opstate;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -76,11 +77,17 @@ public class KeyspaceTableOpStateCache
         return Optional.of(Collections.min(tableEntries.values()));
     }
 
+
     @VisibleForTesting
     Set<KeyspaceTableKey> getValidKeyspaceTableEntries(){
-        return Schema.instance.getKeyspaces().stream()
-                              .flatMap(keyspace -> Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores().stream()
-                                                                  .map(cf -> KeyspaceTableKey.of(keyspace, cf.getColumnFamilyName())))
-                              .collect(Collectors.toSet());
+        Set<KeyspaceTableKey> validEntries = new HashSet<>();
+        Schema.instance.getKeyspaces().forEach(keyspace -> {
+            Set<KeyspaceTableKey> keyspaceEntries = Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores()
+                                                                   .stream()
+                                                                   .map(cf -> KeyspaceTableKey.of(keyspace, cf.getColumnFamilyName()))
+                                                                   .collect(Collectors.toSet());
+            validEntries.addAll(keyspaceEntries);
+        });
+        return validEntries;
     }
 }

--- a/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
+++ b/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
@@ -69,11 +69,7 @@ public class KeyspaceTableOpStatePersister
             return false;
         try
         {
-            Map<KeyspaceTableKey, Instant> persistentEntries = readStateFromFile(persistentStateFile);
-
-            // We assume inputted entries will always be more up to date compared to the ones from the file
-            persistentEntries.putAll(updatedEntries);
-            return writeStateToFile(persistentStateFile, persistentEntries);
+            return writeStateToFile(persistentStateFile, updatedEntries);
         }
         catch (IOException e)
         {

--- a/test/unit/org/apache/cassandra/service/opstate/OpStateTestConstants.java
+++ b/test/unit/org/apache/cassandra/service/opstate/OpStateTestConstants.java
@@ -18,6 +18,10 @@
 
 package org.apache.cassandra.service.opstate;
 
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+
 import org.codehaus.jackson.map.ObjectMapper;
 
 public class OpStateTestConstants
@@ -35,7 +39,8 @@ public class OpStateTestConstants
     public static final String KEYSPACE2 = "keyspace2";
     public static final String TABLE2 = "table2";
     public static final KeyspaceTableKey KEYSPACE_TABLE_KEY_2 =
-    KeyspaceTableKey.of(OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2);
+        KeyspaceTableKey.of(OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2);
 
-
+    public static final Set<KeyspaceTableKey> KEYSPACE_TABLE_VALID_ENTRIES =
+        ImmutableSet.of(KEYSPACE_TABLE_KEY_1, KEYSPACE_TABLE_KEY_2);
 }


### PR DESCRIPTION
Before PR: Deleted tables are not removed from the cleanup persistent state -> when a node wide cleanup is triggered, it only considers existing tables, meaning cleanup ts min will always equal the last time a deleted table was cleaned and cleanups will continue getting triggered.

PR: Ignore obsolete entries in getMinimumTs and update the cache accordingly. This will eventually lead to updating the persistent state as well.