### PR TITLE
Verify commitlog is empty on bootstrap

### DIFF
--- a/src/java/org/apache/cassandra/config/Schema.java
+++ b/src/java/org/apache/cassandra/config/Schema.java
@@ -52,6 +52,8 @@ public class Schema
 
     public static final Schema instance = new Schema();
 
+    public static final Set<String> SYSTEM_KEYSPACES = ImmutableSet.of(SystemKeyspace.NAME, SystemDistributedKeyspace.NAME, TraceKeyspace.NAME, AuthKeyspace.NAME, "system_palantir");
+
     /**
      * longest permissible KS or CF name.  Our main concern is that filename not be more than 255 characters;
      * the filename will contain both the KS and CF names. Since non-schema-name components only take up

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1107,6 +1107,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     private static boolean isCommitlogEmptyForBootstrap() {
         boolean previousDataFound = false;
         Set<UUID> ignoredKeyspacesInCommitLog = CommitLogReplayer.getSeenColumnFamilies().stream()
+                                                                 .filter(Objects::nonNull) // cfIds for commitlog can sometimes be null
                                                                  .filter(uuid -> Schema.instance.getCFMetaData(uuid) == null)
                                                                  .collect(Collectors.toSet());
 

--- a/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
@@ -26,6 +26,7 @@ import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -42,6 +43,7 @@ import org.junit.runner.RunWith;
 import com.palantir.cassandra.cvim.CrossVpcIpMappingHandshaker;
 import org.apache.cassandra.OrderedJUnit4ClassRunner;
 import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.config.CFMetaData;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.KSMetaData;
 import org.apache.cassandra.config.Schema;
@@ -91,6 +93,22 @@ public class StorageServiceServerTest
         DatabaseDescriptor.setCrossVpcInternodeCommunication(false);
         DatabaseDescriptor.setCrossVpcHostnameSwapping(false);
         DatabaseDescriptor.setCrossVpcIpSwapping(false);
+    }
+
+    @Test
+    public void isCommitlogEmptyForBootstrap_returnsTrueWhenEmpty() {
+        assertThat(StorageService.isCommitlogEmptyForBootstrap(ImmutableSet.of())).isTrue();
+    }
+
+    @Test
+    public void isCommitlogEmptyForBootstrap_returnsFalseWhenNotEmpty() {
+        assertThat(StorageService.isCommitlogEmptyForBootstrap(ImmutableSet.of(UUID.randomUUID()))).isFalse();
+    }
+
+    @Test
+    public void isCommitlogEmptyForBootstrap_returnsTrueIgnoresSystemCfs() {
+        Set<UUID> uuids = Schema.instance.getKeyspaceMetaData(SystemKeyspace.NAME).values().stream().map(cf -> cf.cfId).collect(Collectors.toSet());
+        assertThat(StorageService.isCommitlogEmptyForBootstrap(uuids)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Verify commitlog has only replayed system mutations, otherwise, fail the bootstrap, as this indicates a previous commitlog is hanging around, and could result in old data being replayed. 

This also fixes a race condition, where occasionally system_* keyspace may have an sstable created when we perform our empty keyspace check, and fail. This is due to the fact that `Schema.instance.getNonSystemKeyspaces`, in fact, gets you `system_` keyspaces still. 