### PR TITLE
Vguidi/droppable tombstone compaction

### DIFF
--- a/src/java/org/apache/cassandra/db/columniterator/SSTableAwareOnDiskAtomIterator.java
+++ b/src/java/org/apache/cassandra/db/columniterator/SSTableAwareOnDiskAtomIterator.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.columniterator;
+
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+public interface SSTableAwareOnDiskAtomIterator extends OnDiskAtomIterator {
+    public SSTableReader getSSTableReader();
+}

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
@@ -37,7 +37,6 @@ import org.apache.cassandra.io.sstable.ISSTableScanner;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.io.util.FileDataInput;
-import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.slf4j.Logger;

--- a/src/java/org/apache/cassandra/io/sstable/format/big/SSTableNamesIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/SSTableNamesIterator.java
@@ -24,7 +24,7 @@ import com.google.common.collect.AbstractIterator;
 
 import org.apache.cassandra.config.CFMetaData;
 import org.apache.cassandra.db.*;
-import org.apache.cassandra.db.columniterator.OnDiskAtomIterator;
+import org.apache.cassandra.db.columniterator.SSTableAwareOnDiskAtomIterator;
 import org.apache.cassandra.db.composites.CellName;
 import org.apache.cassandra.db.composites.CellNameType;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
@@ -35,7 +35,7 @@ import org.apache.cassandra.io.util.FileMark;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
-class SSTableNamesIterator extends AbstractIterator<OnDiskAtom> implements OnDiskAtomIterator
+public class SSTableNamesIterator extends AbstractIterator<OnDiskAtom> implements SSTableAwareOnDiskAtomIterator
 {
     private ColumnFamily cf;
     private final SSTableReader sstable;
@@ -241,6 +241,10 @@ class SSTableNamesIterator extends AbstractIterator<OnDiskAtom> implements OnDis
                     nextToFetch = toFetch.hasNext() ? toFetch.next() : null;
             }
         }
+    }
+
+    public SSTableReader getSSTableReader() {
+        return this.sstable;
     }
 
     public DecoratedKey getKey()

--- a/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.palantir.cassandra.utils.CountingCellIterator;
 import com.codahale.metrics.*;
+import com.palantir.cassandra.utils.TombstoneCountingIterator;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.Memtable;
@@ -131,9 +132,9 @@ public class ColumnFamilyMetrics
     public final ColumnFamilyHistogram liveReadHistogram;
     /** Tombstones scanned in queries on this CF per {@link CountingCellIterator} */
     public final ColumnFamilyHistogram tombstonesReadHistogram;
-    /** Range tombstones scanned in queries on this CF per {@link com.palantir.cassandra.utils.RangeTombstoneCountingIterator} */
+    /** Range tombstones scanned in queries on this CF per {@link TombstoneCountingIterator} */
     public final ColumnFamilyHistogram rangeTombstonesReadHistogram;
-    /** Droppable range tombstones scanned in queries on this CF per {@link com.palantir.cassandra.utils.RangeTombstoneCountingIterator} */
+    /** Droppable range tombstones scanned in queries on this CF per {@link TombstoneCountingIterator} */
     public final ColumnFamilyHistogram droppableRangeTombstonesReadHistogram;
     /** Range tombstones held in memory when performing a read on this CF */
     public final ColumnFamilyHistogram rangeTombstonesHistogram;

--- a/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
@@ -22,13 +22,13 @@ import java.util.Set;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
+import com.palantir.cassandra.utils.TombstoneCountingIterator;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.palantir.cassandra.utils.CountingCellIterator;
-import org.apache.cassandra.db.Mutation;
 
 import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
 
@@ -91,9 +91,9 @@ public class KeyspaceMetrics
     /** Tombstones scanned in queries on this CF per {@link CountingCellIterator} */
     public final Histogram tombstonesReadHistogram;
 
-    /** Ranged Tombstones scanned in queries on this CF per {@link com.palantir.cassandra.utils.RangeTombstoneCountingIterator} */
+    /** Ranged Tombstones scanned in queries on this CF per {@link TombstoneCountingIterator} */
     public final Histogram rangeTombstonesReadHistogram;
-    /** Droppable ranged Tombstones scanned in queries on this CF per {@link com.palantir.cassandra.utils.RangeTombstoneCountingIterator} */
+    /** Droppable ranged Tombstones scanned in queries on this CF per {@link TombstoneCountingIterator} */
     public final Histogram droppableRangeTombstonesReadHistogram;
     /** Range tombstones held in memory when performing a read on this CF */
     public final Histogram rangeTombstonesHistogram;


### PR DESCRIPTION
This pr changes single sstable compaction on leveled compacting strategy to trigger according to the amount of tombstones read per second on a single sstable, not to the ratio of droppable tombstones present.