### PR TITLE
Account for missing entries when computing LastSuccessfulCleanupTs

### DIFF
--- a/test/unit/org/apache/cassandra/service/opstate/KeyspaceTableOpStateCacheTest.java
+++ b/test/unit/org/apache/cassandra/service/opstate/KeyspaceTableOpStateCacheTest.java
@@ -57,7 +57,8 @@ public class KeyspaceTableOpStateCacheTest
         KeyspaceTableOpStateCache state =
             Mockito.spy(new KeyspaceTableOpStateCache(ImmutableMap.of(OpStateTestConstants.KEYSPACE_TABLE_KEY_1, Instant.ofEpochMilli(10L))));
         doReturn(OpStateTestConstants.KEYSPACE_TABLE_VALID_ENTRIES).when(state).getValidKeyspaceTableEntries();
-        assertThat(state.getMinimumTsOfAllEntries().orElse(null)).isEqualTo(Instant.ofEpochMilli(10L));
+        // Missing entry for KEYSPACE_TABLE_KEY_2, getMinimumTsOfAllEntries should return an empty value
+        assertThat(state.getMinimumTsOfAllEntries().orElse(null)).isNull();
         state.updateTsForEntry(OpStateTestConstants.KEYSPACE_TABLE_KEY_2, Instant.ofEpochMilli(20L));
         assertThat(state.getMinimumTsOfAllEntries().orElse(null)).isEqualTo(Instant.ofEpochMilli(10L));
         state.updateTsForEntry(OpStateTestConstants.KEYSPACE_TABLE_KEY_1, Instant.ofEpochMilli(20L));


### PR DESCRIPTION
To ensure that we account for keyspaces/tables without state in our LastSuccessfulCleanupTs computation, return empty ts (equivalent to EPOCH) if we find that some entries are missing from our state.