### PR TITLE
Dont use sun for cross-VPC

### DIFF
--- a/src/java/com/palantir/cassandra/cvim/InetAddressIp.java
+++ b/src/java/com/palantir/cassandra/cvim/InetAddressIp.java
@@ -18,15 +18,16 @@
 
 package com.palantir.cassandra.cvim;
 
+import com.google.common.net.InetAddresses;
+
 import com.palantir.cassandra.objects.Wrapper;
-import sun.net.util.IPAddressUtil;
 
 public class InetAddressIp extends Wrapper<String>
 {
     public InetAddressIp(String ipAddress)
     {
         super(ipAddress);
-        if (!(IPAddressUtil.isIPv4LiteralAddress(ipAddress) || IPAddressUtil.isIPv6LiteralAddress(ipAddress)))
+        if (!(InetAddresses.isInetAddress(ipAddress)))
         {
             throw new IllegalArgumentException("Provided IP address is not valid IPv4 or IPv6 format: " + ipAddress);
         }


### PR DESCRIPTION
We no longer can use sun.net.util.IPAddressUtil, likely b/c of the upgrade to java17

```
ERROR [2023-01-18T21:44:43.449Z] org.apache.cassandra.io.util.FileUtils: Exception in thread Thread[CrossVpcIpMappingTasks:1,5,main] (throwable0_message: class com.palantir.cassandra.cvim.InetAddressIp (in unnamed module @0xe6ca48a) cannot access class sun.net.util.IPAddressUtil (in module java.base) because module java.base does not export sun.net.util to unnamed module @0xe6ca48a)
java.lang.IllegalAccessError: class com.palantir.cassandra.cvim.InetAddressIp (in unnamed module @0xe6ca48a) cannot access class sun.net.util.IPAddressUtil (in module java.base) because module java.base does not export sun.net.util to unnamed module @0xe6ca48a
        at com.palantir.cassandra.cvim.InetAddressIp.<init>(InetAddressIp.java:29)
```