### PR TITLE
bump libthrift to 0.17.0

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -393,7 +393,7 @@
             <exclusion groupId="org.slf4j" artifactId="slf4j-log4j12"/>
           </dependency>
           <dependency groupId="org.yaml" artifactId="snakeyaml" version="1.33"/>
-          <dependency groupId="org.apache.thrift" artifactId="libthrift" version="0.9.2">
+          <dependency groupId="org.apache.thrift" artifactId="libthrift" version="0.17.0">
 	         <exclusion groupId="commons-logging" artifactId="commons-logging"/>
           </dependency>
           <dependency groupId="junit" artifactId="junit" version="4.6" />
@@ -1341,7 +1341,7 @@
         <pathelement location="${test.classes}" />
         <pathelement location="${build.dir}/${ant.project.name}-clientutil-${version}.jar" />
         <pathelement location="${build.dir}/${ant.project.name}-thrift-${version}.jar" />
-        <pathelement location="${build.lib}/libthrift-0.9.0.jar" />
+        <pathelement location="${build.lib}/libthrift-0.17.0.jar" />
         <pathelement location="${build.lib}/slf4j-api-1.7.7.jar" />
         <pathelement location="${build.lib}/log4j-over-slf4j.jar" />
         <pathelement location="${build.lib}/logback-core-1.1.3.jar" />


### PR DESCRIPTION
This should be safe to bump, tested on a development cluster internally. It appears that the generated thrift code does not rely on the underlying thrift library, which is good, and also makes sense, considering `libthrift` library here doesn't do the codegen anyways. 