### PR TITLE
Fixes for Java 11 and Java 17

### DIFF
--- a/bin/cassandra.in.sh
+++ b/bin/cassandra.in.sh
@@ -41,15 +41,15 @@ cassandra_bin="$cassandra_bin:$CASSANDRA_HOME/build/classes/thrift"
 # if not set in cassandra.yaml
 cassandra_storagedir="$CASSANDRA_HOME/data"
 
-if [ -n "${JAVA_15_HOME}" ]; then
-    JAVA_HOME="${JAVA_15_HOME}"
+if [ -n "${JAVA_17_HOME}" ]; then
+    JAVA_HOME="${JAVA_17_HOME}"
 fi
 
-# verify that JAVA_HOME points to java 15
+# verify that JAVA_HOME points to java 17
 java_ver_output=`"$JAVA_HOME/bin/java" -version 2>&1 | grep '[openjdk|java] version' | awk -F'"' 'NR==1 {print $2}'`
 jvm_version=${java_ver_output%_*}
-if [ "$jvm_version" \< "15.0" ] ; then
-    echo "Palantir Cassandra 2.0.x requires Java 15, but JAVA_HOME is set to '$JAVA_HOME' with version $jvm_version"
+if [ "$jvm_version" \< "17.0" ] ; then
+    echo "Palantir Cassandra 2.0.x requires Java 17, but JAVA_HOME is set to '$JAVA_HOME' with version $jvm_version"
     exit 1;
 fi
 

--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -178,7 +178,9 @@ JVM_OPTS="$JVM_OPTS -ea"
 JVM_OPTS="$JVM_OPTS -javaagent:$CASSANDRA_HOME/lib/jamm-0.3.0.jar"
 
 # some JVMs will fill up their heap when accessed via JMX, see CASSANDRA-6541
-JVM_OPTS="$JVM_OPTS -XX:+CMSClassUnloadingEnabled"
+if [ "$JVM_VERSION" \< "14.0" ] ; then
+    JVM_OPTS="$JVM_OPTS -XX:+CMSClassUnloadingEnabled"
+fi
 
 # enable thread priorities, primarily so we can give periodic tasks
 # a lower priority to avoid interfering with client workload
@@ -243,7 +245,7 @@ JVM_OPTS="$JVM_OPTS -XX:+PerfDisableSharedMem"
 JVM_OPTS="$JVM_OPTS -XX:CompileCommandFile=$CASSANDRA_CONF/hotspot_compiler"
 
 # note: bash evals '1.7.x' as > '1.7' so this is really a >= 1.7 jvm check
-if { [ "$JVM_VERSION" \> "1.7" ] && [ "$JVM_VERSION" \< "1.8.0" ] && [ "$JVM_PATCH_VERSION" -ge "60" ]; } || [ "$JVM_VERSION" \> "1.8" ] ; then
+if { [ "$JVM_VERSION" \> "1.7" ] && [ "$JVM_VERSION" \< "1.8.0" ] && [ "$JVM_PATCH_VERSION" -ge "60" ]; } || { [ "$JVM_VERSION" \> "1.8" ] && [ "$JVM_VERSION" \< "14.0" ] ; } then
     JVM_OPTS="$JVM_OPTS -XX:+CMSParallelInitialMarkEnabled -XX:+CMSEdenChunksRecordAlways -XX:CMSWaitDuration=10000"
 fi
 


### PR DESCRIPTION
Adds version checks on JVM args that work on Java 11 but not on 17.

With this change, `conf/cassandra-env.sh` is compatible with both Java 11 and Java 17.
`bin/cassandra.in.sh` requires Java 17