### PR TITLE
Add is_new_cluster StorageService endpoint

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5114,6 +5114,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
     }
 
+    @Override
     public boolean isNewCluster()
     {
         return Boolean.parseBoolean(System.getProperty("palantir_cassandra.is_new_cluster", "false"));

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -208,7 +208,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     // true when keeping strict consistency while bootstrapping
     private boolean useStrictConsistency = Boolean.parseBoolean(System.getProperty("cassandra.consistent.rangemovement", "true"));
-    private static final boolean allowSimultaneousMoves = Boolean.valueOf(System.getProperty("cassandra.consistent.simultaneousmoves.allow","false"));
+    private static final boolean allowSimultaneousMoves = Boolean.parseBoolean(System.getProperty("cassandra.consistent.simultaneousmoves.allow", "false"));
     private static final boolean joinRing = Boolean.parseBoolean(System.getProperty("cassandra.join_ring", "true"));
     private boolean replacing;
     private UUID replacingId;
@@ -5112,6 +5112,11 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         } catch (IOException e) {
             throw new RuntimeException("Failed to persistently disable client interfaces due to IO Exception", e);
         }
+    }
+
+    public boolean isNewCluster()
+    {
+        return Boolean.parseBoolean(System.getProperty("palantir_cassandra.is_new_cluster", "false"));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -865,4 +865,9 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
     public void persistentDisableClientInterfaces();
 
     public boolean isMigrating();
+
+    /**
+     * Returns the value of the palantir_cassandra.is_new_cluster system variable or false if not set.
+     */
+    public boolean isNewCluster();
 }


### PR DESCRIPTION
Exposes a StorageServiceMBean endpoint that returns the value of `palantir_cassandra.is_new_cluster` env variable if set, or false otherwise