### PR TITLE
Add metric for tracking compactions of large partitions

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -182,6 +182,7 @@ public class BigTableWriter extends SSTableWriter
         {
             String keyString = metadata.getKeyValidator().getString(key.getKey());
             logger.warn("Writing large partition {}/{}:{} ({} bytes)", metadata.ksName, metadata.cfName, keyString, rowSize);
+            Keyspace.open(metadata.ksName).getColumnFamilyStore(metadata.cfName).metric.largePartitionsCompacted.inc();
         }
     }
 

--- a/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
@@ -183,6 +183,8 @@ public class ColumnFamilyMetrics
     public final Meter attemptedReadRepairs;
     public final Meter backgroundReadRepairs;
 
+    public final Counter largePartitionsCompacted;
+
     /** Request rounds in range scan queries on this CF **/
     public final ColumnFamilyHistogram coordinatorScanRequestRounds;
 
@@ -412,6 +414,7 @@ public class ColumnFamilyMetrics
         blockingReadRepairs = Metrics.meter(factory.createMetricName("BlockingReadRepairs"));
         backgroundReadRepairs = Metrics.meter(factory.createMetricName("BackgroundReadRepairs"));
         attemptedReadRepairs = Metrics.meter(factory.createMetricName("AttemptedReadRepairs"));
+        largePartitionsCompacted = Metrics.counter("LargePartitionsCompacted");
         pendingFlushes = createColumnFamilyCounter("PendingFlushes");
         bytesFlushed = createColumnFamilyCounter("BytesFlushed");
         compactionBytesWritten = createColumnFamilyCounter("CompactionBytesWritten");


### PR DESCRIPTION
Adds metric for tracking compactions of partitions exceeding `compaction_large_partition_warning_threshold_mb` in C* yaml.