### PR TITLE
Restrict some cipher suites

### DIFF
--- a/src/java/org/apache/cassandra/config/EncryptionOptions.java
+++ b/src/java/org/apache/cassandra/config/EncryptionOptions.java
@@ -17,6 +17,8 @@
  */
 package org.apache.cassandra.config;
 
+import com.google.common.collect.ImmutableSet;
+
 public abstract class EncryptionOptions
 {
     public String keystore = "conf/.keystore";
@@ -28,6 +30,8 @@ public abstract class EncryptionOptions
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA" 
     };
+    public static ImmutableSet<String> restricted_cipher_suites = ImmutableSet.of(
+        "TLS1_CK_DHE_RSA_WITH_AES_256_CBC_SHA", "TLS1_CK_DHE_RSA_WITH_AES_129_CBC_SHA");
     public String protocol = "TLS";
     public String algorithm = "SunX509";
     public String store_type = "JKS";

--- a/src/java/org/apache/cassandra/security/SSLFactory.java
+++ b/src/java/org/apache/cassandra/security/SSLFactory.java
@@ -30,13 +30,12 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SNIHostName;
@@ -47,9 +46,7 @@ import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
-import javax.xml.crypto.Data;
 
-import ch.qos.logback.core.net.ssl.SSL;
 import com.palantir.cassandra.cvim.CrossVpcIpMappingHandshaker;
 import com.palantir.cassandra.cvim.InetAddressHostname;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -181,11 +178,17 @@ public final class SSLFactory
 
     public static String[] filterCipherSuites(String[] supported, String[] desired)
     {
-        if (Arrays.equals(supported, desired))
-            return desired;
         List<String> ldesired = Arrays.asList(desired);
         ImmutableSet<String> ssupported = ImmutableSet.copyOf(supported);
-        String[] ret = Iterables.toArray(Iterables.filter(ldesired, Predicates.in(ssupported)), String.class);
+
+        String[] ret = Iterables.toArray(
+        ldesired.stream()
+                .filter(potentialCipher -> ssupported.contains(potentialCipher)
+                                           && !EncryptionOptions.restricted_cipher_suites.contains(potentialCipher))
+                .collect(Collectors.toList()),
+        String.class);
+
+
         if (desired.length > ret.length && logger.isWarnEnabled())
         {
             Iterable<String> missing = Iterables.filter(ldesired, Predicates.not(Predicates.in(Sets.newHashSet(ret))));

--- a/src/java/org/apache/cassandra/security/SSLFactory.java
+++ b/src/java/org/apache/cassandra/security/SSLFactory.java
@@ -189,9 +189,9 @@ public final class SSLFactory
                     logger.warn("Removing suite that isn't supported by the socket");
                 }
             })
-                .filter(ssupported::contains)
-                .filter(suite -> !EncryptionOptions.restricted_cipher_suites.contains(suite))
-                .collect(Collectors.toList()),
+            .filter(ssupported::contains)
+            .filter(suite -> !EncryptionOptions.restricted_cipher_suites.contains(suite))
+            .collect(Collectors.toList()),
         String.class);
 
 

--- a/src/java/org/apache/cassandra/security/SSLFactory.java
+++ b/src/java/org/apache/cassandra/security/SSLFactory.java
@@ -186,7 +186,7 @@ public final class SSLFactory
                 if (EncryptionOptions.restricted_cipher_suites.contains(suite)) {
                     logger.warn("Removing restricted cipher suite {}", suite);
                 } else if (!ssupported.contains(suite)) {
-                    logger.warn("Removing suite that isn't supported by the socket");
+                    logger.warn("Removing suite that isn't supported by the socket {}", suite);
                 }
             })
             .filter(ssupported::contains)


### PR DESCRIPTION
While these wouldn't be used unless the socket supported them and EncryptionOptions were explicitly configured to allow them, we should not allow them