### PR TITLE
respect CASSANDRA_HOME when defined externally, like by CCM

### DIFF
--- a/bin/cassandra.in.sh
+++ b/bin/cassandra.in.sh
@@ -16,7 +16,7 @@
 
 SERVICE_HOME=$(cd "$(dirname "$0")/../../" && pwd)
 
-if [ -d "$SERVICE_HOME" ] && [ -z "$CASSANDRA_HOME"]; then
+if [ -d "$SERVICE_HOME" ] && [ -z "$USE_CUSTOM_CASSANDRA_HOME"]; then
     CASSANDRA_HOME="$SERVICE_HOME/service"
     CASSANDRA_CONF="$SERVICE_HOME/var/conf"
 fi

--- a/bin/cassandra.in.sh
+++ b/bin/cassandra.in.sh
@@ -16,7 +16,7 @@
 
 SERVICE_HOME=$(cd "$(dirname "$0")/../../" && pwd)
 
-if [ -d "$SERVICE_HOME" ] && [ -z "$USE_CUSTOM_CASSANDRA_DIRS"]; then
+if [ -d "$SERVICE_HOME" ] && [ -z "$USE_CUSTOM_CASSANDRA_DIRS" ]; then
     CASSANDRA_HOME="$SERVICE_HOME/service"
     CASSANDRA_CONF="$SERVICE_HOME/var/conf"
 fi

--- a/bin/cassandra.in.sh
+++ b/bin/cassandra.in.sh
@@ -16,7 +16,7 @@
 
 SERVICE_HOME=$(cd "$(dirname "$0")/../../" && pwd)
 
-if [ -d "$SERVICE_HOME" ] && [ -z "$USE_CUSTOM_CASSANDRA_HOME"]; then
+if [ -d "$SERVICE_HOME" ] && [ -z "$USE_CUSTOM_CASSANDRA_DIRS"]; then
     CASSANDRA_HOME="$SERVICE_HOME/service"
     CASSANDRA_CONF="$SERVICE_HOME/var/conf"
 fi

--- a/bin/cassandra.in.sh
+++ b/bin/cassandra.in.sh
@@ -16,7 +16,7 @@
 
 SERVICE_HOME=$(cd "$(dirname "$0")/../../" && pwd)
 
-if [ -d "$SERVICE_HOME" ]; then
+if [ -d "$SERVICE_HOME" ] && [ -z "$CASSANDRA_HOME"]; then
     CASSANDRA_HOME="$SERVICE_HOME/service"
     CASSANDRA_CONF="$SERVICE_HOME/var/conf"
 fi


### PR DESCRIPTION
CCM clusters fail to start in DTests on our fork because CCM expects a CASSANDRA_HOME and CASSANDRA_CONF that are not in SERVICE_HOME.

This change fixes test startup. ~This could break something if any production environments define a bad value for CASSANDRA_HOME, relying on it to be overridden here.~ Paths set externally by tests will not be overridden if `USE_CUSTOM_CASSANDRA_DIRS` is set.