### PR TITLE
do not bootstrap with an empty schema

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -920,6 +920,11 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                 }
                 Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
             }
+            while (!isNewCluster() && Schema.instance.getVersion().equals(Schema.emptyVersion))
+            {
+                setMode(Mode.JOINING, "our schema is empty and we are joining an existing cluster, continuing to wait for schema", true);
+                Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+            }
             // if our schema hasn't matched yet, keep sleeping until it does
             // (post CASSANDRA-1391 we don't expect this to be necessary very often, but it doesn't hurt to be careful)
             while (!MigrationManager.isReadyForBootstrap())

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -925,6 +925,10 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                 setMode(Mode.JOINING, "our schema is empty and we are joining an existing cluster, continuing to wait for schema", true);
                 Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
             }
+            while (!Gossiper.instance.schemaIsConsistent())
+            {
+                setMode(Mode.JOINING, "our schema is different from at least one other node, waiting for schema agree", true);
+            }
             // if our schema hasn't matched yet, keep sleeping until it does
             // (post CASSANDRA-1391 we don't expect this to be necessary very often, but it doesn't hurt to be careful)
             while (!MigrationManager.isReadyForBootstrap())


### PR DESCRIPTION
Adds an additional check before bootstrapping. This ensures that a node will not try to bootstrap if its schema is empty.