### PR TITLE
Always wait for JMX finishBootstrap before serving requests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1335,6 +1335,7 @@
     <junit fork="on" forkmode="perTest" failureproperty="testfailed" maxmemory="1024m" timeout="${test.timeout}">
       <!-- Note that the test pass without that next line, but it prints an ugly error message -->
       <jvmarg value="-Djava.library.path=${build.lib}/sigar-bin"/>
+      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
       <test name="org.apache.cassandra.serializers.ClientUtilsTest" todir="${build.test.dir}/output"/>
       <formatter type="brief" usefile="false" />
       <formatter type="xml" usefile="true"/>
@@ -1376,6 +1377,7 @@
       <jvmarg value="-Dcassandra.ring_delay_ms=1000"/>
       <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
       <jvmarg value="-Dcassandra.skip_sync=true" />
+      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
     </testmacro>
     <fileset dir="${test.unit.src}">
         <exclude name="**/pig/*.java" />
@@ -1397,6 +1399,7 @@
         <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
         <jvmarg value="-Dcassandra.config.loader=org.apache.cassandra.OffsetAwareConfigurationLoader"/>
         <jvmarg value="-Dcassandra.skip_sync=true" />
+        <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
       </testmacrohelper>
     </sequential>
   </macrodef>
@@ -1424,6 +1427,7 @@
         <jvmarg value="-Dcassandra.config=file:///${compressed_yaml}"/>
         <jvmarg value="-Dcassandra.skip_sync=true" />
         <jvmarg value="-Dcassandra.config.loader=org.apache.cassandra.OffsetAwareConfigurationLoader"/>
+        <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
       </testmacrohelper>
     </sequential>
   </macrodef>
@@ -1453,6 +1457,7 @@
       <jvmarg value="-Dcassandra.ring_delay_ms=1000"/>
       <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
       <jvmarg value="-Dcassandra.skip_sync=true" />
+      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
     </testmacro>
   </target>
 
@@ -1507,6 +1512,7 @@
                timeout="${test.long.timeout}">
       <jvmarg value="-Dcassandra.ring_delay_ms=1000"/>
       <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
+      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
     </testmacro>
   </target>
 
@@ -1525,6 +1531,7 @@
         <jvmarg value="-Dcassandra.memtable_row_overhead_computation_step=100"/>
         <jvmarg value="-Dcassandra.test.use_prepared=${cassandra.test.use_prepared}"/>
         <jvmarg value="-Dcassandra.skip_sync=true" />
+        <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
         <classpath>
           <path refid="cassandra.classpath" />
           <pathelement location="${test.classes}"/>
@@ -1569,6 +1576,7 @@
         <jvmarg value="-Dcassandra.test.use_prepared=${cassandra.test.use_prepared}"/>
         <jvmarg value="-Dcassandra.memtable_row_overhead_computation_step=100"/>
         <jvmarg value="-Dcassandra.skip_sync=true" />
+        <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
         <classpath>
           <path refid="cassandra.classpath" />
           <pathelement location="${test.classes}"/>
@@ -1847,6 +1855,7 @@
       <jvmarg value="-XX:SoftRefLRUPolicyMSPerMB=0" />
       <jvmarg value="-XX:+HeapDumpOnOutOfMemoryError" />
       <jvmarg value="-XX:HeapDumpPath=build/test/oom.hprof" />
+      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
     </testmacro>
   </target>
 
@@ -1887,6 +1896,7 @@
       <jvmarg value="-Dcassandra.ring_delay_ms=10000"/>
       <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
       <jvmarg value="-Dcassandra.skip_sync=true" />
+      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
     </testmacro>
   </target>
 
@@ -1900,6 +1910,7 @@
       <jvmarg value="-Dcassandra.ring_delay_ms=10000"/>
       <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
       <jvmarg value="-Dcassandra.skip_sync=true" />
+      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
     </testmacro>
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -1302,7 +1302,6 @@
         <jvmarg value="-Dcassandra.testtag=@{testtag}"/>
         <!-- The first time SecureRandom initializes can be slow if it blocks on /dev/random -->
         <jvmarg value="-Djava.security.egd=file:/dev/urandom" />
-        <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
 	<optjvmargs/>
         <classpath>
           <path refid="cassandra.classpath" />
@@ -1335,7 +1334,6 @@
     <junit fork="on" forkmode="perTest" failureproperty="testfailed" maxmemory="1024m" timeout="${test.timeout}">
       <!-- Note that the test pass without that next line, but it prints an ugly error message -->
       <jvmarg value="-Djava.library.path=${build.lib}/sigar-bin"/>
-      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
       <test name="org.apache.cassandra.serializers.ClientUtilsTest" todir="${build.test.dir}/output"/>
       <formatter type="brief" usefile="false" />
       <formatter type="xml" usefile="true"/>
@@ -1377,7 +1375,6 @@
       <jvmarg value="-Dcassandra.ring_delay_ms=1000"/>
       <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
       <jvmarg value="-Dcassandra.skip_sync=true" />
-      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
     </testmacro>
     <fileset dir="${test.unit.src}">
         <exclude name="**/pig/*.java" />
@@ -1399,7 +1396,6 @@
         <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
         <jvmarg value="-Dcassandra.config.loader=org.apache.cassandra.OffsetAwareConfigurationLoader"/>
         <jvmarg value="-Dcassandra.skip_sync=true" />
-        <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
       </testmacrohelper>
     </sequential>
   </macrodef>
@@ -1427,7 +1423,6 @@
         <jvmarg value="-Dcassandra.config=file:///${compressed_yaml}"/>
         <jvmarg value="-Dcassandra.skip_sync=true" />
         <jvmarg value="-Dcassandra.config.loader=org.apache.cassandra.OffsetAwareConfigurationLoader"/>
-        <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
       </testmacrohelper>
     </sequential>
   </macrodef>
@@ -1457,7 +1452,6 @@
       <jvmarg value="-Dcassandra.ring_delay_ms=1000"/>
       <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
       <jvmarg value="-Dcassandra.skip_sync=true" />
-      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
     </testmacro>
   </target>
 
@@ -1512,7 +1506,6 @@
                timeout="${test.long.timeout}">
       <jvmarg value="-Dcassandra.ring_delay_ms=1000"/>
       <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
-      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
     </testmacro>
   </target>
 
@@ -1531,7 +1524,6 @@
         <jvmarg value="-Dcassandra.memtable_row_overhead_computation_step=100"/>
         <jvmarg value="-Dcassandra.test.use_prepared=${cassandra.test.use_prepared}"/>
         <jvmarg value="-Dcassandra.skip_sync=true" />
-        <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
         <classpath>
           <path refid="cassandra.classpath" />
           <pathelement location="${test.classes}"/>
@@ -1576,7 +1568,6 @@
         <jvmarg value="-Dcassandra.test.use_prepared=${cassandra.test.use_prepared}"/>
         <jvmarg value="-Dcassandra.memtable_row_overhead_computation_step=100"/>
         <jvmarg value="-Dcassandra.skip_sync=true" />
-        <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
         <classpath>
           <path refid="cassandra.classpath" />
           <pathelement location="${test.classes}"/>
@@ -1855,7 +1846,6 @@
       <jvmarg value="-XX:SoftRefLRUPolicyMSPerMB=0" />
       <jvmarg value="-XX:+HeapDumpOnOutOfMemoryError" />
       <jvmarg value="-XX:HeapDumpPath=build/test/oom.hprof" />
-      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
     </testmacro>
   </target>
 
@@ -1896,7 +1886,6 @@
       <jvmarg value="-Dcassandra.ring_delay_ms=10000"/>
       <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
       <jvmarg value="-Dcassandra.skip_sync=true" />
-      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
     </testmacro>
   </target>
 
@@ -1910,7 +1899,6 @@
       <jvmarg value="-Dcassandra.ring_delay_ms=10000"/>
       <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
       <jvmarg value="-Dcassandra.skip_sync=true" />
-      <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
     </testmacro>
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -1302,6 +1302,7 @@
         <jvmarg value="-Dcassandra.testtag=@{testtag}"/>
         <!-- The first time SecureRandom initializes can be slow if it blocks on /dev/random -->
         <jvmarg value="-Djava.security.egd=file:/dev/urandom" />
+        <jvmarg value="-Dpalantir_cassandra.disable_wait_to_finish_bootstrap=true"/>
 	<optjvmargs/>
         <classpath>
           <path refid="cassandra.classpath" />

--- a/src/java/com/palantir/cassandra/concurrent/ConditionAwaiter.java
+++ b/src/java/com/palantir/cassandra/concurrent/ConditionAwaiter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.concurrent;
+
+import com.google.common.util.concurrent.Monitor;
+
+public class ConditionAwaiter
+{
+    private volatile boolean allowedToProceed = false;
+    private final Monitor monitor = new Monitor();
+    private final Monitor.Guard isAllowedToProceed = getNewGuard(monitor);
+    private final boolean disabled;
+
+    public ConditionAwaiter(boolean disabled)
+    {
+        this.disabled = disabled;
+    }
+
+    public void proceed() {
+        monitor.enter();
+        try {
+            allowedToProceed = true;
+        } finally {
+            monitor.leave();
+        }
+    }
+
+    public void await() {
+        try {
+            if (disabled)
+                return;
+            monitor.enterWhen(isAllowedToProceed);
+        } catch (InterruptedException | IllegalStateException e) {
+            throw new RuntimeException("Failed while waiting for an operator command", e);
+        }
+    }
+
+    private Monitor.Guard getNewGuard(Monitor monitor) {
+        return new Monitor.Guard(monitor) {
+            @Override
+            public boolean isSatisfied() {
+                return allowedToProceed;
+            }
+        };
+    }
+}

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1614,7 +1614,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     }
 
     @Override
-    public void finalizeBootstrap()
+    public void finishBootstrap()
     {
         finishBootstrapGuard.proceed();
     }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1045,7 +1045,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         {
             if (dataAvailable)
             {
-                logger.info("Bootstrap almost complete. Not becoming an active ring member. Use JMX (StorageService->finishBootstrap()) " +
+                logger.warn("Bootstrap almost complete. Not becoming an active ring member. Use JMX (StorageService->finishBootstrap()) " +
                         "to finalize ring joining. Set palantir_cassandra.disable_wait_to_finish_bootstrap=true to bypass " +
                         "this step and join the ring immediately after bootstrapping.");
                 finishBootstrapGuard.await();

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1040,7 +1040,6 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         ensureTraceKeyspace();
         maybeAddOrUpdateKeyspace(SystemDistributedKeyspace.definition());
 
-
         if (!isSurveyMode)
         {
             if (dataAvailable)
@@ -1199,7 +1198,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             }
             else
             {
-                logger.warn("Cannot join the ring because palantir_cassandra.disable_wait_to_serve_requests is not set and bootstrap hasn't completed");
+                logger.warn("Received operator request to finish joining the ring after bootstrapping, but bootstrap hasn't completed. Not joining the ring.");
             }
         }
         else if (isSurveyMode)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1006,6 +1006,10 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             }
 
             dataAvailable = bootstrap(bootstrapTokens);
+            logger.warn("Bootstrap almost complete. Not becoming an active ring member. Use JMX (StorageService->finishBootstrap()) " +
+                    "to finalize ring joining. Set palantir_cassandra.disable_wait_to_finish_bootstrap=true to bypass " +
+                    "this step and join the ring immediately after bootstrapping.");
+            finishBootstrapGuard.await();
         }
         else
         {
@@ -1045,10 +1049,6 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         {
             if (dataAvailable)
             {
-                logger.warn("Bootstrap almost complete. Not becoming an active ring member. Use JMX (StorageService->finishBootstrap()) " +
-                        "to finalize ring joining. Set palantir_cassandra.disable_wait_to_finish_bootstrap=true to bypass " +
-                        "this step and join the ring immediately after bootstrapping.");
-                finishBootstrapGuard.await();
                 finishJoiningRing(bootstrapTokens);
 
                 // remove the existing info about the replaced node.

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1524,7 +1524,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             public void onSuccess(StreamState streamState)
             {
                 isBootstrapMode = false;
-                logger.info("Bootstrap completed! for the tokens {}", tokens);
+                logger.info("Bootstrap streaming completed for the tokens {}", tokens);
             }
 
             @Override

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1007,8 +1007,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
             dataAvailable = bootstrap(bootstrapTokens);
             logger.warn("Bootstrap almost complete. Not becoming an active ring member. Use JMX (StorageService->finishBootstrap()) " +
-                    "to finalize ring joining. Set palantir_cassandra.disable_wait_to_finish_bootstrap=true to bypass " +
-                    "this step and join the ring immediately after bootstrapping.");
+                    "to finalize ring joining. If using sls-cassandra-sidecar, modify the sidecar runtime config to admit this node. " +
+                    "Set palantir_cassandra.disable_wait_to_finish_bootstrap=true to bypass this step and join the ring immediately after bootstrapping.");
             finishBootstrapGuard.await();
         }
         else

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1522,7 +1522,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         {
             bootstrapStream.get();
             isBootstrapMode = false;
-            logger.info("Bootstrap completed for tokens {}", tokens);
+            logger.info("Bootstrap streaming completed for tokens {}", tokens);
             return true;
         }
         catch (Throwable e)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -102,7 +102,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 {
     private static final Logger logger = LoggerFactory.getLogger(StorageService.class);
     private static final boolean DISABLE_WAIT_TO_BOOTSTRAP = Boolean.getBoolean("palantir_cassandra.disable_wait_to_bootstrap");
-    private static final boolean DISABLE_WAIT_TO_FINISH_BOOTSTRAP = Boolean.getBoolean("palantir_cassandra.disable_wait_to_serve_requests");
+    private static final boolean DISABLE_WAIT_TO_FINISH_BOOTSTRAP = Boolean.getBoolean("palantir_cassandra.disable_wait_to_finish_bootstrap");
     private static final Integer BOOTSTRAP_DISK_USAGE_THRESHOLD = Integer.getInteger("palantir_cassandra.bootstrap_disk_usage_threshold_percentage");
 
     public static final int RING_DELAY = getRingDelay(); // delay after which we assume ring has stablized
@@ -1045,9 +1045,9 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         {
             if (dataAvailable)
             {
-                logger.info("Bootstrapping complete. Not becoming an active ring member. Use JMX (StorageService->joinRing()) " +
-                        "to finalize ring joining. Set palantir_cassandra.disable_wait_to_serve_requests=true to bypass " +
-                        "this check and join the ring immediately after bootstrapping.");
+                logger.info("Bootstrap almost complete. Not becoming an active ring member. Use JMX (StorageService->finishBootstrap()) " +
+                        "to finalize ring joining. Set palantir_cassandra.disable_wait_to_finish_bootstrap=true to bypass " +
+                        "this step and join the ring immediately after bootstrapping.");
                 finishBootstrapGuard.await();
                 finishJoiningRing(bootstrapTokens);
 

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -770,6 +770,11 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
     public void startBootstrap();
 
     /**
+     * Send signal to finalize the bootstrap process and finish joining the ring.
+     */
+    public void finalizeBootstrap();
+
+    /**
      * Retrieve a set of unique errors. every error is represented as a map from an attribute name to a value.
      *
      * Each map representing an error is guarenteed to have the key {@link #NON_TRANSIENT_ERROR_TYPE_KEY} and the

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -772,7 +772,7 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
     /**
      * Send signal to finalize the bootstrap process and finish joining the ring.
      */
-    public void finalizeBootstrap();
+    public void finishBootstrap();
 
     /**
      * Retrieve a set of unique errors. every error is represented as a map from an attribute name to a value.

--- a/test/unit/com/palantir/cassandra/concurrent/ConditionAwaiterTest.java
+++ b/test/unit/com/palantir/cassandra/concurrent/ConditionAwaiterTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.concurrent;
+
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ConditionAwaiterTest
+{
+    @Test
+    public void testBootstrapManager() throws ConfigurationException, InterruptedException
+    {
+        final ConditionAwaiter guard = new ConditionAwaiter(false);
+        Thread awaitSignalThread = new Thread(guard::await);
+        Thread triggerSignalThread = new Thread(guard::proceed);
+
+        awaitSignalThread.start();
+        waitUntilNotState(awaitSignalThread, Thread.State.RUNNABLE);
+        assertEquals(Thread.State.WAITING, awaitSignalThread.getState());
+
+        triggerSignalThread.start();
+        waitUntilNotState(awaitSignalThread, Thread.State.WAITING);
+        assertTrue(awaitSignalThread.getState() == Thread.State.RUNNABLE || awaitSignalThread.getState() == Thread.State.TERMINATED);
+    }
+
+    private void waitUntilNotState(Thread thread, Thread.State state) throws InterruptedException
+    {
+        while(thread.getState() == state) {
+            Thread.sleep(100);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
@@ -193,29 +193,6 @@ public class StorageServiceServerTest
     }
 
     @Test
-    public void testBootstrapManager() throws ConfigurationException, InterruptedException
-    {
-        final StorageService.BootstrapManager bootstrapManager = new StorageService.BootstrapManager();
-        Thread awaitSignalThread = new Thread(bootstrapManager::awaitBootstrappable);
-        Thread allowBootstrapThread = new Thread(bootstrapManager::allowToBootstrap);
-
-        awaitSignalThread.start();
-        waitUntilNotState(awaitSignalThread, Thread.State.RUNNABLE);
-        assertEquals(Thread.State.WAITING, awaitSignalThread.getState());
-
-        allowBootstrapThread.start();
-        waitUntilNotState(awaitSignalThread, Thread.State.WAITING);
-        assertTrue(awaitSignalThread.getState() == Thread.State.RUNNABLE || awaitSignalThread.getState() == Thread.State.TERMINATED);
-    }
-
-    private void waitUntilNotState(Thread thread, Thread.State state) throws InterruptedException
-    {
-        while(thread.getState() == state) {
-            Thread.sleep(100);
-        }
-    }
-
-    @Test
     public void testGetAllRangesEmpty()
     {
         List<Token> toks = Collections.emptyList();


### PR DESCRIPTION
Currently, when a node finishes bootstrapping, it immediately joins the token ring and begins serving requests. This PR adds a new config flag `palantir_cassandra.disable_wait_to_finish_bootstrap`. Unless this flag is set, bootstrapping node will _not_ join the ring. In order for this node to join the ring, an operator must call `StorageService.finishBootstrap` via JMX.