### PR TITLE
Avoid ByteBuffer copy when computing serialized size for rangeScanBytesRead metric

### DIFF
--- a/src/java/org/apache/cassandra/db/AbstractNativeCell.java
+++ b/src/java/org/apache/cassandra/db/AbstractNativeCell.java
@@ -428,7 +428,6 @@ public abstract class AbstractNativeCell extends AbstractCell implements CellNam
     @Override
     public int serializedSize()
     {
-        int serializedSize = 0;
         switch (nametype())
         {
             case SIMPLE_DENSE:
@@ -439,12 +438,12 @@ public abstract class AbstractNativeCell extends AbstractCell implements CellNam
             case COMPOUND_SPARSE:
                 // This is the legacy format of composites.
                 // See org.apache.cassandra.db.marshal.CompositeType for details.
-                if (isStatic())
-                    serializedSize += Short.BYTES;
-
-                for (int i = 0; i < size(); i++)
+                int size = size();
+                int serializedSize = 0;
+                serializedSize += (isStatic() ? Short.BYTES : 0) + ((Short.BYTES + 1) * size);
+                for (int i = 0; i < size; i++)
                 {
-                    serializedSize += Short.BYTES + get(i).remaining() + 1;
+                    serializedSize += get(i).remaining();
                 }
                 return serializedSize;
             default:

--- a/src/java/org/apache/cassandra/db/AbstractNativeCell.java
+++ b/src/java/org/apache/cassandra/db/AbstractNativeCell.java
@@ -428,27 +428,7 @@ public abstract class AbstractNativeCell extends AbstractCell implements CellNam
     @Override
     public int serializedSize()
     {
-        switch (nametype())
-        {
-            case SIMPLE_DENSE:
-            case SIMPLE_SPARSE:
-                return get(0).remaining();
-            case COMPOUND_DENSE:
-            case COMPOUND_SPARSE_STATIC:
-            case COMPOUND_SPARSE:
-                // This is the legacy format of composites.
-                // See org.apache.cassandra.db.marshal.CompositeType for details.
-                int size = size();
-                int serializedSize = 0;
-                serializedSize += (isStatic() ? Short.BYTES : 0) + ((Short.BYTES + 1) * size);
-                for (int i = 0; i < size; i++)
-                {
-                    serializedSize += get(i).remaining();
-                }
-                return serializedSize;
-            default:
-                throw new AssertionError();
-        }
+        return valueStartOffset() - nameDeltaOffset(size());
     }
 
     protected void updateWithName(MessageDigest digest)

--- a/src/java/org/apache/cassandra/db/AbstractNativeCell.java
+++ b/src/java/org/apache/cassandra/db/AbstractNativeCell.java
@@ -425,6 +425,33 @@ public abstract class AbstractNativeCell extends AbstractCell implements CellNam
         }
     }
 
+    @Override
+    public int serializedSize()
+    {
+        int serializedSize = 0;
+        switch (nametype())
+        {
+            case SIMPLE_DENSE:
+            case SIMPLE_SPARSE:
+                return get(0).remaining();
+            case COMPOUND_DENSE:
+            case COMPOUND_SPARSE_STATIC:
+            case COMPOUND_SPARSE:
+                // This is the legacy format of composites.
+                // See org.apache.cassandra.db.marshal.CompositeType for details.
+                if (isStatic())
+                    serializedSize += Short.BYTES;
+
+                for (int i = 0; i < size(); i++)
+                {
+                    serializedSize += Short.BYTES + get(i).remaining() + 1;
+                }
+                return serializedSize;
+            default:
+                throw new AssertionError();
+        }
+    }
+
     protected void updateWithName(MessageDigest digest)
     {
         // for simple sparse we just return our one name buffer

--- a/src/java/org/apache/cassandra/db/AbstractNativeCell.java
+++ b/src/java/org/apache/cassandra/db/AbstractNativeCell.java
@@ -425,16 +425,6 @@ public abstract class AbstractNativeCell extends AbstractCell implements CellNam
         }
     }
 
-    private int serializedCompoundSize()
-    {
-        int size = (isStatic() ? Short.BYTES : 0);
-        for (int i = 0; i < size(); i++)
-        {
-            size += Short.BYTES + get(i).remaining() + 1;
-        }
-        return size;
-    }
-
     @Override
     public int serializedSize()
     {
@@ -448,10 +438,20 @@ public abstract class AbstractNativeCell extends AbstractCell implements CellNam
             case COMPOUND_SPARSE:
                 // This is the legacy format of composites.
                 // See org.apache.cassandra.db.marshal.CompositeType for details.
-                return assertSerializedSize(serializedCompoundSize(), nametype());
+                return assertSerializedSize(compoundSerializedSize(), nametype());
             default:
-                throw new AssertionError();
+                throw new AssertionError("Invalid nametype: " + nametype());
         }
+    }
+
+    private int compoundSerializedSize()
+    {
+        int size = (isStatic() ? Short.BYTES : 0);
+        for (int i = 0; i < size(); i++)
+        {
+            size += Short.BYTES + get(i).remaining() + 1;
+        }
+        return size;
     }
 
     protected void updateWithName(MessageDigest digest)

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -2614,7 +2614,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
                 }
 
                 Row row = new Row(rawRow.key, data);
-                metric.rangeScanBytesRead.mark(Row.serializer.serializedSize(row, MessagingService.current_version));
+                long serializedSize = Row.serializer.serializedSize(row, MessagingService.current_version);
+                metric.rangeScanBytesRead.mark(serializedSize);
                 rows.add(row);
 
                 if (!ignoreTombstonedPartitions || !data.hasOnlyTombstones(filter.timestamp))

--- a/src/java/org/apache/cassandra/db/composites/AbstractCType.java
+++ b/src/java/org/apache/cassandra/db/composites/AbstractCType.java
@@ -385,8 +385,18 @@ public abstract class AbstractCType implements CType
         public long serializedSize(Composite c, TypeSizes type)
         {
             // Avoiding conversion to ByteBuffer just to compute serialized size
-            int serializedSize = c.serializedSize();
-            return type.sizeof((short) serializedSize) + serializedSize;
+            int compositeSerializedSize = c.serializedSize();
+            short shortCompositeSerializedSize = (short) compositeSerializedSize;
+            int typeSerializedSize = type.sizeof(shortCompositeSerializedSize);
+            int serializedSize = typeSerializedSize + compositeSerializedSize;
+
+            int expectedSerializedSize;
+            assert (expectedSerializedSize = type.sizeofWithShortLength(c.toByteBuffer())) == serializedSize
+                    : "Serialized size mismatch, expected: " + expectedSerializedSize
+                    + ", actual: " + serializedSize
+                    + ", type: " + type.getClass().getCanonicalName() + " = " + typeSerializedSize
+                    + ", composite: " + c.getClass().getCanonicalName() + " = " + compositeSerializedSize;
+            return serializedSize;
         }
 
         public void skip(DataInput in) throws IOException

--- a/src/java/org/apache/cassandra/db/composites/AbstractCType.java
+++ b/src/java/org/apache/cassandra/db/composites/AbstractCType.java
@@ -386,7 +386,7 @@ public abstract class AbstractCType implements CType
         {
             // Avoiding conversion to ByteBuffer just to compute serialized size
             int serializedSize = c.serializedSize();
-            return type.sizeof((short)serializedSize) + serializedSize;
+            return type.sizeof((short) serializedSize) + serializedSize;
         }
 
         public void skip(DataInput in) throws IOException

--- a/src/java/org/apache/cassandra/db/composites/AbstractCType.java
+++ b/src/java/org/apache/cassandra/db/composites/AbstractCType.java
@@ -384,7 +384,9 @@ public abstract class AbstractCType implements CType
 
         public long serializedSize(Composite c, TypeSizes type)
         {
-            return type.sizeofWithShortLength(c.toByteBuffer());
+            // Avoiding conversion to ByteBuffer just to compute serialized size
+            int serializedSize = c.serializedSize();
+            return type.sizeof((short)serializedSize) + serializedSize;
         }
 
         public void skip(DataInput in) throws IOException

--- a/src/java/org/apache/cassandra/db/composites/AbstractCType.java
+++ b/src/java/org/apache/cassandra/db/composites/AbstractCType.java
@@ -389,13 +389,13 @@ public abstract class AbstractCType implements CType
             short shortCompositeSerializedSize = (short) compositeSerializedSize;
             int typeSerializedSize = type.sizeof(shortCompositeSerializedSize);
             int serializedSize = typeSerializedSize + compositeSerializedSize;
-
             int expectedSerializedSize;
             assert (expectedSerializedSize = type.sizeofWithShortLength(c.toByteBuffer())) == serializedSize
                     : "Serialized size mismatch, expected: " + expectedSerializedSize
                     + ", actual: " + serializedSize
-                    + ", type: " + type.getClass().getCanonicalName() + " = " + typeSerializedSize
-                    + ", composite: " + c.getClass().getCanonicalName() + " = " + compositeSerializedSize;
+                    + ", length bytes prefix: " + shortCompositeSerializedSize
+                    + ", composite: " + c.getClass().getCanonicalName() + " = " + compositeSerializedSize
+                    + ", type: " + type.getClass().getCanonicalName() + " = " + typeSerializedSize;
             return serializedSize;
         }
 

--- a/src/java/org/apache/cassandra/db/composites/AbstractCType.java
+++ b/src/java/org/apache/cassandra/db/composites/AbstractCType.java
@@ -385,17 +385,27 @@ public abstract class AbstractCType implements CType
         public long serializedSize(Composite c, TypeSizes type)
         {
             // Avoiding conversion to ByteBuffer just to compute serialized size
-            int compositeSerializedSize = c.serializedSize();
-            short shortCompositeSerializedSize = (short) compositeSerializedSize;
-            int typeSerializedSize = type.sizeof(shortCompositeSerializedSize);
+            return assertSizeofWithShortLength(c, type, c.serializedSize());
+        }
+
+        private int assertSizeofWithShortLength(Composite c, TypeSizes type, int compositeSerializedSize)
+        {
+            int typeSerializedSize = type.sizeof((short) compositeSerializedSize);
             int serializedSize = typeSerializedSize + compositeSerializedSize;
-            int expectedSerializedSize;
-            assert (expectedSerializedSize = type.sizeofWithShortLength(c.toByteBuffer())) == serializedSize
-                    : "Serialized size mismatch, expected: " + expectedSerializedSize
-                    + ", actual: " + serializedSize
-                    + ", length bytes prefix: " + shortCompositeSerializedSize
-                    + ", composite: " + c.getClass().getCanonicalName() + " = " + compositeSerializedSize
-                    + ", type: " + type.getClass().getCanonicalName() + " = " + typeSerializedSize;
+            if (getClass().desiredAssertionStatus())
+            {
+                // only perform expensive `toByteBuffer()` when assertions enabled for testing
+                int expectedSerializedSize = type.sizeofWithShortLength(c.toByteBuffer());
+                if (serializedSize != expectedSerializedSize)
+                {
+                    throw new AssertionError("Serialized size mismatch, expected: " + expectedSerializedSize
+                                             + ", actual: " + serializedSize
+                                             + ", length bytes prefix: " + (short) typeSerializedSize
+                                             + ", type: " + type.getClass().getCanonicalName() + " = " + typeSerializedSize
+                                             + ", composite: " + c.getClass().getCanonicalName() + " = " + compositeSerializedSize
+                    );
+                }
+            }
             return serializedSize;
         }
 

--- a/src/java/org/apache/cassandra/db/composites/AbstractComposite.java
+++ b/src/java/org/apache/cassandra/db/composites/AbstractComposite.java
@@ -88,6 +88,21 @@ public abstract class AbstractComposite implements Composite
         return result;
     }
 
+    @Override
+    public int serializedSize()
+    {
+        int serializedSize = 0;
+        if (isStatic())
+        {
+            serializedSize += Short.BYTES;
+        }
+        for (int i = 0; i < size(); i++)
+        {
+            serializedSize += Short.BYTES + get(i).remaining() + 1;
+        }
+        return serializedSize;
+    }
+
     public int dataSize()
     {
         int size = 0;

--- a/src/java/org/apache/cassandra/db/composites/AbstractComposite.java
+++ b/src/java/org/apache/cassandra/db/composites/AbstractComposite.java
@@ -73,7 +73,7 @@ public abstract class AbstractComposite implements Composite
     {
         // This is the legacy format of composites.
         // See org.apache.cassandra.db.marshal.CompositeType for details.
-        ByteBuffer result = ByteBuffer.allocate(dataSize() + 3 * size() + (isStatic() ? 2 : 0));
+        ByteBuffer result = ByteBuffer.allocate(serializedSize());
         if (isStatic())
             ByteBufferUtil.writeShortLength(result, CompositeType.STATIC_MARKER);
 
@@ -91,16 +91,7 @@ public abstract class AbstractComposite implements Composite
     @Override
     public int serializedSize()
     {
-        int serializedSize = 0;
-        if (isStatic())
-        {
-            serializedSize += Short.BYTES;
-        }
-        for (int i = 0; i < size(); i++)
-        {
-            serializedSize += Short.BYTES + get(i).remaining() + 1;
-        }
-        return serializedSize;
+        return dataSize() + ((Short.BYTES + 1) * size()) + (isStatic() ? Short.BYTES : 0);
     }
 
     public int dataSize()

--- a/src/java/org/apache/cassandra/db/composites/AbstractComposite.java
+++ b/src/java/org/apache/cassandra/db/composites/AbstractComposite.java
@@ -85,9 +85,6 @@ public abstract class AbstractComposite implements Composite
             result.put(bb.duplicate());
             result.put((byte)0);
         }
-        assert result.remaining() == 0 : "Remaining should be 0, was: " + result.remaining()
-                + ", position: " + result.position()
-                + ", limit: " + result.limit();
         result.flip();
         return result;
     }

--- a/src/java/org/apache/cassandra/db/composites/AbstractComposite.java
+++ b/src/java/org/apache/cassandra/db/composites/AbstractComposite.java
@@ -73,7 +73,8 @@ public abstract class AbstractComposite implements Composite
     {
         // This is the legacy format of composites.
         // See org.apache.cassandra.db.marshal.CompositeType for details.
-        ByteBuffer result = ByteBuffer.allocate(serializedSize());
+        int serializedSize = defaultCompositeSerializedSize();
+        ByteBuffer result = ByteBuffer.allocate(serializedSize);
         if (isStatic())
             ByteBufferUtil.writeShortLength(result, CompositeType.STATIC_MARKER);
 
@@ -91,7 +92,11 @@ public abstract class AbstractComposite implements Composite
     @Override
     public int serializedSize()
     {
-        return dataSize() + ((Short.BYTES + 1) * size()) + (isStatic() ? Short.BYTES : 0);
+        return defaultCompositeSerializedSize();
+    }
+
+    private int defaultCompositeSerializedSize() {
+        return (isStatic() ? Short.BYTES : 0) + dataSize() + ((Short.BYTES + 1) * size());
     }
 
     public int dataSize()

--- a/src/java/org/apache/cassandra/db/composites/AbstractComposite.java
+++ b/src/java/org/apache/cassandra/db/composites/AbstractComposite.java
@@ -98,7 +98,7 @@ public abstract class AbstractComposite implements Composite
         return defaultCompositeSerializedSize();
     }
 
-    private int defaultCompositeSerializedSize() {
+    protected int defaultCompositeSerializedSize() {
         return (isStatic() ? Short.BYTES : 0) + dataSize() + ((Short.BYTES + 1) * size());
     }
 

--- a/src/java/org/apache/cassandra/db/composites/AbstractComposite.java
+++ b/src/java/org/apache/cassandra/db/composites/AbstractComposite.java
@@ -85,6 +85,9 @@ public abstract class AbstractComposite implements Composite
             result.put(bb.duplicate());
             result.put((byte)0);
         }
+        assert result.remaining() == 0 : "Remaining should be 0, was: " + result.remaining()
+                + ", position: " + result.position()
+                + ", limit: " + result.limit();
         result.flip();
         return result;
     }

--- a/src/java/org/apache/cassandra/db/composites/BoundedComposite.java
+++ b/src/java/org/apache/cassandra/db/composites/BoundedComposite.java
@@ -94,7 +94,11 @@ public class BoundedComposite extends AbstractComposite
 
     @Override
     public int serializedSize() {
-        return wrapped.dataSize();
+        int serializedSize = wrapped.serializedSize();
+        int expectedSerializedSize;
+        assert serializedSize == (expectedSerializedSize = toByteBuffer().remaining()) :
+                getClass().getCanonicalName() + " expected serialized size: " + expectedSerializedSize + " actual: " + serializedSize;
+        return serializedSize;
     }
 
     public long unsharedHeapSize()

--- a/src/java/org/apache/cassandra/db/composites/BoundedComposite.java
+++ b/src/java/org/apache/cassandra/db/composites/BoundedComposite.java
@@ -92,6 +92,11 @@ public class BoundedComposite extends AbstractComposite
         return bb;
     }
 
+    @Override
+    public int serializedSize() {
+        return wrapped.serializedSize();
+    }
+
     public long unsharedHeapSize()
     {
         return EMPTY_SIZE + wrapped.unsharedHeapSize();

--- a/src/java/org/apache/cassandra/db/composites/BoundedComposite.java
+++ b/src/java/org/apache/cassandra/db/composites/BoundedComposite.java
@@ -94,7 +94,7 @@ public class BoundedComposite extends AbstractComposite
 
     @Override
     public int serializedSize() {
-        return wrapped.serializedSize();
+        return wrapped.dataSize();
     }
 
     public long unsharedHeapSize()

--- a/src/java/org/apache/cassandra/db/composites/BoundedComposite.java
+++ b/src/java/org/apache/cassandra/db/composites/BoundedComposite.java
@@ -94,11 +94,7 @@ public class BoundedComposite extends AbstractComposite
 
     @Override
     public int serializedSize() {
-        int serializedSize = wrapped.serializedSize();
-        int expectedSerializedSize;
-        assert serializedSize == (expectedSerializedSize = toByteBuffer().remaining()) :
-                getClass().getCanonicalName() + " expected serialized size: " + expectedSerializedSize + " actual: " + serializedSize;
-        return serializedSize;
+        return assertSerializedSize(wrapped.serializedSize(), wrapped.getClass().getCanonicalName());
     }
 
     public long unsharedHeapSize()

--- a/src/java/org/apache/cassandra/db/composites/Composite.java
+++ b/src/java/org/apache/cassandra/db/composites/Composite.java
@@ -73,7 +73,10 @@ public interface Composite extends IMeasurableMemory
 
     public ByteBuffer toByteBuffer();
 
-    public int serializedSize();
+    default public int serializedSize() {
+        // expensive fallback, subtypes should ideally override to avoid allocations
+        return toByteBuffer().remaining();
+    }
 
     public int dataSize();
     public Composite copy(CFMetaData cfm, AbstractAllocator allocator);

--- a/src/java/org/apache/cassandra/db/composites/Composite.java
+++ b/src/java/org/apache/cassandra/db/composites/Composite.java
@@ -73,6 +73,8 @@ public interface Composite extends IMeasurableMemory
 
     public ByteBuffer toByteBuffer();
 
+    public int serializedSize();
+
     public int dataSize();
     public Composite copy(CFMetaData cfm, AbstractAllocator allocator);
 }

--- a/src/java/org/apache/cassandra/db/composites/Composite.java
+++ b/src/java/org/apache/cassandra/db/composites/Composite.java
@@ -78,6 +78,16 @@ public interface Composite extends IMeasurableMemory
         int serializedSize = toByteBuffer().remaining();
         assert false : getClass().getCanonicalName()
                 + " fallback to expensive toByteBuffer().remaining() serializedSize: " + serializedSize;
+        return assertSerializedSize(serializedSize, "");
+    }
+
+    default int assertSerializedSize(int serializedSize, Object context)
+    {
+        int expectedSerializedSize;
+        assert serializedSize == (expectedSerializedSize = toByteBuffer().remaining())
+        : getClass().getCanonicalName() + " expected serialized size: " + expectedSerializedSize
+          + " for " + context
+          + ", actual: " + serializedSize;
         return serializedSize;
     }
 

--- a/src/java/org/apache/cassandra/db/composites/Composite.java
+++ b/src/java/org/apache/cassandra/db/composites/Composite.java
@@ -73,21 +73,32 @@ public interface Composite extends IMeasurableMemory
 
     public ByteBuffer toByteBuffer();
 
-    default public int serializedSize() {
+    default int serializedSize()
+    {
         // expensive fallback, subtypes should ideally override to avoid allocations
         int serializedSize = toByteBuffer().remaining();
-        assert false : getClass().getCanonicalName()
-                + " fallback to expensive toByteBuffer().remaining() serializedSize: " + serializedSize;
-        return assertSerializedSize(serializedSize, "");
+        if (getClass().desiredAssertionStatus())
+        {
+            throw new AssertionError(getClass().getCanonicalName()
+                                     + " fallback to expensive toByteBuffer().remaining() serializedSize: "
+                                     + serializedSize);
+        }
+        return assertSerializedSize(serializedSize, "base composite");
     }
 
     default int assertSerializedSize(int serializedSize, Object context)
     {
-        int expectedSerializedSize;
-        assert serializedSize == (expectedSerializedSize = toByteBuffer().remaining())
-        : getClass().getCanonicalName() + " expected serialized size: " + expectedSerializedSize
-          + " for " + context
-          + ", actual: " + serializedSize;
+        if (getClass().desiredAssertionStatus())
+        {
+            // only perform expensive `toByteBuffer()` when assertions enabled for testing
+            int expectedSerializedSize = toByteBuffer().remaining();
+            if (serializedSize != expectedSerializedSize)
+            {
+                throw new AssertionError(getClass().getCanonicalName()
+                                         + " expected serialized size: " + expectedSerializedSize
+                                         + " for " + context + ", actual: " + serializedSize);
+            }
+        }
         return serializedSize;
     }
 

--- a/src/java/org/apache/cassandra/db/composites/Composite.java
+++ b/src/java/org/apache/cassandra/db/composites/Composite.java
@@ -75,7 +75,10 @@ public interface Composite extends IMeasurableMemory
 
     default public int serializedSize() {
         // expensive fallback, subtypes should ideally override to avoid allocations
-        return toByteBuffer().remaining();
+        int serializedSize = toByteBuffer().remaining();
+        assert false : getClass().getCanonicalName()
+                + " fallback to expensive toByteBuffer().remaining() serializedSize: " + serializedSize;
+        return serializedSize;
     }
 
     public int dataSize();

--- a/src/java/org/apache/cassandra/db/composites/Composites.java
+++ b/src/java/org/apache/cassandra/db/composites/Composites.java
@@ -122,6 +122,12 @@ public abstract class Composites
             return ByteBufferUtil.EMPTY_BYTE_BUFFER;
         }
 
+        @Override
+        public int serializedSize()
+        {
+            return 0;
+        }
+
         public boolean isStatic()
         {
             return false;

--- a/src/java/org/apache/cassandra/db/composites/Composites.java
+++ b/src/java/org/apache/cassandra/db/composites/Composites.java
@@ -122,6 +122,11 @@ public abstract class Composites
             return ByteBufferUtil.EMPTY_BYTE_BUFFER;
         }
 
+        @Override
+        public int serializedSize() {
+            return 0;
+        }
+
         public boolean isStatic()
         {
             return false;

--- a/src/java/org/apache/cassandra/db/composites/Composites.java
+++ b/src/java/org/apache/cassandra/db/composites/Composites.java
@@ -122,12 +122,6 @@ public abstract class Composites
             return ByteBufferUtil.EMPTY_BYTE_BUFFER;
         }
 
-        @Override
-        public int serializedSize()
-        {
-            return 0;
-        }
-
         public boolean isStatic()
         {
             return false;

--- a/src/java/org/apache/cassandra/db/composites/SimpleComposite.java
+++ b/src/java/org/apache/cassandra/db/composites/SimpleComposite.java
@@ -69,7 +69,11 @@ public class SimpleComposite extends AbstractComposite
 
     @Override
     public int serializedSize() {
-        return dataSize();
+        int serializedSize = dataSize();
+        int expectedSerializedSize;
+        assert serializedSize == (expectedSerializedSize = toByteBuffer().remaining()) :
+                getClass().getCanonicalName() + " expected serialized size: " + expectedSerializedSize + " actual: " + serializedSize;
+        return serializedSize;
     }
 
     public long unsharedHeapSize()

--- a/src/java/org/apache/cassandra/db/composites/SimpleComposite.java
+++ b/src/java/org/apache/cassandra/db/composites/SimpleComposite.java
@@ -67,6 +67,11 @@ public class SimpleComposite extends AbstractComposite
         return element;
     }
 
+    @Override
+    public int serializedSize() {
+        return dataSize();
+    }
+
     public long unsharedHeapSize()
     {
         return EMPTY_SIZE + ObjectSizes.sizeOnHeapOf(element);

--- a/src/java/org/apache/cassandra/db/composites/SimpleComposite.java
+++ b/src/java/org/apache/cassandra/db/composites/SimpleComposite.java
@@ -69,11 +69,7 @@ public class SimpleComposite extends AbstractComposite
 
     @Override
     public int serializedSize() {
-        int serializedSize = dataSize();
-        int expectedSerializedSize;
-        assert serializedSize == (expectedSerializedSize = toByteBuffer().remaining()) :
-                getClass().getCanonicalName() + " expected serialized size: " + expectedSerializedSize + " actual: " + serializedSize;
-        return serializedSize;
+        return assertSerializedSize(element.remaining(), "simple composite");
     }
 
     public long unsharedHeapSize()

--- a/src/java/org/apache/cassandra/db/composites/SimpleSparseCellName.java
+++ b/src/java/org/apache/cassandra/db/composites/SimpleSparseCellName.java
@@ -64,11 +64,7 @@ public class SimpleSparseCellName extends AbstractComposite implements CellName
 
     @Override
     public int serializedSize() {
-        int serializedSize = dataSize();
-        int expectedSerializedSize;
-        assert serializedSize == (expectedSerializedSize = toByteBuffer().remaining()) :
-                getClass().getCanonicalName() + " expected serialized size: " + expectedSerializedSize + " actual: " + serializedSize;
-        return serializedSize;
+        return assertSerializedSize(columnName.bytes.remaining(), "simple sparse cell name");
     }
 
     public int clusteringSize()

--- a/src/java/org/apache/cassandra/db/composites/SimpleSparseCellName.java
+++ b/src/java/org/apache/cassandra/db/composites/SimpleSparseCellName.java
@@ -64,7 +64,11 @@ public class SimpleSparseCellName extends AbstractComposite implements CellName
 
     @Override
     public int serializedSize() {
-        return dataSize();
+        int serializedSize = dataSize();
+        int expectedSerializedSize;
+        assert serializedSize == (expectedSerializedSize = toByteBuffer().remaining()) :
+                getClass().getCanonicalName() + " expected serialized size: " + expectedSerializedSize + " actual: " + serializedSize;
+        return serializedSize;
     }
 
     public int clusteringSize()

--- a/src/java/org/apache/cassandra/db/composites/SimpleSparseCellName.java
+++ b/src/java/org/apache/cassandra/db/composites/SimpleSparseCellName.java
@@ -62,6 +62,11 @@ public class SimpleSparseCellName extends AbstractComposite implements CellName
         return columnName.bytes;
     }
 
+    @Override
+    public int serializedSize() {
+        return dataSize();
+    }
+
     public int clusteringSize()
     {
         return 0;


### PR DESCRIPTION
While reviewing some JFR profiles, I noticed that as part of computing the serialized size of composites for `rangeScanBytesRead` metrics, it is allocating new `ByteBuffer`. This is very expensive unnecessary allocation and causes significant GC pressure. We should consider allocation-free serialized size computation. 

https://github.com/palantir/cassandra/blob/aad2368b01e601c87020092d7cda87720dd4cd34/src/java/org/apache/cassandra/db/ColumnFamilyStore.java#L2569

https://github.com/palantir/cassandra/blob/aad2368b01e601c87020092d7cda87720dd4cd34/src/java/org/apache/cassandra/db/composites/AbstractCType.java#L387

![image](https://github.com/palantir/cassandra/assets/54594/02e5158b-1314-4b49-8e89-88c50fdffe3d)
