### PR TITLE
CASSANDRA-18632: track completed streams in StreamManager and report in nodetool netstats

### DIFF
--- a/src/java/org/apache/cassandra/streaming/StreamManagerMBean.java
+++ b/src/java/org/apache/cassandra/streaming/StreamManagerMBean.java
@@ -29,4 +29,14 @@ public interface StreamManagerMBean extends NotificationEmitter
      * Returns the current state of all ongoing streams.
      */
     Set<CompositeData> getCurrentStreams();
+
+    /**
+     * Returns the current state of all completed streams.
+     */
+    Set<CompositeData> getCompletedStreams();
+
+    /**
+     * Returns the current state of all ongoing and completed streams.
+     */
+    Set<CompositeData> getAllStreams();
 }

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -713,6 +713,17 @@ public class NodeProbe implements AutoCloseable
         }));
     }
 
+    public Set<StreamState> getCompletedStreamStatus()
+    {
+        return Sets.newHashSet(Iterables.transform(streamProxy.getCompletedStreams(), new Function<CompositeData, StreamState>()
+        {
+            public StreamState apply(CompositeData input)
+            {
+                return StreamStateCompositeData.fromCompositeData(input);
+            }
+        }));
+    }
+
     public String getOperationMode()
     {
         return ssProxy.getOperationMode();


### PR DESCRIPTION
This PR adds a separate map in StreamManager to track completed streams, and reports those stream summaries in StreamManagerMBean.getCompletedStreams() and .getAllStreams()

It also adds an option to nodetool netstats to display completed streams alongside the current streams.