### PR TITLE
Add diskused metric representing most full data_file_dir

### DIFF
--- a/src/java/org/apache/cassandra/metrics/StorageMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/StorageMetrics.java
@@ -30,17 +30,20 @@ public class StorageMetrics
 {
     private static final MetricNameFactory factory = new DefaultNameFactory("Storage");
 
+    /* Tracks the most filled data_file_directory */
+    static
+    {
+        Metrics.register(factory.createMetricName("DiskUsed"), new Gauge<Double>()
+        {
+            public Double getValue()
+            {
+                return Directories.getMaxPathToUtilization().getValue();
+            }
+        });
+    }
+
     public static final Counter load = Metrics.counter(factory.createMetricName("Load"));
     public static final Counter exceptions = Metrics.counter(factory.createMetricName("Exceptions"));
     public static final Counter totalHintsInProgress  = Metrics.counter(factory.createMetricName("TotalHintsInProgress"));
     public static final Counter totalHints = Metrics.counter(factory.createMetricName("TotalHints"));
-
-    /* Tracks the most filled data_file_directory */
-    public static final Gauge<Double> diskUsed = Metrics.register(factory.createMetricName("DiskUsed"), new Gauge<Double>()
-    {
-        public Double getValue()
-        {
-            return Directories.getMaxPathToUtilization().getValue();
-        }
-    });
 }

--- a/src/java/org/apache/cassandra/metrics/StorageMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/StorageMetrics.java
@@ -18,6 +18,8 @@
 package org.apache.cassandra.metrics;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import org.apache.cassandra.db.Directories;
 
 import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
 
@@ -32,4 +34,13 @@ public class StorageMetrics
     public static final Counter exceptions = Metrics.counter(factory.createMetricName("Exceptions"));
     public static final Counter totalHintsInProgress  = Metrics.counter(factory.createMetricName("TotalHintsInProgress"));
     public static final Counter totalHints = Metrics.counter(factory.createMetricName("TotalHints"));
+
+    /* Tracks the most filled data_file_directory */
+    public static final Gauge<Double> diskUsed = Metrics.register(factory.createMetricName("DiskUsed"), new Gauge<Double>()
+    {
+        public Double getValue()
+        {
+            return Directories.getMaxPathToUtilization().getValue();
+        }
+    });
 }


### PR DESCRIPTION
Adds DiskUsed to the StorageMetrics metric family. This metric shows the busiest data directory listed in `data_file_directories` as a percentage ranging from 0 to 100.

<img width="1012" alt="Storage#DiskUsed" src="https://github.com/palantir/cassandra/assets/1090035/2a529db5-feec-4a3d-a54e-35da5537d7ba">
