### PR TITLE
Align the libthrift version in build.xml with `lib/`

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -393,7 +393,7 @@
             <exclusion groupId="org.slf4j" artifactId="slf4j-log4j12"/>
           </dependency>
           <dependency groupId="org.yaml" artifactId="snakeyaml" version="2.1"/>
-          <dependency groupId="org.apache.thrift" artifactId="libthrift" version="0.17.0">
+          <dependency groupId="org.apache.thrift" artifactId="libthrift" version="0.9.2">
 	         <exclusion groupId="commons-logging" artifactId="commons-logging"/>
           </dependency>
           <dependency groupId="junit" artifactId="junit" version="4.6" />


### PR DESCRIPTION
This is a safer alternative to #427

When I attempt to resolve published jars and run cassandra from the published classpath, I get errors due to abi breaks in newer libthrift versions.

cc @Sam-Kramer due to https://github.com/palantir/cassandra/pull/381