### PR TITLE
Fail loudly if there's a bootstrap error

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -910,7 +910,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                                         ImmutableMap.of("previousDataFound", "true"));
                 unsafeDisableNode();
                 // leave node in non-transient error state and prevent it from bootstrapping into the cluster
-                throw new BootstrappingSafetyException("Detected data from previous bootstrap, failling.");
+                throw new BootstrappingSafetyException("Detected data from previous bootstrap, failing.");
             }
 
             if (SystemKeyspace.bootstrapInProgress())
@@ -1016,6 +1016,13 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             }
 
             dataAvailable = bootstrap(bootstrapTokens);
+            if (!dataAvailable)
+            {
+                recordNonTransientError(NonTransientError.BOOTSTRAP_ERROR, ImmutableMap.of("streamingFailed", "true"));
+                unsafeDisableNode();
+                // leave node in non-transient error state and prevent it from bootstrapping into the cluster
+                throw new BootstrappingSafetyException("Bootstrap streaming failed.");
+            }
             logger.info("Bootstrap streaming complete. Waiting to finish bootstrap. Not becoming an active ring " +
                         "member. Use JMX (StorageService->finishBootstrap()) to finalize ring joining.");
             try

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1020,7 +1020,6 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             {
                 recordNonTransientError(NonTransientError.BOOTSTRAP_ERROR, ImmutableMap.of("streamingFailed", "true"));
                 unsafeDisableNode();
-                // leave node in non-transient error state and prevent it from bootstrapping into the cluster
                 throw new BootstrappingSafetyException("Bootstrap streaming failed.");
             }
             logger.info("Bootstrap streaming complete. Waiting to finish bootstrap. Not becoming an active ring " +


### PR DESCRIPTION
Currently, if bootstrapping fails, the node won't join the ring. Usually this would emit a warning, but after adding WAITING_TO_FINISH_BOOTSTRAP in #402 and #414, a warning is not emitted.

This PR puts the node in NON_TRANSIENT_ERROR state if bootstrapping fails.