### PR TITLE
compilation target in idea is java8

### DIFF
--- a/ide/idea-iml-file.xml
+++ b/ide/idea-iml-file.xml
@@ -18,7 +18,7 @@
   -->
 
 <module type="JAVA_MODULE" version="4">
-    <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+    <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="false">
         <output url="file://$MODULE_DIR$/.idea/out/main" />
         <output-test url="file://$MODULE_DIR$/.idea/out/test" />
         <exclude-output />


### PR DESCRIPTION
running `ant generate-idea-files` will now produce an .iml file with a compilation target of java 8 (not java 7), which in turn will ensure everything compiles in intellij out of the box...