### PR TITLE
Removed logback dependency from build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -381,8 +381,6 @@
           <dependency groupId="org.slf4j" artifactId="slf4j-api" version="1.7.7"/>
           <dependency groupId="org.slf4j" artifactId="log4j-over-slf4j" version="1.7.7"/>
           <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j" version="1.7.7" />
-          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.1.3"/>
-          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.1.3"/>
           <dependency groupId="org.codehaus.jackson" artifactId="jackson-core-asl" version="1.9.2"/>
           <dependency groupId="org.codehaus.jackson" artifactId="jackson-mapper-asl" version="1.9.2"/>
           <dependency groupId="com.googlecode.json-simple" artifactId="json-simple" version="1.1"/>
@@ -627,9 +625,6 @@
         <dependency groupId="com.thinkaurelius.thrift" artifactId="thrift-server"/>
         <dependency groupId="com.clearspring.analytics" artifactId="stream"/>
         <dependency groupId="net.sf.supercsv" artifactId="super-csv"/>
-
-        <dependency groupId="ch.qos.logback" artifactId="logback-core"/>
-        <dependency groupId="ch.qos.logback" artifactId="logback-classic"/>
 
         <dependency groupId="org.apache.thrift" artifactId="libthrift"/>
         <dependency groupId="org.apache.cassandra" artifactId="cassandra-thrift"/>


### PR DESCRIPTION
In preparation for switching sls-cassandra away from logback onto sls-logging-log4j. Because the logback depependency is declared on cassandra's pom, it's getting pulled into sls-cassandra transitively and we don't want this.