### PR TITLE
Throw if not crashing on oom

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1317,6 +1317,7 @@
         -->
         <jvmarg value="-XX:MaxMetaspaceSize=256M" />
         <jvmarg value="-XX:SoftRefLRUPolicyMSPerMB=0" />
+        <jvmarg value="-XX:+CrashOnOutOfMemoryError" />
         <jvmarg value="-Dcassandra.memtable_row_overhead_computation_step=100"/>
         <jvmarg value="-Dcassandra.test.use_prepared=${cassandra.test.use_prepared}"/>
 	    <jvmarg value="-Dcassandra.test.offsetseed=@{poffset}"/>
@@ -1868,6 +1869,7 @@
       <jvmarg value="-Dcassandra.skip_sync=true" />
       <jvmarg value="-XX:MaxMetaspaceSize=256M" />
       <jvmarg value="-XX:SoftRefLRUPolicyMSPerMB=0" />
+      <jvmarg value="-XX:+CrashOnOutOfMemoryError" />
       <jvmarg value="-XX:+HeapDumpOnOutOfMemoryError" />
       <jvmarg value="-XX:HeapDumpPath=build/test/oom.hprof" />
     </testmacro>

--- a/conf/cassandra-env.ps1
+++ b/conf/cassandra-env.ps1
@@ -396,8 +396,8 @@ Function SetCassandraEnvironment
     # uncomment the preferred option
     # ExitOnOutOfMemoryError and CrashOnOutOfMemoryError require a JRE greater or equals to 1.7 update 101 or 1.8 update 92
     # $env:JVM_OPTS="$env:JVM_OPTS -XX:+ExitOnOutOfMemoryError"
-    # $env:JVM_OPTS="$env:JVM_OPTS -XX:+CrashOnOutOfMemoryError"
-    $env:JVM_OPTS="$env:JVM_OPTS -XX:OnOutOfMemoryError=""taskkill /F /PID %p"""
+    $env:JVM_OPTS="$env:JVM_OPTS -XX:+CrashOnOutOfMemoryError"
+    # $env:JVM_OPTS="$env:JVM_OPTS -XX:OnOutOfMemoryError=""taskkill /F /PID %p"""
 
     # print an heap histogram on OutOfMemoryError
     # $env:JVM_OPTS="$env:JVM_OPTS -Dcassandra.printHeapHistogramOnOutOfMemoryError=true"

--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -210,8 +210,8 @@ startswith() { [ "${1#$2}" != "$1" ]; }
 # on white spaces without taking quotes into account
 # ExitOnOutOfMemoryError and CrashOnOutOfMemoryError require a JRE greater or equals to 1.7 update 101 or 1.8 update 92
 # JVM_OPTS="$JVM_OPTS -XX:+ExitOnOutOfMemoryError"
-# JVM_OPTS="$JVM_OPTS -XX:+CrashOnOutOfMemoryError"
-JVM_ON_OUT_OF_MEMORY_ERROR_OPT="-XX:OnOutOfMemoryError=kill -9 %p"
+JVM_OPTS="$JVM_OPTS -XX:+CrashOnOutOfMemoryError"
+# JVM_ON_OUT_OF_MEMORY_ERROR_OPT="-XX:OnOutOfMemoryError=kill -9 %p"
 
 # print an heap histogram on OutOfMemoryError
 # JVM_OPTS="$JVM_OPTS -Dcassandra.printHeapHistogramOnOutOfMemoryError=true"

--- a/ide/idea/workspace.xml
+++ b/ide/idea/workspace.xml
@@ -168,7 +168,7 @@
       <option name="MAIN_CLASS_NAME" value="" />
       <option name="METHOD_NAME" value="" />
       <option name="TEST_OBJECT" value="class" />
-      <option name="VM_PARAMETERS" value="-Dcassandra.config=file://$PROJECT_DIR$/test/conf/cassandra.yaml -Dlogback.configurationFile=file://$PROJECT_DIR$/test/conf/logback-test.xml -Dcassandra.logdir=$PROJECT_DIR$/build/test/logs -ea -XX:MaxMetaspaceSize=256M -XX:SoftRefLRUPolicyMSPerMB=0" />
+      <option name="VM_PARAMETERS" value="-Dcassandra.config=file://$PROJECT_DIR$/test/conf/cassandra.yaml -Dlogback.configurationFile=file://$PROJECT_DIR$/test/conf/logback-test.xml -Dcassandra.logdir=$PROJECT_DIR$/build/test/logs -ea -XX:MaxMetaspaceSize=256M -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CrashOnOutOfMemoryError" />
       <option name="PARAMETERS" value="" />
       <option name="WORKING_DIRECTORY" value="" />
       <option name="ENV_VARIABLES" />

--- a/src/java/org/apache/cassandra/service/StartupChecks.java
+++ b/src/java/org/apache/cassandra/service/StartupChecks.java
@@ -164,7 +164,7 @@ public class StartupChecks
 
     public static final StartupCheck inspectJvmOptions = new StartupCheck()
     {
-        public void execute()
+        public void execute() throws StartupException
         {
             // log warnings for different kinds of sub-optimal JVMs.  tldr use 64-bit Oracle >= 1.6u32
             if (!DatabaseDescriptor.hasLargeAddressSpace())
@@ -191,19 +191,19 @@ public class StartupChecks
         /**
          * Checks that the JVM is configured to handle OutOfMemoryError
          */
-        private void checkOutOfMemoryHandling()
+        private void checkOutOfMemoryHandling() throws StartupException
         {
             if (JavaUtils.supportExitOnOutOfMemory(System.getProperty("java.version")))
             {
                 if (!jvmOptionsContainsOneOf("-XX:OnOutOfMemoryError=", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError"))
-                    logger.warn("The JVM is not configured to stop on OutOfMemoryError which can cause data corruption."
+                    throw new StartupException(1, "The JVM is not configured to stop on OutOfMemoryError which can cause data corruption."
                                 + " Use one of the following JVM options to configure the behavior on OutOfMemoryError: "
                                 + " -XX:+ExitOnOutOfMemoryError, -XX:+CrashOnOutOfMemoryError, or -XX:OnOutOfMemoryError=\"<cmd args>;<cmd args>\"");
             }
             else
             {
                 if (!jvmOptionsContainsOneOf("-XX:OnOutOfMemoryError="))
-                    logger.warn("The JVM is not configured to stop on OutOfMemoryError which can cause data corruption."
+                    throw new StartupException(1, "The JVM is not configured to stop on OutOfMemoryError which can cause data corruption."
                             + " Either upgrade your JRE to a version greater or equal to 8u92 and use -XX:+ExitOnOutOfMemoryError/-XX:+CrashOnOutOfMemoryError"
                             + " or use -XX:OnOutOfMemoryError=\"<cmd args>;<cmd args>\" on your current JRE.");
             }

--- a/src/java/org/apache/cassandra/service/StartupChecks.java
+++ b/src/java/org/apache/cassandra/service/StartupChecks.java
@@ -176,6 +176,7 @@ public class StartupChecks
                 // There is essentially no QA done on OpenJDK builds, and
                 // clusters running OpenJDK have seen many heap and load issues.
                 logger.warn("OpenJDK is not recommended. Please upgrade to the newest Oracle Java release");
+                checkOutOfMemoryHandling();
             }
             else if (!javaVmName.contains("HotSpot"))
             {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSANDRA-13006

In cassandra.in.sh we assert that we're running with at least java 17. We should rely on the JVM's CrashOnOutOfMemoryError rather than kill -9'ing the C* process, which means we should get the hs_err.pid files and heap histograms on ooms we were not getting previously.

Also, we can be more opinionated than mainline and throw if C* is not configured to crash on oom to prevent corruption, rather than just logging a warn.