### PR TITLE
Refresh cache on InvalidMutation

### DIFF
--- a/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
+++ b/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
@@ -73,13 +73,19 @@ public class MutationVerificationUtils
             if (mutationIsInvalid(naturalEndpoints, pendingEndpoints))
             {
                 keyspace.metric.invalidMutations.inc();
-                logger.error("Cannot apply mutation as this host {} does not contain key {} in keyspace {}. Only hosts {} and {} do.",
+                logger.error("InvalidMutation! Cannot apply mutation as this host {} does not contain key {} in keyspace {}. Only hosts {} and {} do.",
                         FBUtilities.getBroadcastAddress(),
                         Hex.bytesToHex(mutation.key().array()),
                         mutation.getKeyspaceName(),
                         naturalEndpoints,
                         pendingEndpoints);
-                throw new RuntimeException("Cannot apply mutation as this host does not contain key.");
+                throw new RuntimeException("InvalidMutation! Cannot apply mutation as this host does not contain key.");
+            }
+            else
+            {
+                logger.warn("Ignoring InvalidMutation error detected using stale token ring cache. Error was originally detected for key {} in keyspace {}.",
+                        Hex.bytesToHex(mutation.key().array()),
+                        mutation.getKeyspaceName());
             }
 
             keyspace.metric.validMutations.inc();

--- a/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
+++ b/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
@@ -56,8 +56,6 @@ public class MutationVerificationUtils
         if (keyspace.getReplicationStrategy() instanceof NetworkTopologyStrategy)
         {
             Token tk = StorageService.getPartitioner().getToken(mutation.key());
-
-
             List<InetAddress> naturalEndpoints = StorageService.instance.getNaturalEndpoints(mutation.getKeyspaceName(), tk);
             Collection<InetAddress> pendingEndpoints = StorageService.instance.getTokenMetadata().pendingEndpointsFor(tk, mutation.getKeyspaceName());
 

--- a/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
+++ b/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
@@ -74,9 +74,10 @@ public class MutationVerificationUtils
             if (mutationIsInvalid(naturalEndpoints, pendingEndpoints))
             {
                 keyspace.metric.invalidMutations.inc();
-                logger.error("Cannot apply mutation as this host {} does not contain key {}. Only hosts {} and {} do.",
+                logger.error("Cannot apply mutation as this host {} does not contain key {} in keyspace {}. Only hosts {} and {} do.",
                         FBUtilities.getBroadcastAddress(),
                         Hex.bytesToHex(mutation.key().array()),
+                        mutation.getKeyspaceName(),
                         naturalEndpoints,
                         pendingEndpoints);
                 throw new RuntimeException("Cannot apply mutation as this host does not contain key.");

--- a/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
+++ b/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
@@ -18,6 +18,12 @@
 
 package com.palantir.cassandra.utils;
 
+import java.net.InetAddress;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.dht.Token;
@@ -27,12 +33,6 @@ import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.net.InetAddress;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Collection;
-import java.util.List;
 
 public class MutationVerificationUtils
 {

--- a/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
+++ b/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
@@ -40,7 +40,7 @@ public class MutationVerificationUtils
     private static final boolean VERIFY_KEYS_ON_WRITE = Boolean.valueOf(System.getProperty("palantir_cassandra.verify_keys_on_write", "false"));
     private static final Logger logger = LoggerFactory.getLogger(MutationVerificationUtils.class);
 
-    private static volatile Instant lastNaturalEndpointsCacheUpdate = Instant.MIN;
+    private static volatile Instant lastTokenRingCacheUpdate = Instant.MIN;
 
     private MutationVerificationUtils()
     {
@@ -61,10 +61,10 @@ public class MutationVerificationUtils
 
             if (mutationIsInvalid(naturalEndpoints, pendingEndpoints))
             {
-                if (Duration.between(lastNaturalEndpointsCacheUpdate, Instant.now()).compareTo(Duration.ofMinutes(10)) > 0)
+                if (Duration.between(lastTokenRingCacheUpdate, Instant.now()).compareTo(Duration.ofMinutes(10)) > 0)
                 {
-                    keyspace.getReplicationStrategy().clearCachedEndpoints();
-                    lastNaturalEndpointsCacheUpdate = Instant.now();
+                    StorageService.instance.getTokenMetadata().invalidateCachedRings();
+                    lastTokenRingCacheUpdate = Instant.now();
 
                     naturalEndpoints = StorageService.instance.getNaturalEndpoints(mutation.getKeyspaceName(), tk);
                 }

--- a/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
+++ b/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
@@ -24,6 +24,9 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.dht.Token;
@@ -31,8 +34,6 @@ import org.apache.cassandra.locator.NetworkTopologyStrategy;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Hex;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MutationVerificationUtils
 {

--- a/src/java/org/apache/cassandra/locator/AbstractReplicationStrategy.java
+++ b/src/java/org/apache/cassandra/locator/AbstractReplicationStrategy.java
@@ -94,15 +94,6 @@ public abstract class AbstractReplicationStrategy
         return cachedEndpoints.get(t);
     }
 
-    public void clearCachedEndpoints()
-    {
-        synchronized (this)
-        {
-            logger.trace("clearing cached endpoints");
-            cachedEndpoints.clear();
-            lastInvalidatedVersion = tokenMetadata.getRingVersion();
-        }
-    }
 
     /**
      * get the (possibly cached) endpoints that should store the given Token.

--- a/src/java/org/apache/cassandra/locator/AbstractReplicationStrategy.java
+++ b/src/java/org/apache/cassandra/locator/AbstractReplicationStrategy.java
@@ -94,7 +94,6 @@ public abstract class AbstractReplicationStrategy
         return cachedEndpoints.get(t);
     }
 
-
     /**
      * get the (possibly cached) endpoints that should store the given Token.
      * Note that while the endpoints are conceptually a Set (no duplicates will be included),

--- a/src/java/org/apache/cassandra/locator/AbstractReplicationStrategy.java
+++ b/src/java/org/apache/cassandra/locator/AbstractReplicationStrategy.java
@@ -94,6 +94,16 @@ public abstract class AbstractReplicationStrategy
         return cachedEndpoints.get(t);
     }
 
+    public void clearCachedEndpoints()
+    {
+        synchronized (this)
+        {
+            logger.trace("clearing cached endpoints");
+            cachedEndpoints.clear();
+            lastInvalidatedVersion = tokenMetadata.getRingVersion();
+        }
+    }
+
     /**
      * get the (possibly cached) endpoints that should store the given Token.
      * Note that while the endpoints are conceptually a Set (no duplicates will be included),


### PR DESCRIPTION
The logic that checks for invalid mutations relies on a cached map owner endpoints for tokens. In production, we've observed false positives for InvalidMutation errors when the cache out of sync. 

This PR refreshes that cache when an invalid mutation is detected, and checks again before throwing.

The cache will be refreshed at most once every 10 minutes.