### PR TITLE
Use broadcast address for cross-vcp handshake

### DIFF
--- a/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
+++ b/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
@@ -202,7 +202,7 @@ public class CrossVpcIpMappingHandshaker
     synchronized void triggerHandshakeFromSelf(Set<InetAddress> targets)
     {
         lastTriggeredHandshakeMillis = System.currentTimeMillis();
-        InetAddressHostname selfName = new InetAddressHostname(FBUtilities.getLocalAddress().getHostName());
+        InetAddressHostname selfName = new InetAddressHostname(FBUtilities.getBroadcastAddress().getHostName());
         InetAddressIp selfIp = new InetAddressIp(FBUtilities.getBroadcastAddress().getHostAddress());
         targets.forEach(target -> {
             try


### PR DESCRIPTION
We're communicating our local addr to other DCs instead of the broadcast addr, which is causing some churn