### PR TITLE
Only insert hostnames if not present for internal broadcast addrs

### DIFF
--- a/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingAckVerbHandler.java
+++ b/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingAckVerbHandler.java
@@ -39,6 +39,6 @@ public class CrossVpcIpMappingAckVerbHandler implements IVerbHandler<CrossVpcIpM
                      targetName,
                      targetInternal,
                      targetExternal);
-        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(targetName, targetInternal, targetExternal);
+        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(targetName, targetInternal);
     }
 }

--- a/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
+++ b/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
@@ -114,7 +114,7 @@ public class CrossVpcIpMappingHandshaker
         }
         if (!resolved.contains(endpoint))
         {
-            logger.warn("DNS-resolved address different than provided endpoint. This should mean that the endpoint " +
+            logger.debug("DNS-resolved address different than provided endpoint. This should mean that the endpoint " +
                         "includes a VPC-internal IP. Swapping. provided: {} resolved: {}",
                          endpoint, resolved);
             return resolved.stream().findFirst().get();

--- a/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
+++ b/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
@@ -70,7 +70,8 @@ public class CrossVpcIpMappingHandshaker
 
     public void updateCrossVpcMappings(InetAddressHostname host, InetAddressIp internalIp)
     {
-        if (!DatabaseDescriptor.isCrossVpcInternodeCommunicationEnabled()) {
+        if (!DatabaseDescriptor.isCrossVpcInternodeCommunicationEnabled())
+        {
             return;
         }
         InetAddressHostname old = this.privateIpToHostname.get(internalIp);
@@ -87,11 +88,13 @@ public class CrossVpcIpMappingHandshaker
      */
     public InetAddress maybeUpdateAddress(InetAddress endpoint)
     {
-        if (!DatabaseDescriptor.isCrossVpcInternodeCommunicationEnabled()) {
+        if (!DatabaseDescriptor.isCrossVpcInternodeCommunicationEnabled())
+        {
             return endpoint;
         }
         InetAddressIp proposedAddress = new InetAddressIp(endpoint.getHostAddress());
-        if (DatabaseDescriptor.isCrossVpcHostnameSwappingEnabled() && privateIpToHostname.containsKey(proposedAddress)) {
+        if (DatabaseDescriptor.isCrossVpcHostnameSwappingEnabled() && privateIpToHostname.containsKey(proposedAddress))
+        {
             return maybeInsertHostname(endpoint);
         }
         return endpoint;
@@ -118,7 +121,8 @@ public class CrossVpcIpMappingHandshaker
                         "includes a VPC-internal IP. Swapping. provided: {} resolved: {}",
                          endpoint, resolved);
             return resolved.stream().findFirst().get();
-        } else {
+        } else
+        {
             logger.trace("Endpoint matches resolved addresses. Not taking any action. provided: {} resolved: {}",
                          endpoint, resolved);
         }
@@ -133,7 +137,8 @@ public class CrossVpcIpMappingHandshaker
      */
     public Optional<InetAddressHostname> getAssociatedHostname(InetAddress endpoint)
     {
-        if (!DatabaseDescriptor.isCrossVpcInternodeCommunicationEnabled()) {
+        if (!DatabaseDescriptor.isCrossVpcInternodeCommunicationEnabled())
+        {
             return Optional.empty();
         }
         InetAddressIp ip = new InetAddressIp(endpoint.getHostAddress());
@@ -142,10 +147,12 @@ public class CrossVpcIpMappingHandshaker
 
     public void triggerHandshakeWithAllPeers()
     {
-        if (!DatabaseDescriptor.isCrossVpcInternodeCommunicationEnabled()) {
+        if (!DatabaseDescriptor.isCrossVpcInternodeCommunicationEnabled())
+        {
             return;
         }
-        try {
+        try
+        {
             if (System.currentTimeMillis() - lastTriggeredHandshakeMillis < minHandshakeInterval.toMillis())
             {
                 logger.trace("Ignoring handshake request as last handshake is too recent");

--- a/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandler.java
+++ b/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandler.java
@@ -77,7 +77,7 @@ public class CrossVpcIpMappingSynVerbHandler implements IVerbHandler<CrossVpcIpM
                      targetExternalIp);
 
 
-        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(sourceName, sourceInternalIp, sourceExternalIp);
+        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(sourceName, sourceInternalIp);
 
         CrossVpcIpMappingAck ack = new CrossVpcIpMappingAck(targetName, targetInternalIp, targetExternalIp);
         MessageOut<CrossVpcIpMappingAck> ackMessage = new MessageOut<>(MessagingService.Verb.CROSS_VPC_IP_MAPPING_ACK,

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1398,6 +1398,7 @@ public class DatabaseDescriptor
         conf.cross_vpc_internode_communication_enabled = setting;
     }
 
+    @Deprecated
     public static Boolean isCrossVpcIpSwappingEnabled()
     {
         return conf.cross_vpc_ip_swapping_enabled;

--- a/src/java/org/apache/cassandra/security/SSLFactory.java
+++ b/src/java/org/apache/cassandra/security/SSLFactory.java
@@ -95,7 +95,7 @@ public final class SSLFactory
     public static SSLSocket getSocket(EncryptionOptions options, InetAddress address, int port, InetAddress localAddress, int localPort) throws Exception
     {
         SSLContext ctx = createSSLContext(options, true);
-        InetAddress mappedAddress = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(address);
+        InetAddress mappedAddress = CrossVpcIpMappingHandshaker.instance.maybeUpdateAddress(address);
         SSLSocket socket = maybeConnectWithTimeout(() -> (SSLSocket) ctx.getSocketFactory().createSocket(mappedAddress, port, localAddress, localPort));
         prepareSocket(socket, options, mappedAddress);
         return socket;
@@ -105,7 +105,7 @@ public final class SSLFactory
     public static SSLSocket getSocket(EncryptionOptions options, InetAddress address, int port) throws Exception
     {
         SSLContext ctx = createSSLContext(options, true);
-        InetAddress mappedAddress = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(address);
+        InetAddress mappedAddress = CrossVpcIpMappingHandshaker.instance.maybeUpdateAddress(address);
         SSLSocket socket = maybeConnectWithTimeout(() -> (SSLSocket) ctx.getSocketFactory().createSocket(mappedAddress, port));
         prepareSocket(socket, options, mappedAddress);
         return socket;

--- a/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingAckVerbHandlerTest.java
+++ b/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingAckVerbHandlerTest.java
@@ -81,10 +81,10 @@ public class CrossVpcIpMappingAckVerbHandlerTest
         DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
         DatabaseDescriptor.setCrossVpcHostnameSwapping(false);
         DatabaseDescriptor.setCrossVpcIpSwapping(true);
-        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(input);
+        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeUpdateAddress(input);
         assertThat(result.getHostAddress()).isNotEqualTo(targetExternalIp.toString());
         handler.doVerb(messageIn, 0);
-        result = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(input);
+        result = CrossVpcIpMappingHandshaker.instance.maybeUpdateAddress(input);
         assertThat(result.getHostAddress()).isEqualTo(targetExternalIp.toString());
     }
 }

--- a/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshakerTest.java
+++ b/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshakerTest.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.net.MessagingService;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,130 +47,64 @@ public class CrossVpcIpMappingHandshakerTest
     }
 
     @Test
-    public void maybeSwapAddress_swapsHostnameWhenEnabled() throws UnknownHostException
+    public void maybeUpdateAddress_insertsHostnameWhenEnabled() throws UnknownHostException
     {
         InetAddress real = InetAddress.getByName("20.0.0.1");
-        mockMapping("localhost", "20.0.0.1", "10.0.0.1", true, false, true);
-        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(real);
+        mockMapping("localhost", "20.0.0.1", true, false, true);
+        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeUpdateAddress(real);
         assertThat(real.getHostName()).isEqualTo("20.0.0.1");
         assertThat(result.getHostName()).isEqualTo("localhost");
     }
 
     @Test
-    public void maybeSwapAddress_noopsWhenHostnameUnresolvable() throws UnknownHostException
+    public void maybeUpdateAddress_noopsWhenAddressIsNotTracked() throws UnknownHostException
     {
-        InetAddress input = InetAddress.getByName("localhost");
-        mockMapping("unresolvable", "127.0.0.1", "10.0.0.1", true, false, true);
-        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(input);
-        assertThat(result).isEqualTo(input);
-    }
-
-    @Test
-    public void maybeSwapAddress_swapsIpWhenEnabled() throws UnknownHostException
-    {
-        InetAddress input = InetAddress.getByName("20.0.0.1");
-        mockMapping("localhost", "20.0.0.1", "10.0.0.1", true, true, false);
-        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(input);
-        assertThat(input.getHostAddress()).isEqualTo("20.0.0.1");
+        // The case when we are hitting an already resolved
+        InetAddress provided = mock(InetAddress.class);
+        doReturn("10.0.0.1").when(provided).getHostAddress();
+        mockMapping("localhost", "20.0.0.1", true, false, true);
+        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeUpdateAddress(provided);
         assertThat(result.getHostAddress()).isEqualTo("10.0.0.1");
     }
 
     @Test
-    public void maybeSwapAddress_swapsHostnameWhenBothEnabled() throws UnknownHostException
+    public void maybeUpdateAddress_noopsWhenHostnameUnresolvable() throws UnknownHostException
     {
-        InetAddress input = InetAddress.getByName("20.0.0.1");
-        mockMapping("localhost", "20.0.0.1", "10.0.0.1", true, true, true);
-        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(input);
-        assertThat(input.getHostName()).isEqualTo("20.0.0.1");
-        assertThat(result.getHostName()).isEqualTo("localhost");
-    }
-
-    @Test
-    public void maybeSwapAddress_onlyTriesHostnameWhenBothEnabled() throws UnknownHostException
-    {
-        InetAddress input = InetAddress.getByName("20.0.0.1");
-        mockMapping("unresolvable", "20.0.0.1", "10.0.0.1", true, true, true);
-        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(input);
-        assertThat(input.getHostName()).isEqualTo("20.0.0.1");
-        // Would be 10.0.0.1 if we fell back to IP swapping if hostname failed
-        assertThat(result.getHostName()).isEqualTo("20.0.0.1");
-    }
-
-    @Test
-    public void maybeSwapAddress_noopsWhenBothMappingsDisabled() throws UnknownHostException
-    {
-        InetAddress input = InetAddress.getByName("20.0.0.1");
-        mockMapping("localhost", "20.0.0.1", "10.0.0.1", true, false, false);
-        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(input);
-        assertThat(input).isEqualTo(result);
-    }
-
-    @Test
-    public void maybeSwapAddress_noopsWhenCrossVpcComm_disabled() throws UnknownHostException
-    {
-        InetAddress input = InetAddress.getByName("20.0.0.1");
-        mockMapping("localhost", "20.0.0.1", "10.0.0.1", false, true, true);
-        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(input);
-        assertThat(input).isEqualTo(result);
-    }
-
-    @Test
-    public void maybeSwapAddress_noopsOnIpResolutionFailure() throws UnknownHostException
-    {
-        InetAddressIp causeFail = mock(InetAddressIp.class);
-        when(causeFail.toString()).thenReturn("ip-to-cause-exception");
-        InetAddressHostname name = new InetAddressHostname("localhost");
-        InetAddressIp internal = new InetAddressIp("127.0.0.1");
-        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal, causeFail);
-        DatabaseDescriptor.setCrossVpcHostnameSwapping(false);
-        DatabaseDescriptor.setCrossVpcIpSwapping(true);
-
         InetAddress input = InetAddress.getByName("localhost");
-        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(input);
-
+        mockMapping("unresolvable", "127.0.0.1", true, false, true);
+        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeUpdateAddress(input);
         assertThat(result).isEqualTo(input);
     }
 
     @Test
-    public void updateCrossVpcMappings_updatesPrivatePublicIp()
+    public void maybeUpdateAddress_noopsWhenBothMappingsDisabled() throws UnknownHostException
     {
-        InetAddressHostname name = new InetAddressHostname("host");
+        InetAddress input = InetAddress.getByName("20.0.0.1");
+        mockMapping("localhost", "20.0.0.1",  true, false, false);
+        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeUpdateAddress(input);
+        assertThat(input).isEqualTo(result);
+    }
+
+    @Test
+    public void maybeUpdateAddress_noopsWhenCrossVpcComm_disabled() throws UnknownHostException
+    {
+        InetAddress input = InetAddress.getByName("20.0.0.1");
+        mockMapping("localhost", "20.0.0.1", false, true, true);
+        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeUpdateAddress(input);
+        assertThat(input).isEqualTo(result);
+    }
+
+    @Test
+    public void updateCrossVpcMappings_onlyContainsInternalIp()
+    {
+        InetAddressHostname name = new InetAddressHostname("localhost");
         InetAddressIp internal = new InetAddressIp("10.0.0.1");
-        InetAddressIp external = new InetAddressIp("20.0.0.1");
-        Map<InetAddressIp, InetAddressIp> mapping = CrossVpcIpMappingHandshaker.instance.getCrossVpcIpMapping();
+        Map<InetAddressIp, InetAddressHostname> mapping = CrossVpcIpMappingHandshaker.instance.getCrossVpcIpHostnameMapping();
         assertThat(mapping).isEmpty();
         DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
-        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal, external);
+        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal);
         assertThat(mapping).hasSize(1);
-        assertThat(mapping).containsEntry(internal, external);
-    }
-
-    @Test
-    public void updateCrossVpcMappings_updatesPrivateIpHostname()
-    {
-        InetAddressHostname name = new InetAddressHostname("host");
-        InetAddressIp internal = new InetAddressIp("10.0.0.1");
-        InetAddressIp external = new InetAddressIp("20.0.0.1");
-        Map<InetAddressIp, InetAddressHostname> mapping = CrossVpcIpMappingHandshaker.instance.getCrossVpcIpHostnameMapping();
-        assertThat(mapping).isEmpty();
-        DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
-        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal, external);
-        assertThat(mapping).hasSize(2);
         assertThat(mapping).containsEntry(internal, name);
-    }
-
-    @Test
-    public void updateCrossVpcMappings_updatesPublicIpHostname()
-    {
-        InetAddressHostname name = new InetAddressHostname("host");
-        InetAddressIp internal = new InetAddressIp("10.0.0.1");
-        InetAddressIp external = new InetAddressIp("20.0.0.1");
-        Map<InetAddressIp, InetAddressHostname> mapping = CrossVpcIpMappingHandshaker.instance.getCrossVpcIpHostnameMapping();
-        assertThat(mapping).isEmpty();
-        DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
-        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal, external);
-        assertThat(mapping).hasSize(2);
-        assertThat(mapping).containsEntry(external, name);
     }
 
     @Test
@@ -177,11 +112,10 @@ public class CrossVpcIpMappingHandshakerTest
     {
         InetAddressHostname name = new InetAddressHostname("host");
         InetAddressIp internal = new InetAddressIp("10.0.0.1");
-        InetAddressIp external = new InetAddressIp("20.0.0.1");
         Map<InetAddressIp, InetAddressHostname> mapping = CrossVpcIpMappingHandshaker.instance.getCrossVpcIpHostnameMapping();
         assertThat(mapping).isEmpty();
         DatabaseDescriptor.setCrossVpcInternodeCommunication(false);
-        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal, external);
+        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal);
         assertThat(mapping).isEmpty();
     }
 
@@ -245,16 +179,14 @@ public class CrossVpcIpMappingHandshakerTest
 
     private void mockMapping(String hostname,
                              String internalIp,
-                             String externalIp,
                              boolean crossVpc,
                              boolean ipSwap,
                              boolean hostSwap) throws UnknownHostException
     {
         InetAddressHostname name = new InetAddressHostname(hostname);
         InetAddressIp internal = new InetAddressIp(internalIp);
-        InetAddressIp external = new InetAddressIp(externalIp);
         DatabaseDescriptor.setCrossVpcInternodeCommunication(crossVpc);
-        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal, external);
+        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal);
         // Hostname mapping takes precedence
         DatabaseDescriptor.setCrossVpcHostnameSwapping(hostSwap);
         DatabaseDescriptor.setCrossVpcIpSwapping(ipSwap);

--- a/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandlerTest.java
+++ b/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandlerTest.java
@@ -85,10 +85,10 @@ public class CrossVpcIpMappingSynVerbHandlerTest
         DatabaseDescriptor.setCrossVpcHostnameSwapping(false);
         DatabaseDescriptor.setCrossVpcIpSwapping(true);
         DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
-        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(input);
+        InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeUpdateAddress(input);
         Assertions.assertThat(result.getHostAddress()).isNotEqualTo("127.0.0.1");
         handler.doVerb(messageIn, 0);
-        result = CrossVpcIpMappingHandshaker.instance.maybeSwapAddress(input);
+        result = CrossVpcIpMappingHandshaker.instance.maybeUpdateAddress(input);
         Assertions.assertThat(result.getHostAddress()).isEqualTo("127.0.0.1");
     }
 

--- a/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandlerTest.java
+++ b/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandlerTest.java
@@ -82,7 +82,7 @@ public class CrossVpcIpMappingSynVerbHandlerTest
     public void doVerb_invokesCrossVpcIpMappingHandshaker() throws UnknownHostException
     {
         InetAddress input = InetAddress.getByName(sourceInternalIp.toString());
-        DatabaseDescriptor.setCrossVpcHostnameSwapping(false);
+        DatabaseDescriptor.setCrossVpcHostnameSwapping(true);
         DatabaseDescriptor.setCrossVpcIpSwapping(true);
         DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
         InetAddress result = CrossVpcIpMappingHandshaker.instance.maybeUpdateAddress(input);

--- a/test/unit/org/apache/cassandra/security/SSLFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/SSLFactoryTest.java
@@ -143,10 +143,9 @@ public class SSLFactoryTest
 
         InetAddressHostname name = new InetAddressHostname(localhost.getHostName());
         InetAddressIp internal = new InetAddressIp(addressToReplace.getHostAddress());
-        InetAddressIp external = new InetAddressIp(localhost.getHostAddress());
         // Swap hostname from whatever 10.0.0.1 resolves to with "localhost"
         DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
-        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal, external);
+        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal);
         DatabaseDescriptor.setCrossVpcHostnameSwapping(true);
         DatabaseDescriptor.setCrossVpcIpSwapping(false);
 
@@ -175,10 +174,9 @@ public class SSLFactoryTest
 
         InetAddressHostname name = new InetAddressHostname(localhost.getHostName());
         InetAddressIp internal = new InetAddressIp(addressToReplace.getHostAddress());
-        InetAddressIp external = new InetAddressIp(localhost.getHostAddress());
         // Swap hostname from whatever 10.0.0.1 resolves to with "localhost"
         DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
-        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal, external);
+        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal);
         DatabaseDescriptor.setCrossVpcHostnameSwapping(true);
         DatabaseDescriptor.setCrossVpcIpSwapping(false);
 
@@ -227,13 +225,12 @@ public class SSLFactoryTest
         InetAddress localhost = InetAddress.getByName("localhost");
         InetAddressHostname name = new InetAddressHostname("test-name");
         InetAddressIp internal = new InetAddressIp(localhost.getHostAddress());
-        InetAddressIp external = new InetAddressIp("10.0.0.1");
 
         DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
         DatabaseDescriptor.setCrossVpcSniSubstitution(true);
         DatabaseDescriptor.setCrossVpcIpSwapping(false);
         DatabaseDescriptor.setCrossVpcHostnameSwapping(false);
-        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal, external);
+        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal);
 
         try (SSLServerSocket server = SSLFactory.getServerSocket(getServerEncryptionOptions(), localhost, PORT))
         {
@@ -254,13 +251,12 @@ public class SSLFactoryTest
         InetAddress localhost = InetAddress.getByName("localhost");
         InetAddressHostname name = new InetAddressHostname("test-name");
         InetAddressIp internal = new InetAddressIp(localhost.getHostAddress());
-        InetAddressIp external = new InetAddressIp("10.0.0.1");
 
         DatabaseDescriptor.setCrossVpcInternodeCommunication(true);
         DatabaseDescriptor.setCrossVpcSniSubstitution(false);
         DatabaseDescriptor.setCrossVpcIpSwapping(false);
         DatabaseDescriptor.setCrossVpcHostnameSwapping(false);
-        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal, external);
+        CrossVpcIpMappingHandshaker.instance.updateCrossVpcMappings(name, internal);
 
         try (SSLServerSocket server = SSLFactory.getServerSocket(getServerEncryptionOptions(), localhost, PORT))
         {


### PR DESCRIPTION
We discovered that two hostnames in a separate VPC can resolve to the same proxy IP and we were mistakenly swapping them, since we were tracking proxy/public IPs as well as private/broadcast addresses.

This PR rips out some direct IP-mapping logic, as it was quite convoluted, and focuses on hostname-related mapping only. 

We now only track internal IP / broadcast address -> hostname, and will only update the endpoint we are trying to hit if the InetAddress does not contain a hostname, or has a hostname + endpoint which is from the other VPC (and therefore in our map).

If there is a hostname + we do not have the IP in the map, it must be a "public" / proxy IP, so we should leave the InetAddress as-is.

example:

For a node in another VPC hostA with broadcast address 10.100.0.1 that resolves to 10.9.0.1, 10.9.0.2, and 10.9.0.3 in the other VPC, you could have the following:
* hostA/10.100.0.1 -> (DNS) hostA/10.9.0.(1,2,3)
* hostA/10.9.0.(1,2,3) -> no-op
* /10.100.0.1 -> look up in our map -> hostA/10.9.0.(1,2,3)