### PR TITLE
Ignore cross vpc messages sent to incorrect nodes

### DIFF
--- a/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandler.java
+++ b/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandler.java
@@ -46,7 +46,6 @@ public class CrossVpcIpMappingSynVerbHandler implements IVerbHandler<CrossVpcIpM
         InetAddressIp sourceInternalIp = synMessage.getSourceInternalAddress();
 
         InetAddressHostname proposedTargetName = synMessage.getTargetHostname();
-
         InetAddressIp proposedTargetExternalIp = synMessage.getTargetExternalAddress();
 
         // InetAddress.getByHostname performs a DNS lookup

--- a/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandler.java
+++ b/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandler.java
@@ -48,6 +48,14 @@ public class CrossVpcIpMappingSynVerbHandler implements IVerbHandler<CrossVpcIpM
         InetAddressHostname targetName = synMessage.getTargetHostname();
         InetAddressIp targetExternalIp = synMessage.getTargetExternalAddress();
 
+        if (!targetName.toString().equals(DatabaseDescriptor.getBroadcastAddress().getHostName()))
+        {
+            logger.warn("Received a cross VPC Syn intended for another host. Ignoring. Intended: {} Actual: {}",
+                        targetName, DatabaseDescriptor.getBroadcastAddress());
+            return;
+        }
+
+
         // InetAddress.getByHostname performs a DNS lookup
         InetAddressIp sourceExternalIp = new InetAddressIp(InetAddress.getByName(sourceName.toString())
                                                                       .getHostAddress());

--- a/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandlerTest.java
+++ b/test/unit/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandlerTest.java
@@ -119,7 +119,7 @@ public class CrossVpcIpMappingSynVerbHandlerTest
     }
 
     @Test
-    public void doVerb_doesUpdateMappingWhenTargetDoesNotMatchBroadcastAddress() throws UnknownHostException
+    public void doVerb_doesNotUpdateMappingWhenTargetDoesNotMatchBroadcastAddress() throws UnknownHostException
     {
         doReturn(new InetAddressHostname("other")).when(handler).getBroadcastHostname();
         DatabaseDescriptor.setCrossVpcInternodeCommunication(true);


### PR DESCRIPTION
If we send a Syn to hostA, but include hostB as the target in the cross vpc syn body, hostA would respond with its internal IP as if it were hostB's. This can result in an incorrect broadcast address -> hostname mapping across the cluster