### PR TITLE
Add additional logs on startup

### DIFF
--- a/src/java/org/apache/cassandra/db/SystemKeyspace.java
+++ b/src/java/org/apache/cassandra/db/SystemKeyspace.java
@@ -1102,7 +1102,6 @@ public final class SystemKeyspace
      */
     public static void snapshotOnVersionChange() throws IOException
     {
-        logger.info("Attempting snapshotOnVersionChange");
         String previous = getPreviousVersionString();
         String next = FBUtilities.getReleaseVersionString();
 

--- a/src/java/org/apache/cassandra/db/SystemKeyspace.java
+++ b/src/java/org/apache/cassandra/db/SystemKeyspace.java
@@ -1102,6 +1102,7 @@ public final class SystemKeyspace
      */
     public static void snapshotOnVersionChange() throws IOException
     {
+        logger.info("Attempting snapshotOnVersionChange");
         String previous = getPreviousVersionString();
         String next = FBUtilities.getReleaseVersionString();
 

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -205,9 +205,9 @@ public class CassandraDaemon
         {
             startupChecks.verify();
         }
-        catch (StartupException e)
+        catch (Exception e)
         {
-            exitOrFail(e.returnCode, e.getMessage(), e.getCause());
+            exitOrFail(1, e.getMessage(), e.getCause());
         }
 
         logger.info("Startup checks completed.");

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -148,7 +148,7 @@ public class CassandraDaemon
             jmxServer.start();
             ((JmxRegistry)registry).setRemoteServerStub(server.toStub());
         }
-        catch (Exception e)
+        catch (IOException e)
         {
             exitOrFail(1, e.getMessage(), e.getCause());
         }

--- a/src/java/org/apache/cassandra/service/StartupChecks.java
+++ b/src/java/org/apache/cassandra/service/StartupChecks.java
@@ -114,7 +114,7 @@ public class StartupChecks
         {
             logger.info("Executing preflight check {}", check.getKey());
             check.getValue().execute();
-            logger.info("Startup check {} completed", check.getKey());
+            logger.info("Preflight check {} completed", check.getKey());
         }
     }
 

--- a/src/java/org/apache/cassandra/service/StartupChecks.java
+++ b/src/java/org/apache/cassandra/service/StartupChecks.java
@@ -297,23 +297,38 @@ public class StartupChecks
             {
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException
                 {
+                    logger.debug("Visiting file {}", file.toString());
+
                     if (!file.toString().endsWith(".db"))
+                    {
+                        logger.debug("Completed non db file {} visit", file.toString());
                         return FileVisitResult.CONTINUE;
+                    }
 
                     try
                     {
+                        logger.debug("Checking db file {} compatibility", file.toString());
                         if (!Descriptor.fromFilename(file.toString()).isCompatible())
+                        {
                             invalid.add(file.toString());
+                            logger.debug("db file {} is incompatible", file.toString());
+                        }
+                        else
+                        {
+                            logger.debug("db file {} is compatible", file.toString());
+                        }
                     }
                     catch (Exception e)
                     {
                         invalid.add(file.toString());
                     }
+                    logger.debug("Completed file {} visit", file.toString());
                     return FileVisitResult.CONTINUE;
                 }
 
                 public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException
                 {
+                    logger.debug("Visiting dir {}", dir.toString());
                     String name = dir.getFileName().toString();
                     return (name.equals("snapshots")
                             || name.equals("backups")

--- a/src/java/org/apache/cassandra/service/StartupChecks.java
+++ b/src/java/org/apache/cassandra/service/StartupChecks.java
@@ -356,6 +356,8 @@ public class StartupChecks
             for (CFMetaData cfm : Schema.instance.getKeyspaceMetaData(SystemKeyspace.NAME).values())
                 ColumnFamilyStore.scrubDataDirectories(cfm);
 
+            logger.debug("Finished scrubbing data directories for system keyspace. Checking keyspace health");
+
             try
             {
                 SystemKeyspace.checkHealth();
@@ -364,6 +366,8 @@ public class StartupChecks
             {
                 throw new StartupException(100, "Fatal exception during initialization", e);
             }
+
+            logger.debug("System keyspace is healthy");
         }
     };
 
@@ -399,6 +403,7 @@ public class StartupChecks
                 if (storedRack != null)
                 {
                     String currentRack = DatabaseDescriptor.getEndpointSnitch().getRack(FBUtilities.getBroadcastAddress());
+                    logger.debug("Successfully grabbed endpoint rack via snitch: {}", currentRack);
                     if (!storedRack.equals(currentRack))
                     {
                         String formatMessage = "Cannot start node if snitch's rack (%s) differs from previous rack (%s). " +
@@ -419,6 +424,7 @@ public class StartupChecks
             if (restrictedIp != null)
             {
                 String currentIp = FBUtilities.getLocalAddress().getHostAddress();
+                logger.debug("Successfully grabbed current IP: {}", currentIp);
                 if (currentIp.equals(restrictedIp))
                 {
                     {

--- a/src/java/org/apache/cassandra/service/StartupChecks.java
+++ b/src/java/org/apache/cassandra/service/StartupChecks.java
@@ -112,7 +112,7 @@ public class StartupChecks
     {
         for (Map.Entry<String, StartupCheck> check : preFlightChecks.entrySet())
         {
-            logger.info("Executing preflight check {}", check.getKey());
+            logger.debug("Executing preflight check {}", check.getKey());
             check.getValue().execute();
             logger.debug("Preflight check {} completed", check.getKey());
         }

--- a/src/java/org/apache/cassandra/service/StartupChecks.java
+++ b/src/java/org/apache/cassandra/service/StartupChecks.java
@@ -65,27 +65,31 @@ public class StartupChecks
     private static final Logger logger = LoggerFactory.getLogger(StartupChecks.class);
 
     // List of checks to run before starting up. If any test reports failure, startup will be halted.
-    private final List<StartupCheck> preFlightChecks = new ArrayList<>();
+    private final Map<String, StartupCheck> preFlightChecks = new LinkedHashMap<>();
 
     // The default set of pre-flight checks to run. Order is somewhat significant in that we probably
     // always want the system keyspace check run last, as this actually loads the schema for that
     // keyspace. All other checks should not require any schema initialization.
-    private final List<StartupCheck> DEFAULT_TESTS = ImmutableList.of(checkJemalloc,
-                                                                      checkValidLaunchDate,
-                                                                      checkJMXPorts,
-                                                                      inspectJvmOptions,
-                                                                      checkJnaInitialization,
-                                                                      initSigarLibrary,
-                                                                      checkDataDirs,
-                                                                      checkSSTablesFormat,
-                                                                      checkSystemKeyspaceState,
-                                                                      checkDatacenter,
-                                                                      checkRack,
-                                                                      checkIp);
+    private final List<Map.Entry<String, StartupCheck>> DEFAULT_TESTS = ImmutableList.of(
+        new AbstractMap.SimpleEntry<>("checkJemalloc", checkJemalloc),
+        new AbstractMap.SimpleEntry<>("checkValidLaunchDate", checkValidLaunchDate),
+        new AbstractMap.SimpleEntry<>("checkJMXPorts", checkJMXPorts),
+        new AbstractMap.SimpleEntry<>("inspectJvmOptions", inspectJvmOptions),
+        new AbstractMap.SimpleEntry<>("checkJnaInitialization", checkJnaInitialization),
+        new AbstractMap.SimpleEntry<>("initSigarLibrary", initSigarLibrary),
+        new AbstractMap.SimpleEntry<>("checkDataDirs", checkDataDirs),
+        new AbstractMap.SimpleEntry<>("checkSSTablesFormat", checkSSTablesFormat),
+        new AbstractMap.SimpleEntry<>("checkSystemKeyspaceState", checkSystemKeyspaceState),
+        new AbstractMap.SimpleEntry<>("checkDatacenter", checkDatacenter),
+        new AbstractMap.SimpleEntry<>("checkRack", checkRack),
+        new AbstractMap.SimpleEntry<>("checkIp", checkIp));
 
     public StartupChecks withDefaultTests()
     {
-        preFlightChecks.addAll(DEFAULT_TESTS);
+        for (Map.Entry<String, StartupCheck> test : DEFAULT_TESTS)
+        {
+            preFlightChecks.put(test.getKey(), test.getValue());
+        }
         return this;
     }
 
@@ -93,9 +97,9 @@ public class StartupChecks
      * Add system test to be run before schema is loaded during startup
      * @param test the system test to include
      */
-    public StartupChecks withTest(StartupCheck test)
+    public StartupChecks withTest(String name, StartupCheck test)
     {
-        preFlightChecks.add(test);
+        preFlightChecks.put(name, test);
         return this;
     }
 
@@ -106,8 +110,12 @@ public class StartupChecks
      */
     public void verify() throws StartupException
     {
-        for (StartupCheck test : preFlightChecks)
-            test.execute();
+        for (Map.Entry<String, StartupCheck> check : preFlightChecks.entrySet())
+        {
+            logger.info("Executing preflight check {}", check.getKey());
+            check.getValue().execute();
+            logger.info("Startup check {} completed", check.getKey());
+        }
     }
 
     public static final StartupCheck checkJemalloc = new StartupCheck()

--- a/test/unit/org/apache/cassandra/service/StartupChecksTest.java
+++ b/test/unit/org/apache/cassandra/service/StartupChecksTest.java
@@ -71,7 +71,7 @@ public class StartupChecksTest
     @Test
     public void failStartupIfInvalidSSTablesFound() throws Exception
     {
-        startupChecks = startupChecks.withTest(StartupChecks.checkSSTablesFormat);
+        startupChecks = startupChecks.withTest("checkSSTablesFormat", StartupChecks.checkSSTablesFormat);
 
         copyInvalidLegacySSTables(sstableDir);
 
@@ -94,7 +94,7 @@ public class StartupChecksTest
     @Test
     public void failStartupIfIpMatchesRestrictedIp()
     {
-        startupChecks = startupChecks.withTest(StartupChecks.checkIp);
+        startupChecks = startupChecks.withTest("checkIp", StartupChecks.checkIp);
         System.setProperty("palantir_cassandra.restricted_ip", "127.0.0.1");
 
         verifyFailure(startupChecks, "Cannot start as current IP");
@@ -103,7 +103,7 @@ public class StartupChecksTest
     @Test
     public void compatibilityCheckIgnoresNonDbFiles() throws Exception
     {
-        startupChecks = startupChecks.withTest(StartupChecks.checkSSTablesFormat);
+        startupChecks = startupChecks.withTest("checkSSTablesFormat", StartupChecks.checkSSTablesFormat);
 
         copyLegacyNonSSTableFiles(sstableDir);
         assertFalse(sstableDir.toFile().listFiles().length == 0);


### PR DESCRIPTION
Follows: PDS-457102 and PDS-545433
Adding logs to StartupChecks and CassandraDaemon. 
Moving `FileUtils.setDefaultUncaughtExceptionHandler();` before startup checks