### PR TITLE
Block requests to join ring after failed bootstraps

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -650,7 +650,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         logger.info("Thrift API version: {}", cassandraConstants.VERSION);
         logger.info("CQL supported versions: {} (default: {})",
                     StringUtils.join(ClientState.getCQLSupportedVersion(), ","), ClientState.DEFAULT_CQL_VERSION);
-        isBootstrapMode = SystemKeyspace.getBootstrapState() == SystemKeyspace.BootstrapState.IN_PROGRESS;
+        isBootstrapMode = SystemKeyspace.bootstrapInProgress();
 
         initialized = true;
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -247,6 +247,10 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     public void setGossipTokens(Collection<Token> tokens)
     {
+        if (DatabaseDescriptor.isAutoBootstrap() && !bootstrapComplete())
+        {
+            throw new BootstrappingSafetyException("Cannot set tokens for a non-bootstrapped node");
+        }
         List<Pair<ApplicationState, VersionedValue>> states = new ArrayList<Pair<ApplicationState, VersionedValue>>();
         states.add(Pair.create(ApplicationState.TOKENS, valueFactory.tokens(tokens)));
         states.add(Pair.create(ApplicationState.STATUS, valueFactory.normal(tokens)));
@@ -327,7 +331,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     // should only be called via JMX
     public void startGossiping()
     {
-        if (!initialized)
+        if (!isInitialized())
         {
             logger.warn("Starting gossip by operator request");
             Collection<Token> tokens = SystemKeyspace.getSavedTokens();
@@ -478,6 +482,11 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     }
 
     private void startTransports() {
+        if (!bootstrapComplete())
+        {
+            throw new IllegalStateException("Node is not yet bootstrapped completely. Refusing operator request to "
+                                           + "start transports.");
+        }
         if (!isInitialized() && !Gossiper.instance.isEnabled())
         {
             logger.info("Starting gossiper");
@@ -641,6 +650,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         logger.info("Thrift API version: {}", cassandraConstants.VERSION);
         logger.info("CQL supported versions: {} (default: {})",
                     StringUtils.join(ClientState.getCQLSupportedVersion(), ","), ClientState.DEFAULT_CQL_VERSION);
+        isBootstrapMode = SystemKeyspace.getBootstrapState() == SystemKeyspace.BootstrapState.IN_PROGRESS;
 
         initialized = true;
 
@@ -1486,7 +1496,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         setMode(m, null, log);
     }
 
-    private void setMode(Mode m, String msg, boolean log)
+    @VisibleForTesting
+    void setMode(Mode m, String msg, boolean log)
     {
         operationMode = m;
         String logMsg = msg == null ? m.toString() : String.format("%s: %s", m, msg);
@@ -1697,6 +1708,12 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public boolean isBootstrapMode()
     {
         return isBootstrapMode;
+    }
+
+    @VisibleForTesting
+    boolean bootstrapComplete()
+    {
+        return SystemKeyspace.bootstrapComplete();
     }
 
     public TokenMetadata getTokenMetadata()
@@ -5067,7 +5084,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
     }
 
-    public static void disableAutoCompaction() {
+    public void disableAutoCompaction() {
         for (String keyspaceName : Schema.instance.getKeyspaces())
         {
             for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
@@ -5096,7 +5113,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     // Unsafe as does not check state before disabling the node
     public void unsafeDisableNode() {
         logger.info("Stopping transports, disabling auto compactions, stopping in-progress compactions");
-        instance.stopTransports();
+        stopTransports();
         disableAutoCompaction();
         CompactionManager.instance.stopAllCompactions();
     }
@@ -5151,6 +5168,11 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     @Override
     public void persistentEnableClientInterfaces() {
+        if (!bootstrapComplete())
+        {
+            throw new IllegalStateException("Node is not yet bootstrapped completely. Refusing operator request to "
+                    + "enable client interfaces.");
+        }
         DisableClientInterfaceSetting.instance.setFalse();
         instance.startTransports();
     }

--- a/test/unit/com/palantir/cassandra/utils/MutationVerificationUtilsTest.java
+++ b/test/unit/com/palantir/cassandra/utils/MutationVerificationUtilsTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.InvalidMutationException;
 import org.apache.cassandra.locator.NetworkTopologyStrategy;
@@ -77,6 +78,7 @@ public class MutationVerificationUtilsTest
 
         TokenMetadata tmd = StorageService.instance.getTokenMetadata();
         tmd.clearUnsafe();
+        SystemKeyspace.setBootstrapState(SystemKeyspace.BootstrapState.COMPLETED);
         StorageService.instance.setTokens(Collections.singletonList(StorageService.getPartitioner().getToken(ByteBufferUtil.bytes("a"))));
         tmd.updateNormalToken(StorageService.getPartitioner().getToken(ByteBufferUtil.bytes("b")), REMOTE);
         MutationVerificationUtils.clearLastTokenRingCacheUpdate();

--- a/test/unit/org/apache/cassandra/service/ActiveRepairServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/ActiveRepairServiceTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutionException;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Sets;
+import org.apache.cassandra.db.*;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -32,10 +33,6 @@ import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.KSMetaData;
-import org.apache.cassandra.db.ColumnFamilyStore;
-import org.apache.cassandra.db.DecoratedKey;
-import org.apache.cassandra.db.Keyspace;
-import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
@@ -90,6 +87,7 @@ public class ActiveRepairServiceTest
 
         TokenMetadata tmd = StorageService.instance.getTokenMetadata();
         tmd.clearUnsafe();
+        SystemKeyspace.setBootstrapState(SystemKeyspace.BootstrapState.COMPLETED);
         StorageService.instance.setTokens(Collections.singleton(StorageService.getPartitioner().getRandomToken()));
         tmd.updateNormalToken(StorageService.getPartitioner().getMinimumToken(), REMOTE);
         assert tmd.isMember(REMOTE);


### PR DESCRIPTION
Had to mock reads from System keyspace b/c it was messing with some unit tests

zombie mode should be fine b/c it goes through join ring 

Validated enable interfaces endpoint throws. Also circumvented w/ nodetool and validated we don't set tokens as part of enabling gossip either:

```
./service/bin/nodetool enablegossip
error: Cannot set tokens for a non-bootstrapped node
-- StackTrace --
com.palantir.cassandra.db.BootstrappingSafetyException: Cannot set tokens for a non-bootstrapped node
        at org.apache.cassandra.service.StorageService.setGossipTokens(StorageService.java:252)
```

