### PR TITLE
additional checks to prevent bootstrapping if a cleanup is in progress

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1641,7 +1641,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     @Override
     public void startBootstrap()
     {
-        Preconditions.checkState(!StorageService.instance.isCleanupRunning(), "Cleanup is running. Refusing to start bootstrap.");
+        Preconditions.checkState(!isCleanupRunning(), "Cleanup is running. Refusing to start bootstrap.");
         startBootstrapCondition.signalAll();
     }
 


### PR DESCRIPTION
These checks are already implemented in cassandra-manager. Also adding here in cassandra as an additional safety measure.