### PR TITLE
Avoid NPE on cross vpc handshake if broadcast address is not explicitly set

### DIFF
--- a/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
+++ b/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
@@ -74,6 +74,9 @@ public class CrossVpcIpMappingHandshaker
         {
             return;
         }
+        if (host == null || internalIp == null) {
+            logger.warn("Received null host {}/{}", host, internalIp);
+        }
         InetAddressHostname old = this.privateIpToHostname.get(internalIp);
         if (!host.equals(old))
         {
@@ -93,6 +96,9 @@ public class CrossVpcIpMappingHandshaker
             return endpoint;
         }
         InetAddressIp proposedAddress = new InetAddressIp(endpoint.getHostAddress());
+        if (proposedAddress == null) {
+            logger.warn("null proposed address {}!", endpoint);
+        }
         if (DatabaseDescriptor.isCrossVpcHostnameSwappingEnabled() && privateIpToHostname.containsKey(proposedAddress))
         {
             return maybeInsertHostname(endpoint);
@@ -103,6 +109,9 @@ public class CrossVpcIpMappingHandshaker
     private InetAddress maybeInsertHostname(InetAddress endpoint)
     {
         InetAddressHostname hostname = privateIpToHostname.get(new InetAddressIp(endpoint.getHostAddress()));
+        if (hostname == null) {
+            logger.warn("Trying to insert null hostname for endpoint {}!", endpoint);
+        }
         logger.trace("Performing DNS lookup for host {}", hostname);
         Set<InetAddress> resolved;
         try

--- a/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
+++ b/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingHandshaker.java
@@ -74,9 +74,6 @@ public class CrossVpcIpMappingHandshaker
         {
             return;
         }
-        if (host == null || internalIp == null) {
-            logger.warn("Received null host {}/{}", host, internalIp);
-        }
         InetAddressHostname old = this.privateIpToHostname.get(internalIp);
         if (!host.equals(old))
         {
@@ -96,9 +93,6 @@ public class CrossVpcIpMappingHandshaker
             return endpoint;
         }
         InetAddressIp proposedAddress = new InetAddressIp(endpoint.getHostAddress());
-        if (proposedAddress == null) {
-            logger.warn("null proposed address {}!", endpoint);
-        }
         if (DatabaseDescriptor.isCrossVpcHostnameSwappingEnabled() && privateIpToHostname.containsKey(proposedAddress))
         {
             return maybeInsertHostname(endpoint);
@@ -109,9 +103,6 @@ public class CrossVpcIpMappingHandshaker
     private InetAddress maybeInsertHostname(InetAddress endpoint)
     {
         InetAddressHostname hostname = privateIpToHostname.get(new InetAddressIp(endpoint.getHostAddress()));
-        if (hostname == null) {
-            logger.warn("Trying to insert null hostname for endpoint {}!", endpoint);
-        }
         logger.trace("Performing DNS lookup for host {}", hostname);
         Set<InetAddress> resolved;
         try

--- a/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandler.java
+++ b/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandler.java
@@ -52,7 +52,8 @@ public class CrossVpcIpMappingSynVerbHandler implements IVerbHandler<CrossVpcIpM
         InetAddressIp sourceExternalIp = new InetAddressIp(InetAddress.getByName(sourceName.toString())
                                                                       .getHostAddress());
 
-        InetAddressIp targetInternalIp = new InetAddressIp(FBUtilities.getBroadcastAddress().getHostAddress());
+        InetAddress broadcastAddress = FBUtilities.getBroadcastAddress();
+        InetAddressIp targetInternalIp = new InetAddressIp(broadcastAddress.getHostAddress());
 
         if (!DatabaseDescriptor.isCrossVpcInternodeCommunicationEnabled())
         {
@@ -70,7 +71,7 @@ public class CrossVpcIpMappingSynVerbHandler implements IVerbHandler<CrossVpcIpM
         if (!proposedTargetName.equals(getBroadcastHostname()))
         {
             logger.warn("Received a cross VPC Syn intended for another host. Ignoring. Intended: {} Actual: {}",
-                        proposedTargetName, DatabaseDescriptor.getBroadcastAddress());
+                        proposedTargetName, broadcastAddress);
             return;
         }
 

--- a/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandler.java
+++ b/src/java/com/palantir/cassandra/cvim/CrossVpcIpMappingSynVerbHandler.java
@@ -97,7 +97,7 @@ public class CrossVpcIpMappingSynVerbHandler implements IVerbHandler<CrossVpcIpM
     @VisibleForTesting
     InetAddressHostname getBroadcastHostname() {
         // Supplying broadcast address as a hostname via config avoids a reverse-DNS lookup
-        return new InetAddressHostname(DatabaseDescriptor.getBroadcastAddress().getHostName());
+        return new InetAddressHostname(FBUtilities.getBroadcastAddress().getHostName());
     }
 
     /**


### PR DESCRIPTION
FBUtilities#getBroadcastAddress falls back to local address if not set in config. DatabaseDescriptor just passes along null