### PR TITLE
finishBootstrap check times out after 30 minutes as a BootstrapError

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1042,7 +1042,9 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                 {
                     recordNonTransientError(NonTransientError.BOOTSTRAP_ERROR, ImmutableMap.of("bootstrapSafetyCheckFailed", "true"));
                     unsafeDisableNode();
-                    throw new BootstrappingSafetyException("Bootstrap safety check failed.");
+                    String message = "Finish bootstrap was not called within 30 minutes. Bootstrap safety check failed.";
+                    logger.error(message);
+                    throw new BootstrappingSafetyException(message);
                 }
             }
             catch (InterruptedException e)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1037,7 +1037,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             try
             {
                 setMode(Mode.WAITING_TO_FINISH_BOOTSTRAP, "Awaiting finish bootstrap call", true);
-                boolean timeoutExceeded = !finishBootstrapCondition.await(10, MINUTES);
+                boolean timeoutExceeded = !finishBootstrapCondition.await(30, MINUTES);
                 if (timeoutExceeded)
                 {
                     recordNonTransientError(NonTransientError.BOOTSTRAP_ERROR, ImmutableMap.of("bootstrapSafetyCheckFailed", "true"));

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -91,6 +91,8 @@ import org.apache.cassandra.utils.concurrent.SimpleCondition;
 import org.apache.cassandra.utils.progress.jmx.JMXProgressSupport;
 import org.apache.cassandra.utils.progress.jmx.LegacyJMXProgressSupport;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 /**
  * This abstraction contains the token/identifier of this node
  * on the identifier space. This token gets gossiped around.
@@ -1035,7 +1037,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             try
             {
                 setMode(Mode.WAITING_TO_FINISH_BOOTSTRAP, "Awaiting finish bootstrap call", true);
-                boolean timeoutExceeded = !finishBootstrapCondition.await(10, TimeUnit.MINUTES);
+                boolean timeoutExceeded = !finishBootstrapCondition.await(10, MINUTES);
                 if (timeoutExceeded)
                 {
                     recordNonTransientError(NonTransientError.BOOTSTRAP_ERROR, ImmutableMap.of("bootstrapSafetyCheckFailed", "true"));


### PR DESCRIPTION
When WAITING_TO_FINISH_BOOTSTRAP was added, we required operators to manually ACK the successfully bootstrapped node before it could join the ring. Now, this is done by our automation, but cases where the automated safety check report an error, Cassandra will remain in this state indefinitely. This could be unsafe if the node is added manually, so this PR adds a timeout to fail fast.

The expectation is that our automation will evaluate and trigger `finishBootstrap` immediately if the checks pass, and if the checks fail, waiting some time will not cause them to pass.