### PR TITLE
Add safeguard to NTE node incase local pause leads to gossip timeout

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1558,7 +1558,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             bootstrapStream.get();
             isBootstrapMode = false;
             logger.info("Bootstrap streaming completed for tokens {}", tokens);
-            return true;
+            return nonTransientErrors.stream().anyMatch(nte -> nte.containsKey(NonTransientError.BOOTSTRAP_ERROR.toString()));
         }
         catch (Throwable e)
         {
@@ -4539,6 +4539,11 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public boolean isStarting()
     {
         return operationMode == Mode.STARTING;
+    }
+
+    public boolean isJoining()
+    {
+        return operationMode == Mode.JOINING;
     }
 
     public boolean inNonTransientErrorMode()

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1558,7 +1558,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             bootstrapStream.get();
             isBootstrapMode = false;
             logger.info("Bootstrap streaming completed for tokens {}", tokens);
-            return nonTransientErrors.stream().anyMatch(nte -> nte.containsKey(NonTransientError.BOOTSTRAP_ERROR.toString()));
+            return StorageService.instance.hasNonTransientError(StorageServiceMBean.NonTransientError.BOOTSTRAP_ERROR);
         }
         catch (Throwable e)
         {
@@ -4541,9 +4541,9 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         return operationMode == Mode.STARTING;
     }
 
-    public boolean isJoining()
+    public boolean isJoiningOrWaitingToFinishBootstrap()
     {
-        return operationMode == Mode.JOINING;
+        return operationMode == Mode.JOINING || operationMode == Mode.WAITING_TO_FINISH_BOOTSTRAP;
     }
 
     public boolean inNonTransientErrorMode()

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -193,7 +193,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     @VisibleForTesting
     static enum Mode { STARTING, NORMAL, JOINING, LEAVING, DECOMMISSIONED, MOVING, DRAINING, DRAINED, ZOMBIE, NON_TRANSIENT_ERROR, TRANSIENT_ERROR, WAITING_TO_BOOTSTRAP, WAITING_TO_FINISH_BOOTSTRAP, DISABLED }
-    private Mode operationMode = Mode.STARTING;
+    private volatile Mode operationMode = Mode.STARTING;
 
     /* Used for tracking drain progress */
     private volatile int totalCFs, remainingCFs;


### PR DESCRIPTION
When a node bootstraps, it is viewed as fat clients by the rest of the cluster. This means if a local pause prevents heart-beating for longer than [MAX_LOCAL_PAUSE_IN_NANOS](https://github.com/palantir/cassandra/blob/palantir-cassandra-2.2.18/src/java/org/apache/cassandra/gms/FailureDetector.java#L275C20-L275C44), the bootstrapping node will be evicted from gossip from the rest of the nodes in the cluster. This leads to a state where the bootstrapping node continues to receive streams of data in but  isn't propagating its gossip state.

The problem occurs when the node completes streaming. It will think that it should be part of the cluster and ACK reads / writes / range-scans. This leads to a split-brain where not all nodes in the cluster agree on ownership.

This patch sets the node to non-transient-error mode should if hit the gossip timeout and adds a check once streaming completes to verify no NTEs for bootstrap errors were recorded. If any were observed, the node will fail the bootstrap.