### PR TITLE
Do not gossip to unreachable endpoints that have been removed

### DIFF
--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -673,7 +673,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             double prob = unreachableEndpointCount / (liveEndpointCount + 1);
             double randDbl = random.nextDouble();
             if (randDbl < prob)
-                // Theoritically justRemoved endpoints should not be added unreachableEndpoints
+                // Theoritically justRemovedEndpoints and unreachableEndpoints should have no intersections
                 // but the Gossiper is prone to races
                 sendGossip(message, Sets.filter(unreachableEndpoints.keySet(),
                                             ep -> justRemovedEndpoints.containsKey(ep)));

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -665,12 +665,6 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
     /* Sends a Gossip message to an unreachable member */
     private void maybeGossipToUnreachableMember(MessageOut<GossipDigestSyn> message)
     {
-        Set<InetAddress> unreachableRemovedEndpoints =
-                Sets.intersection(unreachableEndpoints.keySet(), justRemovedEndpoints.keySet());
-        if (unreachableRemovedEndpoints.size() > 0) {
-            logger.warn("Found common inet addresses between unreachable and just removed list: {}",
-                    unreachableRemovedEndpoints);
-        }
         double liveEndpointCount = liveEndpoints.size();
         double unreachableEndpointCount = unreachableEndpoints.size();
         if (unreachableEndpointCount > 0)
@@ -679,7 +673,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             double prob = unreachableEndpointCount / (liveEndpointCount + 1);
             double randDbl = random.nextDouble();
             if (randDbl < prob)
-                // Theoritically justRemoved endpoints should never be added unreachableEndpoints
+                // Theoritically justRemoved endpoints should not be added unreachableEndpoints
                 // but the Gossiper is prone to races
                 sendGossip(message, Sets.filter(unreachableEndpoints.keySet(),
                                             ep -> justRemovedEndpoints.containsKey(ep)));

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -676,7 +676,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                 // Theoritically justRemovedEndpoints and unreachableEndpoints should have no intersections
                 // but the Gossiper is prone to races
                 sendGossip(message, Sets.filter(unreachableEndpoints.keySet(),
-                                            ep -> justRemovedEndpoints.containsKey(ep)));
+                                            ep -> !justRemovedEndpoints.containsKey(ep)));
         }
     }
 


### PR DESCRIPTION
A race in Cassandra Gossiper code can cause an endpoint to be re-added to `unreachableEndpoints` after it was removed from the node's state and quarantined.