### PR TITLE
[CASSANDRA-15439] Add option to override the FatClient timeout for Bootstrapping nodes

### DIFF
--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -216,6 +216,10 @@ JVM_OPTS="$JVM_OPTS -XX:+CrashOnOutOfMemoryError"
 # print an heap histogram on OutOfMemoryError
 # JVM_OPTS="$JVM_OPTS -Dcassandra.printHeapHistogramOnOutOfMemoryError=true"
 
+# Allows overriding the timeout after which an unresponsive bootstrapping node is considered failed
+# and is removed from gossip state and bootstrapTokens. (Default: cassandra.ring_delay * 10)
+# JVM_OPTS="$JVM_OPTS -Dcassandra.failed_bootstrap_timeout_ms=ms"
+
 # Per-thread stack size.
 JVM_OPTS="$JVM_OPTS -Xss256k"
 

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -96,7 +96,10 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
 
     // Maximimum difference between generation value and local time we are willing to accept about a peer
     static final int MAX_GENERATION_DIFFERENCE = 86400 * 365;
-    private long fatClientTimeout;
+
+    // half of QUARATINE_DELAY, to ensure justRemovedEndpoints has enough leeway to prevent re-gossip
+    private static final long FAT_CLIENT_TIMEOUT = (QUARANTINE_DELAY / 2);
+    private static final long FAILED_BOOTSTRAP_TIMEOUT = getFailedBootstrapTimeout();
     private final Random random = new Random();
     private final Comparator<InetAddress> inetcomparator = new Comparator<InetAddress>()
     {
@@ -202,10 +205,27 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         }
     }
 
+    private static long getFailedBootstrapTimeout()
+    {
+        String newtimeout = System.getProperty("cassandra.failed_bootstrap_timeout_ms");
+        if (newtimeout != null)
+        {
+            long longValue = Long.parseLong(newtimeout);
+            if (longValue == -1)
+            {
+                longValue = Long.MAX_VALUE;
+            }
+            logger.info("Overriding FAILED_BOOTSTRAP_TIMEOUT to {}ms", longValue);
+            return longValue;
+        }
+        else
+        {
+            return FAT_CLIENT_TIMEOUT * 10;
+        }
+    }
+
     private Gossiper()
     {
-        // half of QUARATINE_DELAY, to ensure justRemovedEndpoints has enough leeway to prevent re-gossip
-        fatClientTimeout = (QUARANTINE_DELAY / 2);
         /* register with the Failure Detector for receiving Failure detector events */
         FailureDetector.instance.registerFailureDetectionEventListener(this);
 
@@ -775,6 +795,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             {
                 // check if this is a fat client. fat clients are removed automatically from
                 // gossip after FatClientTimeout.  Do not remove dead states here.
+                long fatClientTimeout = getFatClientTimeoutForEndpoint(epState);
                 if (isGossipOnlyMember(endpoint)
                     && !justRemovedEndpoints.containsKey(endpoint)
                     && TimeUnit.NANOSECONDS.toMillis(nowNano - epState.getUpdateTimestamp()) > fatClientTimeout)
@@ -810,6 +831,24 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                 }
             }
         }
+    }
+
+    private static long getFatClientTimeoutForEndpoint(EndpointState epState)
+    {
+        return isBootstrappingState(epState) ?
+                FAILED_BOOTSTRAP_TIMEOUT :
+                FAT_CLIENT_TIMEOUT;
+    }
+
+    private static boolean isBootstrappingState(EndpointState epState)
+    {
+        String status = getGossipStatus(epState);
+        if (status.isEmpty())
+        {
+            return false;
+        }
+
+        return VersionedValue.BOOTSTRAPPING_STATES.contains(status);
     }
 
     protected long getExpireTimeForEndpoint(InetAddress endpoint)

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -848,7 +848,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             return false;
         }
 
-        return VersionedValue.BOOTSTRAPPING_STATES.contains(status);
+        return VersionedValue.BOOTSTRAPPING_STATUS.contains(status);
     }
 
     protected long getExpireTimeForEndpoint(InetAddress endpoint)

--- a/src/java/org/apache/cassandra/gms/VersionedValue.java
+++ b/src/java/org/apache/cassandra/gms/VersionedValue.java
@@ -20,13 +20,11 @@ package org.apache.cassandra.gms;
 import java.io.*;
 
 import java.net.InetAddress;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 import org.apache.cassandra.db.TypeSizes;
@@ -81,8 +79,8 @@ public class VersionedValue implements Comparable<VersionedValue>
 
     // values for ApplicationState.REMOVAL_COORDINATOR
     public final static String REMOVAL_COORDINATOR = "REMOVER";
-    public final static List<String> BOOTSTRAPPING_STATES = Arrays.asList(VersionedValue.STATUS_BOOTSTRAPPING,
-            VersionedValue.STATUS_BOOTSTRAPPING_REPLACE);
+    public final static Set<String> BOOTSTRAPPING_STATUS = ImmutableSet.of(STATUS_BOOTSTRAPPING, STATUS_BOOTSTRAPPING_REPLACE);
+
 
     public final int version;
     public final String value;

--- a/src/java/org/apache/cassandra/gms/VersionedValue.java
+++ b/src/java/org/apache/cassandra/gms/VersionedValue.java
@@ -81,7 +81,6 @@ public class VersionedValue implements Comparable<VersionedValue>
     public final static String REMOVAL_COORDINATOR = "REMOVER";
     public final static Set<String> BOOTSTRAPPING_STATUS = ImmutableSet.of(STATUS_BOOTSTRAPPING, STATUS_BOOTSTRAPPING_REPLACE);
 
-
     public final int version;
     public final String value;
 

--- a/src/java/org/apache/cassandra/gms/VersionedValue.java
+++ b/src/java/org/apache/cassandra/gms/VersionedValue.java
@@ -20,7 +20,9 @@ package org.apache.cassandra.gms;
 import java.io.*;
 
 import java.net.InetAddress;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
@@ -79,6 +81,8 @@ public class VersionedValue implements Comparable<VersionedValue>
 
     // values for ApplicationState.REMOVAL_COORDINATOR
     public final static String REMOVAL_COORDINATOR = "REMOVER";
+    public final static List<String> BOOTSTRAPPING_STATES = Arrays.asList(VersionedValue.STATUS_BOOTSTRAPPING,
+            VersionedValue.STATUS_BOOTSTRAPPING_REPLACE);
 
     public final int version;
     public final String value;


### PR DESCRIPTION
Backport of [CASSANDRA-15439](https://issues.apache.org/jira/browse/CASSANDRA-15439)

This allows us to override the timeout for node removal while a node is bootstrapping. We know that we never want a bootstrapping node that has been removed by other nodes while streaming to succeed bootstrapping, and have already implemented safeguards to prevent that node from joining the ring after completing streaming.

Setting this parameter to a higher value makes this error state less likely to occur. This change takes the default set in 5.0, which is 5 minutes. We could consider making this higher.

We also had success reducing the frequency of this issue by vertically upsizing nodes and throttling streaming.

