### PR TITLE
Zombie fixes

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5207,6 +5207,12 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     }
 
     @Override
+    public InetAddress getBroadcastAddress()
+    {
+        return FBUtilities.getBroadcastAddress();
+    }
+
+    @Override
     public boolean isMigrating()
     {
         return Boolean.getBoolean("palantir_cassandra.migration_mode");

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -810,7 +810,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     private boolean shouldBootstrap(boolean autoBootstrap)
     {
-        return autoBootstrap && !SystemKeyspace.bootstrapComplete() && !DatabaseDescriptor.getSeeds().contains(FBUtilities.getBroadcastAddress());
+        return joinRing && autoBootstrap && !SystemKeyspace.bootstrapComplete() && !DatabaseDescriptor.getSeeds().contains(FBUtilities.getBroadcastAddress());
     }
 
     private void prepareToJoin() throws ConfigurationException

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -372,7 +372,7 @@ public interface StorageServiceMBean extends NotificationEmitter
     @Deprecated
     public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, int jobs, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
 
-public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, boolean reinsertOverflowedTTLRows, int jobs, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
+    public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, boolean reinsertOverflowedTTLRows, int jobs, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
 
     /**
      * Verify (checksums of) the given keyspace.
@@ -903,4 +903,9 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
      * Returns the value of the palantir_cassandra.is_new_cluster system variable or false if not set.
      */
     public boolean isNewCluster();
+
+    /**
+     * Returns the broadcast address of the node.
+     */
+    public InetAddress getBroadcastAddress();
 }


### PR DESCRIPTION
WIP
- `shouldBootstrap` being true in ZOMBIE mode causes a shadow round of gossip check via `checkForEndpointCollision` that fails and causes the node to crash. Audited all other places where this function is used, this change should not affect any other behavior.
- exposes getBoadcastAddress function