### PR TITLE
Don’t affect other tests in the rebuild tombstone purging test

### DIFF
--- a/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
@@ -206,6 +206,8 @@ public class CompactionControllerTest extends SchemaLoader
         StorageService.instance.unsafeSetRebuilding(true);
 
         assertEquals(CompactionController.getFullyExpiredSSTables(cfs, compacting, overlapping, gcBefore), Collections.emptySet());
+
+        StorageService.instance.unsafeSetRebuilding(true);
     }
 
     private void applyMutation(String cf, ByteBuffer rowKey, long timestamp)

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
@@ -203,11 +203,12 @@ public class CompactionControllerTest extends SchemaLoader
         // the first sstable should be expired because the overlapping sstable is newer and the gc period is later
         int gcBefore = (int) (System.currentTimeMillis() / 1000) + 5;
 
-        StorageService.instance.unsafeSetRebuilding(true);
-
-        assertEquals(CompactionController.getFullyExpiredSSTables(cfs, compacting, overlapping, gcBefore), Collections.emptySet());
-
-        StorageService.instance.unsafeSetRebuilding(true);
+        try {
+            StorageService.instance.unsafeSetRebuilding(true);
+            assertEquals(CompactionController.getFullyExpiredSSTables(cfs, compacting, overlapping, gcBefore), Collections.emptySet());
+        } finally {
+            StorageService.instance.unsafeSetRebuilding(false);
+        }
     }
 
     private void applyMutation(String cf, ByteBuffer rowKey, long timestamp)


### PR DESCRIPTION
The test in https://github.com/palantir/cassandra/pull/488 may affect other tests depending on the order in which they're run