### PR TITLE
Bump max local pause to 28 seconds

### DIFF
--- a/src/java/org/apache/cassandra/gms/FailureDetector.java
+++ b/src/java/org/apache/cassandra/gms/FailureDetector.java
@@ -52,7 +52,7 @@ public class FailureDetector implements IFailureDetector, FailureDetectorMBean
     private static final int SAMPLE_SIZE = 1000;
     protected static final long INITIAL_VALUE_NANOS = TimeUnit.NANOSECONDS.convert(getInitialValue(), TimeUnit.MILLISECONDS);
     private static final int DEBUG_PERCENTAGE = 80; // if the phi is larger than this percentage of the max, log a debug message
-    private static final long DEFAULT_MAX_PAUSE = 5000L * 1000000L; // 5 seconds
+    private static final long DEFAULT_MAX_PAUSE = 28000L * 1000000L; // 28 seconds
     private static final long MAX_LOCAL_PAUSE_IN_NANOS = getMaxLocalPause();
     private static final long BOOSTRAP_SAFEGUARD_PAUSE_IN_NANOS = Long.getLong("palantir_cassandra.boostrap_safeguard_pause_in_ms", 30000L) * 1000000L;
     private long lastInterpret = System.nanoTime();


### PR DESCRIPTION
Follows: https://github.com/palantir/cassandra/pull/477
The check is too aggressive in practice. Pauses up to 30s should be fine (fat client removal timeout)