### PR TITLE
Cross VPC messages over large connection pool

### DIFF
--- a/src/java/org/apache/cassandra/net/OutboundTcpConnectionPool.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnectionPool.java
@@ -69,6 +69,10 @@ public class OutboundTcpConnectionPool
     {
         if (Stage.GOSSIP == msg.getStage())
             return gossipMessages;
+        if (Stage.CROSS_VPC_IP_MAPPING == msg.getStage()) {
+            // Application-level keepalive to avoid NLB idle resets around 6 minutes
+            return largeMessages;
+        }
         return msg.payloadSize(smallMessages.getTargetVersion()) > LARGE_MESSAGE_THRESHOLD
                ? largeMessages
                : smallMessages;


### PR DESCRIPTION
Application-level keepalive to avoid NLB idle resets around 6 minutes for cross-vpc connections. This was causing a small, but consistent number of connection resets based on how we use C*