### PR TITLE
Multi-node unit testing setup to MessagingService.

### DIFF
--- a/src/java/org/apache/cassandra/net/IDatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/net/IDatabaseDescriptor.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.net;
+
+import java.net.InetAddress;
+
+import org.apache.cassandra.utils.FBUtilities;
+
+public interface IDatabaseDescriptor
+{
+
+    // FBUtilities
+
+    InetAddress getBroadcastRpcAddress();
+
+    InetAddress getLocalAddress();
+
+    InetAddress getBroadcastAddress();
+
+    enum StaticDatabaseDescriptor implements IDatabaseDescriptor
+    {
+        INSTANCE;
+
+        public InetAddress getBroadcastRpcAddress()
+        {
+            return FBUtilities.getBroadcastRpcAddress();
+        }
+
+        public InetAddress getLocalAddress()
+        {
+            return FBUtilities.getLocalAddress();
+        }
+
+        public InetAddress getBroadcastAddress()
+        {
+            return FBUtilities.getBroadcastAddress();
+        }
+
+        public String getNetworkInterface(InetAddress localAddress)
+        {
+            return FBUtilities.getNetworkInterface(localAddress);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/net/MessageDeliveryTask.java
+++ b/src/java/org/apache/cassandra/net/MessageDeliveryTask.java
@@ -34,14 +34,16 @@ public class MessageDeliveryTask implements Runnable
 {
     private static final Logger logger = LoggerFactory.getLogger(MessageDeliveryTask.class);
 
+    private final MessagingService messagingService;
     private final MessageIn message;
     private final int id;
     private final long constructionTime;
     private final boolean isCrossNodeTimestamp;
 
-    public MessageDeliveryTask(MessageIn message, int id, long timestamp, boolean isCrossNodeTimestamp)
+    public MessageDeliveryTask(MessagingService messagingService, MessageIn message, int id, long timestamp, boolean isCrossNodeTimestamp)
     {
         assert message != null;
+        this.messagingService = messagingService;
         this.message = message;
         this.id = id;
         this.constructionTime = timestamp;
@@ -54,11 +56,11 @@ public class MessageDeliveryTask implements Runnable
         if (MessagingService.DROPPABLE_VERBS.contains(verb)
             && System.currentTimeMillis() > constructionTime + message.getTimeout())
         {
-            MessagingService.instance().incrementDroppedMessages(verb, isCrossNodeTimestamp);
+            messagingService.incrementDroppedMessages(verb, isCrossNodeTimestamp);
             return;
         }
 
-        IVerbHandler verbHandler = MessagingService.instance().getVerbHandler(verb);
+        IVerbHandler verbHandler = messagingService.getVerbHandler(verb);
         if (verbHandler == null)
         {
             logger.trace("Unknown verb {}", verb);
@@ -110,7 +112,7 @@ public class MessageDeliveryTask implements Runnable
         {
             MessageOut response = new MessageOut(MessagingService.Verb.INTERNAL_RESPONSE)
                                                 .withParameter(MessagingService.FAILURE_RESPONSE_PARAM, MessagingService.ONE_BYTE);
-            MessagingService.instance().sendReply(response, id, message.from);
+            messagingService.sendReply(response, id, message.from);
         }
     }
 

--- a/src/java/org/apache/cassandra/net/MessageIn.java
+++ b/src/java/org/apache/cassandra/net/MessageIn.java
@@ -59,7 +59,7 @@ public class MessageIn<T>
         return new MessageIn<T>(from, payload, parameters, verb, version);
     }
 
-    public static <T2> MessageIn<T2> read(DataInput in, int version, int id) throws IOException
+    public static <T2> MessageIn<T2> read(MessagingService messagingService, DataInput in, int version, int id) throws IOException
     {
         InetAddress from = CompactEndpointSerializationHelper.deserialize(in);
 
@@ -87,7 +87,7 @@ public class MessageIn<T>
         IVersionedSerializer<T2> serializer = (IVersionedSerializer<T2>) MessagingService.verbSerializers.get(verb);
         if (serializer instanceof MessagingService.CallbackDeterminedSerializer)
         {
-            CallbackInfo callback = MessagingService.instance().getRegisteredCallback(id);
+            CallbackInfo callback = messagingService.getRegisteredCallback(id);
             if (callback == null)
             {
                 // reply for expired callback.  we'll have to skip it.

--- a/src/java/org/apache/cassandra/net/MessageOut.java
+++ b/src/java/org/apache/cassandra/net/MessageOut.java
@@ -107,6 +107,11 @@ public class MessageOut<T>
 
     public void serialize(DataOutputPlus out, int version) throws IOException
     {
+        serialize(out, version, this.from);
+    }
+
+    public void serialize(DataOutputPlus out, int version, InetAddress from) throws IOException
+    {
         CompactEndpointSerializationHelper.serialize(from, out);
 
         out.writeInt(verb.ordinal());

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
@@ -151,10 +151,10 @@ public class OutboundTcpConnection extends Thread
         cs = newCoalescingStrategy(pool.endPoint().getHostAddress());
     }
 
-    private static boolean isLocalDC(InetAddress targetHost)
+    private boolean isLocalDC(InetAddress targetHost)
     {
         String remoteDC = DatabaseDescriptor.getEndpointSnitch().getDatacenter(targetHost);
-        String localDC = DatabaseDescriptor.getEndpointSnitch().getDatacenter(FBUtilities.getBroadcastAddress());
+        String localDC = DatabaseDescriptor.getEndpointSnitch().getDatacenter(poolReference.dbDescriptor.getBroadcastAddress());
         return remoteDC.equals(localDC);
     }
 
@@ -352,7 +352,7 @@ public class OutboundTcpConnection extends Thread
         // int cast cuts off the high-order half of the timestamp, which we can assume remains
         // the same between now and when the recipient reconstructs it.
         out.writeInt((int) timestamp);
-        message.serialize(out, targetVersion);
+        message.serialize(out, targetVersion, poolReference.dbDescriptor.getBroadcastAddress());
     }
 
     private static void writeHeader(DataOutput out, int version, boolean compressionEnabled) throws IOException
@@ -400,7 +400,7 @@ public class OutboundTcpConnection extends Thread
         long timeout = TimeUnit.MILLISECONDS.toNanos(DatabaseDescriptor.getRpcTimeout());
         while (System.nanoTime() - start < timeout && !isStopped)
         {
-            targetVersion = MessagingService.instance().getVersion(poolReference.endPoint());
+            targetVersion = poolReference.messagingService.getVersion(poolReference.endPoint());
             try
             {
                 socket = poolReference.newSocket();
@@ -446,7 +446,7 @@ public class OutboundTcpConnection extends Thread
                 }
                 else
                 {
-                    MessagingService.instance().setVersion(poolReference.endPoint(), maxTargetVersion);
+                    poolReference.messagingService.setVersion(poolReference.endPoint(), maxTargetVersion);
                 }
 
                 if (targetVersion > maxTargetVersion)
@@ -480,7 +480,7 @@ public class OutboundTcpConnection extends Thread
                 }
 
                 out.writeInt(MessagingService.current_version);
-                CompactEndpointSerializationHelper.serialize(FBUtilities.getBroadcastAddress(), out);
+                CompactEndpointSerializationHelper.serialize(poolReference.dbDescriptor.getBroadcastAddress(), out);
                 if (shouldCompressConnection())
                 {
                     out.flush();

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnectionPool.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnectionPool.java
@@ -46,13 +46,19 @@ public class OutboundTcpConnectionPool
     public final OutboundTcpConnection largeMessages;
     public final OutboundTcpConnection gossipMessages;
 
+    public final IDatabaseDescriptor dbDescriptor;
+
+    public final MessagingService messagingService;
+
     // pointer to the reset Address.
     private InetAddress resetEndpoint;
     private ConnectionMetrics metrics;
 
-    OutboundTcpConnectionPool(InetAddress remoteEp)
+    OutboundTcpConnectionPool(InetAddress remoteEp, IDatabaseDescriptor dbDescriptor, MessagingService messagingService)
     {
         id = remoteEp;
+        this.dbDescriptor = dbDescriptor;
+        this.messagingService = messagingService;
         resetEndpoint = SystemKeyspace.getPreferredIP(remoteEp);
         started = new CountDownLatch(1);
 
@@ -119,20 +125,26 @@ public class OutboundTcpConnectionPool
 
     public Socket newSocket() throws Exception
     {
-        return newSocket(endPoint());
+        return newSocket(endPoint(), dbDescriptor);
+    }
+
+    @SuppressWarnings("resource")
+    public static Socket newSocket(InetAddress endpoint) throws Exception
+    {
+        return newSocket(endpoint, IDatabaseDescriptor.StaticDatabaseDescriptor.INSTANCE);
     }
 
     // Closing the socket will close the underlying channel.
     @SuppressWarnings("resource")
-    public static Socket newSocket(InetAddress endpoint) throws Exception
+    public static Socket newSocket(InetAddress endpoint, IDatabaseDescriptor dbDescriptor) throws Exception
     {
         // zero means 'bind on any available port.'
-        if (isEncryptedChannel(endpoint))
+        if (isEncryptedChannel(endpoint, dbDescriptor))
         {
             if (DatabaseDescriptor.getOutboundBindAny())
                 return SSLFactory.getSocket(DatabaseDescriptor.getServerEncryptionOptions(), endpoint, DatabaseDescriptor.getSSLStoragePort());
             else
-                return SSLFactory.getSocket(DatabaseDescriptor.getServerEncryptionOptions(), endpoint, DatabaseDescriptor.getSSLStoragePort(), FBUtilities.getLocalAddress(), 0);
+                return SSLFactory.getSocket(DatabaseDescriptor.getServerEncryptionOptions(), endpoint, DatabaseDescriptor.getSSLStoragePort(), dbDescriptor.getLocalAddress(), 0);
         }
         else
         {
@@ -146,12 +158,12 @@ public class OutboundTcpConnectionPool
 
     public InetAddress endPoint()
     {
-        if (id.equals(FBUtilities.getBroadcastAddress()))
-            return FBUtilities.getLocalAddress();
+        if (id.equals(dbDescriptor.getBroadcastAddress()))
+            return dbDescriptor.getLocalAddress();
         return resetEndpoint;
     }
 
-    public static boolean isEncryptedChannel(InetAddress address)
+    public static boolean isEncryptedChannel(InetAddress address, IDatabaseDescriptor dbDescriptor)
     {
         IEndpointSnitch snitch = DatabaseDescriptor.getEndpointSnitch();
         switch (DatabaseDescriptor.getServerEncryptionOptions().internode_encryption)
@@ -161,13 +173,13 @@ public class OutboundTcpConnectionPool
             case all:
                 break;
             case dc:
-                if (snitch.getDatacenter(address).equals(snitch.getDatacenter(FBUtilities.getBroadcastAddress())))
+                if (snitch.getDatacenter(address).equals(snitch.getDatacenter(dbDescriptor.getBroadcastAddress())))
                     return false;
                 break;
             case rack:
                 // for rack then check if the DC's are the same.
-                if (snitch.getRack(address).equals(snitch.getRack(FBUtilities.getBroadcastAddress()))
-                        && snitch.getDatacenter(address).equals(snitch.getDatacenter(FBUtilities.getBroadcastAddress())))
+                if (snitch.getRack(address).equals(snitch.getRack(dbDescriptor.getBroadcastAddress()))
+                    && snitch.getDatacenter(address).equals(snitch.getDatacenter(dbDescriptor.getBroadcastAddress())))
                     return false;
                 break;
         }

--- a/src/java/org/apache/cassandra/net/ResponseVerbHandler.java
+++ b/src/java/org/apache/cassandra/net/ResponseVerbHandler.java
@@ -28,10 +28,17 @@ public class ResponseVerbHandler implements IVerbHandler
 {
     private static final Logger logger = LoggerFactory.getLogger( ResponseVerbHandler.class );
 
+    private final MessagingService messagingService;
+
+    public ResponseVerbHandler(MessagingService messagingService)
+    {
+        this.messagingService = messagingService;
+    }
+
     public void doVerb(MessageIn message, int id)
     {
-        long latency = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - MessagingService.instance().getRegisteredCallbackAge(id));
-        CallbackInfo callbackInfo = MessagingService.instance().removeRegisteredCallback(id);
+        long latency = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - messagingService.getRegisteredCallbackAge(id));
+        CallbackInfo callbackInfo = messagingService.removeRegisteredCallback(id);
         if (callbackInfo == null)
         {
             String msg = "Callback already removed for {} (from {})";
@@ -49,7 +56,7 @@ public class ResponseVerbHandler implements IVerbHandler
         else
         {
             //TODO: Should we add latency only in success cases?
-            MessagingService.instance().maybeAddLatency(cb, message.from, latency);
+            messagingService.maybeAddLatency(cb, message.from, latency);
             cb.response(message);
         }
     }

--- a/src/java/org/apache/cassandra/service/EchoVerbHandler.java
+++ b/src/java/org/apache/cassandra/service/EchoVerbHandler.java
@@ -33,10 +33,17 @@ public class EchoVerbHandler implements IVerbHandler<EchoMessage>
 {
     private static final Logger logger = LoggerFactory.getLogger(EchoVerbHandler.class);
 
+    private final MessagingService messagingService;
+
+    public EchoVerbHandler(MessagingService messagingService)
+    {
+        this.messagingService = messagingService;
+    }
+
     public void doVerb(MessageIn<EchoMessage> message, int id)
     {
         MessageOut<EchoMessage> echoMessage = new MessageOut<EchoMessage>(MessagingService.Verb.REQUEST_RESPONSE, EchoMessage.instance, EchoMessage.serializer);
         logger.trace("Sending a EchoMessage reply {}", message.from);
-        MessagingService.instance().sendReply(echoMessage, id, message.from);
+        messagingService.sendReply(echoMessage, id, message.from);
     }
 }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -283,8 +283,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
         // see BootStrapper for a summary of how the bootstrap verbs interact
         MessagingService.instance().registerVerbHandlers(MessagingService.Verb.REPLICATION_FINISHED, new ReplicationFinishedVerbHandler());
-        MessagingService.instance().registerVerbHandlers(MessagingService.Verb.REQUEST_RESPONSE, new ResponseVerbHandler());
-        MessagingService.instance().registerVerbHandlers(MessagingService.Verb.INTERNAL_RESPONSE, new ResponseVerbHandler());
+        MessagingService.instance().registerVerbHandlers(MessagingService.Verb.REQUEST_RESPONSE, ResponseVerbHandler::new);
+        MessagingService.instance().registerVerbHandlers(MessagingService.Verb.INTERNAL_RESPONSE, ResponseVerbHandler::new);
         MessagingService.instance().registerVerbHandlers(MessagingService.Verb.REPAIR_MESSAGE, new RepairMessageVerbHandler());
         MessagingService.instance().registerVerbHandlers(MessagingService.Verb.GOSSIP_SHUTDOWN, new GossipShutdownVerbHandler());
 
@@ -297,7 +297,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         MessagingService.instance().registerVerbHandlers(MessagingService.Verb.MIGRATION_REQUEST, new MigrationRequestVerbHandler());
 
         MessagingService.instance().registerVerbHandlers(MessagingService.Verb.SNAPSHOT, new SnapshotVerbHandler());
-        MessagingService.instance().registerVerbHandlers(MessagingService.Verb.ECHO, new EchoVerbHandler());
+        MessagingService.instance().registerVerbHandlers(MessagingService.Verb.ECHO, EchoVerbHandler::new);
 
         MessagingService.instance().registerVerbHandlers(MessagingService.Verb.CROSS_VPC_IP_MAPPING_SYN, new CrossVpcIpMappingSynVerbHandler());
         MessagingService.instance().registerVerbHandlers(MessagingService.Verb.CROSS_VPC_IP_MAPPING_ACK, new CrossVpcIpMappingAckVerbHandler());

--- a/src/java/org/apache/cassandra/utils/ExpiringMap.java
+++ b/src/java/org/apache/cassandra/utils/ExpiringMap.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 
 import com.google.common.base.Function;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -182,5 +183,10 @@ public class ExpiringMap<K, V>
     public Set<K> keySet()
     {
         return cache.keySet();
+    }
+
+    public void forEach(BiConsumer<K, CacheableObject<V>> consumer)
+    {
+        cache.forEach(consumer);
     }
 }

--- a/test/unit/org/apache/cassandra/db/SerializationsTest.java
+++ b/test/unit/org/apache/cassandra/db/SerializationsTest.java
@@ -43,6 +43,7 @@ import org.apache.cassandra.utils.ByteBufferUtil;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -117,7 +118,7 @@ public class SerializationsTest extends AbstractSerializationsTester
 
         DataInputStream in = getInput("db.RangeSliceCommand.bin");
         for (int i = 0; i < 6; i++)
-            MessageIn.read(in, getVersion(), -1);
+            read(in, getVersion(), -1);
         in.close();
     }
 
@@ -151,8 +152,8 @@ public class SerializationsTest extends AbstractSerializationsTester
         assert SliceByNamesReadCommand.serializer.deserialize(in, getVersion()) != null;
         assert ReadCommand.serializer.deserialize(in, getVersion()) != null;
         assert ReadCommand.serializer.deserialize(in, getVersion()) != null;
-        assert MessageIn.read(in, getVersion(), -1) != null;
-        assert MessageIn.read(in, getVersion(), -1) != null;
+        assert read(in, getVersion(), -1) != null;
+        assert read(in, getVersion(), -1) != null;
         in.close();
     }
 
@@ -187,8 +188,8 @@ public class SerializationsTest extends AbstractSerializationsTester
         assert SliceFromReadCommand.serializer.deserialize(in, getVersion()) != null;
         assert ReadCommand.serializer.deserialize(in, getVersion()) != null;
         assert ReadCommand.serializer.deserialize(in, getVersion()) != null;
-        assert MessageIn.read(in, getVersion(), -1) != null;
-        assert MessageIn.read(in, getVersion(), -1) != null;
+        assert read(in, getVersion(), -1) != null;
+        assert read(in, getVersion(), -1) != null;
         in.close();
     }
 
@@ -267,11 +268,11 @@ public class SerializationsTest extends AbstractSerializationsTester
         assert Mutation.serializer.deserialize(in, getVersion()) != null;
         assert Mutation.serializer.deserialize(in, getVersion()) != null;
         assert Mutation.serializer.deserialize(in, getVersion()) != null;
-        assert MessageIn.read(in, getVersion(), -1) != null;
-        assert MessageIn.read(in, getVersion(), -1) != null;
-        assert MessageIn.read(in, getVersion(), -1) != null;
-        assert MessageIn.read(in, getVersion(), -1) != null;
-        assert MessageIn.read(in, getVersion(), -1) != null;
+        assert read(in, getVersion(), -1) != null;
+        assert read(in, getVersion(), -1) != null;
+        assert read(in, getVersion(), -1) != null;
+        assert read(in, getVersion(), -1) != null;
+        assert read(in, getVersion(), -1) != null;
         in.close();
     }
 
@@ -307,14 +308,14 @@ public class SerializationsTest extends AbstractSerializationsTester
         assert Truncation.serializer.deserialize(in, getVersion()) != null;
         assert TruncateResponse.serializer.deserialize(in, getVersion()) != null;
         assert TruncateResponse.serializer.deserialize(in, getVersion()) != null;
-        assert MessageIn.read(in, getVersion(), -1) != null;
+        assert read(in, getVersion(), -1) != null;
 
         // set up some fake callbacks so deserialization knows that what it's deserializing is a TruncateResponse
         MessagingService.instance().setCallbackForTests(1, new CallbackInfo(null, null, TruncateResponse.serializer, false));
         MessagingService.instance().setCallbackForTests(2, new CallbackInfo(null, null, TruncateResponse.serializer, false));
 
-        assert MessageIn.read(in, getVersion(), 1) != null;
-        assert MessageIn.read(in, getVersion(), 2) != null;
+        assert read(in, getVersion(), 1) != null;
+        assert read(in, getVersion(), 2) != null;
         in.close();
     }
 
@@ -352,6 +353,11 @@ public class SerializationsTest extends AbstractSerializationsTester
     private static CellName cn(String s)
     {
         return CellNames.simpleDense(ByteBufferUtil.bytes(s));
+    }
+
+    private static <T2> MessageIn<T2> read(DataInput in, int version, int id) throws IOException
+    {
+        return MessageIn.read(MessagingService.instance(), in, version, id);
     }
 
     private static class Statics

--- a/test/unit/org/apache/cassandra/net/MessagingServiceMultinodeTest.java
+++ b/test/unit/org/apache/cassandra/net/MessagingServiceMultinodeTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.net;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.ExecutionException;
+
+import com.google.common.util.concurrent.AbstractFuture;
+import org.junit.Test;
+
+import org.apache.cassandra.gms.EchoMessage;
+import org.apache.cassandra.service.EchoVerbHandler;
+
+public final class MessagingServiceMultinodeTest
+{
+
+    private static final FixedDatabaseDescriptor SERVER1;
+    private static final FixedDatabaseDescriptor SERVER2;
+
+    static
+    {
+        SERVER1 = FixedDatabaseDescriptor.create(127, 0, 0, 1);
+        SERVER2 = FixedDatabaseDescriptor.create(127, 0, 0, 2);
+    }
+
+    @Test
+    public void testEchoRequestResponse() throws ExecutionException, InterruptedException
+    {
+
+        // Note: server1 is only setup to receive responses, server 2 is only setup to receive requests.pushM
+        MessagingService server1 = MessagingService.test(SERVER1);
+        server1.registerVerbHandlers(MessagingService.Verb.REQUEST_RESPONSE, ResponseVerbHandler::new);
+        server1.listen();
+        MessagingService server2 = MessagingService.test(SERVER2);
+        server2.registerVerbHandlers(MessagingService.Verb.ECHO, EchoVerbHandler::new);
+        server2.listen();
+
+        MessageOut<EchoMessage> echoMessage = new MessageOut<>(MessagingService.Verb.ECHO, EchoMessage.instance, EchoMessage.serializer);
+
+        FutureCallback<EchoMessage> res = FutureCallback.create();
+        server1.sendRRWithFailure(echoMessage, SERVER2.address, res);
+
+        res.get();
+    }
+
+    private static final class FutureCallback<V> extends AbstractFuture<MessageIn<V>> implements IAsyncCallbackWithFailure<V>
+    {
+
+        public void onFailure(InetAddress from)
+        {
+            setException(new RuntimeException("Failed to send message to " + from));
+        }
+
+        public void response(MessageIn<V> msg)
+        {
+            set(msg);
+        }
+
+        public boolean isLatencyForSnitch()
+        {
+            return true;
+        }
+
+        static <V> FutureCallback<V> create()
+        {
+            return new FutureCallback<V>();
+        }
+    }
+
+    private static final class FixedDatabaseDescriptor implements IDatabaseDescriptor
+    {
+
+        private final InetAddress address;
+
+        private FixedDatabaseDescriptor(InetAddress address)
+        {
+            this.address = address;
+        }
+
+        public InetAddress getBroadcastRpcAddress()
+        {
+            return address;
+        }
+
+        public InetAddress getLocalAddress()
+        {
+            return address;
+        }
+
+        public InetAddress getBroadcastAddress()
+        {
+            return address;
+        }
+
+        public static FixedDatabaseDescriptor create(int a1, int a2, int a3, int a4)
+        {
+            try
+            {
+                return new FixedDatabaseDescriptor(InetAddress.getByAddress(new byte[]{ (byte) a1, (byte) a2, (byte) a3, (byte) a4 }));
+            }
+            catch (UnknownHostException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/service/SerializationsTest.java
+++ b/test/unit/org/apache/cassandra/service/SerializationsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.cassandra.service;
 
+import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -62,7 +63,7 @@ public class SerializationsTest extends AbstractSerializationsTester
             }
             // also serialize MessageOut
             for (RepairMessage message : messages)
-                message.createMessage().serialize(out,  getVersion());
+                message.createMessage().serialize(out,  getVersion(), FBUtilities.getBroadcastAddress());
         }
     }
 
@@ -85,7 +86,7 @@ public class SerializationsTest extends AbstractSerializationsTester
             assert DESC.equals(message.desc);
             assert ((ValidationRequest) message).gcBefore == 1234;
 
-            assert MessageIn.read(in, getVersion(), -1) != null;
+            assert read(in, getVersion(), -1) != null;
         }
     }
 
@@ -144,7 +145,7 @@ public class SerializationsTest extends AbstractSerializationsTester
 
             // MessageOuts
             for (int i = 0; i < 3; i++)
-                assert MessageIn.read(in, getVersion(), -1) != null;
+                assert read(in, getVersion(), -1) != null;
         }
     }
 
@@ -178,7 +179,7 @@ public class SerializationsTest extends AbstractSerializationsTester
             assert dest.equals(((SyncRequest) message).dst);
             assert ((SyncRequest) message).ranges.size() == 1 && ((SyncRequest) message).ranges.contains(FULL_RANGE);
 
-            assert MessageIn.read(in, getVersion(), -1) != null;
+            assert read(in, getVersion(), -1) != null;
         }
     }
 
@@ -224,7 +225,12 @@ public class SerializationsTest extends AbstractSerializationsTester
 
             // MessageOuts
             for (int i = 0; i < 2; i++)
-                assert MessageIn.read(in, getVersion(), -1) != null;
+                assert read(in, getVersion(), -1) != null;
         }
+    }
+
+    private static <T2> MessageIn<T2> read(DataInput in, int version, int id) throws IOException
+    {
+        return MessageIn.read(MessagingService.instance(), in, version, id);
     }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Cassandra uses static singletons for most of it's components. This makes it very convenient to dev (because you can always magically access everything from every part of the codebase, without having consideration for passing values down explicitly), but difficult to write unit tests where you would like to have multiple instances of the same component (i.e. multi-node messaging tests).

This PR attempted (seemingly successfully) to write a test that sends a request from one MessagingService to another, using local loopback interface aliases to achieve the ability to have multiple listening services on the same port.

This approach is much less invasive than forcing everything to use unique ports and single IP.

This will allow us to e.g. make improvements to connection reset handling.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

==COMMIT_MSG==
Multi-node unit testing setup to MessagingService.
==COMMIT_MSG==

## Possible downsides?

* It deviates from upstream: the diff is not that large and changes are mostly about passing instances explicitly instead of fetching them from static #instance() methods.
* Since in prod, everything should still be using the statics, this is unlikely to introduce bugs when we backport things from mainline. IMHO the only risk is hard-to-debug test failures for tests that use this multi-node functionality, so I'd judge the overhead to be low.
* I could've plausibly missed a bunch of codepaths: but as we write more tests we'll just discover them. Next PR would attempt to reproduce connection resets and fix them.

## Are Docs needed?
<!-- Please indicate whether documentation is needed for this PR. -->
