### PR TITLE
Add jmx endpoint to load new schema from disk

### DIFF
--- a/src/java/org/apache/cassandra/config/Schema.java
+++ b/src/java/org/apache/cassandra/config/Schema.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.config;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
+import java.util.stream.Collectors;
+
 import com.palantir.tracing.CloseableTracer;
 
 import com.google.common.base.Splitter;
@@ -127,6 +129,22 @@ public class Schema
         load(LegacySchemaTables.readSchemaFromSystemTables());
         if (updateVersion)
             updateVersion();
+        return this;
+    }
+
+    /**
+     * Load new keyspace schema definitions from disk.
+     * Schema version may be updated and announced as the result.
+     *
+     */
+    public Schema loadNewKeyspacesFromDisk()
+    {
+        Collection<KSMetaData> newKeyspaceDefs = LegacySchemaTables.readSchemaFromSystemTables()
+                                                                         .stream()
+                                                                         .filter(def -> !keyspaces.containsKey(def.name))
+                                                                         .collect(Collectors.toList());
+        load(newKeyspaceDefs);
+        updateVersionAndAnnounce();
         return this;
     }
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5231,6 +5231,12 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     }
 
     @Override
+    public void loadSchemaFromDiskForNewKeyspaces() {
+        logger.info("Loading schema from disk for newly added keyspaces");
+        Schema.instance.loadNewKeyspacesFromDisk();
+    }
+
+    @Override
     public boolean isNewCluster()
     {
         return Boolean.parseBoolean(System.getProperty("palantir_cassandra.is_new_cluster", "false"));

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -903,6 +903,11 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
 
     public boolean localQuorumReadsForSerialCasEnabled();
 
+    /**
+     * Load schema from disk for new keyspaces without restarting.
+     */
+    public void loadSchemaFromDiskForNewKeyspaces();
+
     public boolean isMigrating();
 
     /**


### PR DESCRIPTION
When performing a restore, this will allow us to load schema restored to system tables without restarting CassandraDaemon. 