### PR TITLE
Backport reloadLocalSchema jmx endpoint from CASSANDRA-13954

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -41,6 +41,7 @@ import com.google.common.collect.*;
 import com.google.common.util.concurrent.*;
 import com.palantir.cassandra.db.BootstrappingSafetyException;
 import com.palantir.cassandra.settings.LocalQuorumReadForSerialCasSetting;
+import org.apache.cassandra.schema.LegacySchemaTables;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -5077,6 +5078,14 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public void resetLocalSchema() throws IOException
     {
         MigrationManager.resetLocalSchema();
+    }
+
+    /**
+     * This API is backported from Cassandra 3 (CASSANDRA-13954).
+     */
+    public void reloadLocalSchema()
+    {
+        LegacySchemaTables.reloadSchemaAndAnnounceVersion();
     }
 
     public void setTraceProbability(double probability)

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -727,6 +727,8 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
 
     public void resetLocalSchema() throws IOException;
 
+    public void reloadLocalSchema();
+
     /**
      * Enables/Disables tracing for the whole system. Only thrift requests can start tracing currently.
      *

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1134,6 +1134,11 @@ public class NodeProbe implements AutoCloseable
         ssProxy.resetLocalSchema();
     }
 
+    public void reloadLocalSchema()
+    {
+        ssProxy.reloadLocalSchema();
+    }
+
     public boolean isFailed()
     {
         return failed;

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -142,6 +142,7 @@ public class NodeTool
                 EnableBackup.class,
                 DisableBackup.class,
                 ResetLocalSchema.class,
+                ReloadLocalSchema.class,
                 ReloadTriggers.class,
                 SetCacheKeysToSave.class,
                 DisableThrift.class,

--- a/src/java/org/apache/cassandra/tools/nodetool/ReloadLocalSchema.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/ReloadLocalSchema.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.tools.nodetool;
+
+import io.airlift.command.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
+
+@Command(name = "reloadlocalschema", description = "Reload local node schema from system tables")
+public class ReloadLocalSchema extends NodeToolCmd
+{
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        probe.reloadLocalSchema();
+    }
+}


### PR DESCRIPTION
Cherry-picked https://github.com/apache/cassandra/commit/d8a18f988f08de8504a45704632eff7f9494d82b with modification to account for the refactor of `LegacySchemaTables` and `SchemaKeyspace` in Cassandra 2 -> 3

original commit message: 

Provide a JMX call to sync schema with local storage

patch by Aleksey Yeschenko; reviewed by Sylvain Lebresne for [CASSANDRA-13954](https://issues.apache.org/jira/browse/CASSANDRA-13954)