### PR TITLE
backport rebuild API from Cassandra 3.11

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1378,6 +1378,19 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
     }
 
+    public void rebuild(String sourceDc, String keyspace, String tokens, String specificSources)
+    {
+        if (tokens != null)
+        {
+            throw new UnsupportedOperationException("Rebuild with specific tokens is not supported");
+        }
+        if (specificSources != null)
+        {
+            throw new UnsupportedOperationException("Rebuild with specificSources is not supported");
+        }
+        rebuild(sourceDc, keyspace);
+    }
+
     public boolean isRebuilding()
     {
         return isRebuilding.get();

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -654,10 +654,13 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
      * <p>
      * This API is Backported from Cassandra 3.11
      *
+     * @apiNote tokens and specificSources are not supported on this release and must be set to null.
+     *
      * @param sourceDc Name of DC from which to select sources for streaming or null to pick any node
      * @param keyspace Name of the keyspace which to rebuild or null to rebuild all keyspaces.
      * @param tokens   Range of tokens to rebuild or null to rebuild all token ranges. In the format of:
      *                 "(start_token_1,end_token_1],(start_token_2,end_token_2],...(start_token_n,end_token_n]"
+     * @param specificSources Comma-separated list of hostnames to stream from during the rebuild
      */
     public void rebuild(String sourceDc, String keyspace, String tokens, String specificSources);
 

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -646,6 +646,7 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
      * @param sourceDc Name of DC from which to select sources for streaming or null to pick any node
      * @param keyspace Name of the keyspace which to rebuild or null to rebuild all keyspaces.
      */
+    @Deprecated
     public void rebuild(String sourceDc, String keyspace);
 
     /**

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -648,6 +648,18 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
      */
     public void rebuild(String sourceDc, String keyspace);
 
+    /**
+     * Same as {@link #rebuild(String)}, but only for specified keyspace and ranges.
+     * <p>
+     * This API is Backported from Cassandra 3.11
+     *
+     * @param sourceDc Name of DC from which to select sources for streaming or null to pick any node
+     * @param keyspace Name of the keyspace which to rebuild or null to rebuild all keyspaces.
+     * @param tokens   Range of tokens to rebuild or null to rebuild all token ranges. In the format of:
+     *                 "(start_token_1,end_token_1],(start_token_2,end_token_2],...(start_token_n,end_token_n]"
+     */
+    public void rebuild(String sourceDc, String keyspace, String tokens, String specificSources);
+
     /** True if this node is rebuilding and receiving data. */
     public boolean isRebuilding();
 


### PR DESCRIPTION
To avoid breaking changes between major versions of Cassandra, it's useful for the JMX endpoints on this fork to match those on later releases of OSS Cassandra.

This PR adds another rebuild endpoint that matches the API [here](https://github.com/apache/cassandra/blob/9679206f7443328b8688e35f6f09ce284d4bfe21/src/java/org/apache/cassandra/service/StorageServiceMBean.java#L859), which exists in 3.11 and later.