### PR TITLE
move SeedProvider and AbstractNetworkTopologySnitch to InetAddressAndPort for forward compatibility

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -80,7 +80,19 @@
     <condition property="version" value="${base.version}">
       <isset property="release"/>
     </condition>
-    <property name="version" value="${base.version}-SNAPSHOT"/>
+    <exec executable="git" outputproperty="BUILD_NUMBER">
+      <arg value="describe"/>
+      <arg value="--tags"/>
+      <redirector>
+        <outputfilterchain>
+          <tokenfilter>
+            <replaceregex pattern="^[^-]+-" replace=""/>
+            <replaceregex pattern="-.+$" replace=""/>
+          </tokenfilter>
+        </outputfilterchain>
+      </redirector>
+    </exec>
+    <property name="version" value="${base.version}-${BUILD_NUMBER}"/>
     <property name="version.properties.dir"
               value="${build.src.resources}/org/apache/cassandra/config/" />
     <property name="final.name" value="${ant.project.name}-${version}"/>

--- a/build.xml
+++ b/build.xml
@@ -80,19 +80,7 @@
     <condition property="version" value="${base.version}">
       <isset property="release"/>
     </condition>
-    <exec executable="git" outputproperty="BUILD_NUMBER">
-      <arg value="describe"/>
-      <arg value="--tags"/>
-      <redirector>
-        <outputfilterchain>
-          <tokenfilter>
-            <replaceregex pattern="^[^-]+-" replace=""/>
-            <replaceregex pattern="-.+$" replace=""/>
-          </tokenfilter>
-        </outputfilterchain>
-      </redirector>
-    </exec>
-    <property name="version" value="${base.version}-${BUILD_NUMBER}"/>
+    <property name="version" value="${base.version}-SNAPSHOT"/>
     <property name="version.properties.dir"
               value="${build.src.resources}/org/apache/cassandra/config/" />
     <property name="final.name" value="${ant.project.name}-${version}"/>

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -295,6 +295,8 @@ public class DatabaseDescriptor
     public static void applyConfig(Config config) throws ConfigurationException
     {
         conf = config;
+        
+        InetAddressAndPort.initializeDefaultPort(getSSLStoragePort());
 
         if (conf.commitlog_sync == null)
         {

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -28,10 +28,8 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.primitives.Ints;

--- a/src/java/org/apache/cassandra/db/SystemKeyspace.java
+++ b/src/java/org/apache/cassandra/db/SystemKeyspace.java
@@ -667,28 +667,6 @@ public final class SystemKeyspace
     /**
      * Return a map of IP addresses containing a map of dc and rack info
      */
-    public static Map<InetAddress, Map<String, String>> loadDcRackInfoLegacy()
-    {
-        Map<InetAddress, Map<String, String>> result = new HashMap<>();
-        for (UntypedResultSet.Row row : executeInternal("SELECT peer, data_center, rack from system." + PEERS))
-        {
-            InetAddress peer = row.getInetAddress("peer");
-            if (row.has("data_center") && row.has("rack"))
-            {
-                Map<String, String> dcRack = new HashMap<>();
-                dcRack.put("data_center", row.getString("data_center"));
-                dcRack.put("rack", row.getString("rack"));
-                result.put(peer, dcRack);
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Return a map of IP addresses containing a map of dc and rack info
-     *
-     * @apiNote Shim for plugin forward compatibility. Do not use internally.
-     */
     public static Map<InetAddressAndPort, Map<String, String>> loadDcRackInfo()
     {
         Map<InetAddressAndPort, Map<String, String>> result = new HashMap<>();

--- a/src/java/org/apache/cassandra/db/SystemKeyspace.java
+++ b/src/java/org/apache/cassandra/db/SystemKeyspace.java
@@ -694,7 +694,7 @@ public final class SystemKeyspace
         Map<InetAddressAndPort, Map<String, String>> result = new HashMap<>();
         for (UntypedResultSet.Row row : executeInternal("SELECT peer, data_center, rack from system." + PEERS))
         {
-            InetAddressAndPort peer = InetAddressAndPort.wrap(row.getInetAddress("peer"));
+            InetAddressAndPort peer = InetAddressAndPort.getByAddress(row.getInetAddress("peer"));
             if (row.has("data_center") && row.has("rack"))
             {
                 Map<String, String> dcRack = new HashMap<>();

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -859,14 +859,12 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         return storedTime == null ? computeExpireTime() : storedTime;
     }
 
-    /**
-     * @apiNote Shim for plugin forward compatibility. Do not use internally.
-     */
     public EndpointState getEndpointStateForEndpoint(InetAddressAndPort ep)
     {
         return getEndpointStateForEndpoint(ep.address);
     }
 
+    @Deprecated
     public EndpointState getEndpointStateForEndpoint(InetAddress ep)
     {
         return endpointStateMap.get(ep);

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 
 import com.palantir.cassandra.cvim.CrossVpcIpMappingHandshaker;
+import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.MBeanWrapper;
 import org.apache.cassandra.utils.Pair;
@@ -856,6 +857,14 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         /* default expireTime is aVeryLongTime */
         Long storedTime = expireTimeEndpointMap.get(endpoint);
         return storedTime == null ? computeExpireTime() : storedTime;
+    }
+
+    /**
+     * @apiNote Shim for plugin forward compatibility. Do not use internally.
+     */
+    public EndpointState getEndpointStateForEndpoint(InetAddressAndPort ep)
+    {
+        return getEndpointStateForEndpoint(ep.address);
     }
 
     public EndpointState getEndpointStateForEndpoint(InetAddress ep)

--- a/src/java/org/apache/cassandra/locator/AbstractNetworkTopologySnitch.java
+++ b/src/java/org/apache/cassandra/locator/AbstractNetworkTopologySnitch.java
@@ -30,14 +30,30 @@ public abstract class AbstractNetworkTopologySnitch extends AbstractEndpointSnit
      * @param endpoint a specified endpoint
      * @return string of rack
      */
-    abstract public String getRack(InetAddress endpoint);
+    abstract public String getRack(InetAddressAndPort endpoint);
+
+    /**
+     * @apiNote Only override in tests!
+     */
+    public String getRack(InetAddress endpoint)
+    {
+        return getRack(InetAddressAndPort.wrap(endpoint));
+    }
 
     /**
      * Return the data center for which an endpoint resides in
      * @param endpoint a specified endpoint
      * @return string of data center
      */
-    abstract public String getDatacenter(InetAddress endpoint);
+    abstract public String getDatacenter(InetAddressAndPort endpoint);
+
+    /**
+     * @apiNote Only override in tests!
+     */
+    public String getDatacenter(InetAddress endpoint)
+    {
+        return getDatacenter(InetAddressAndPort.wrap(endpoint));
+    }
 
     public int compareEndpoints(InetAddress address, InetAddress a1, InetAddress a2)
     {

--- a/src/java/org/apache/cassandra/locator/AbstractNetworkTopologySnitch.java
+++ b/src/java/org/apache/cassandra/locator/AbstractNetworkTopologySnitch.java
@@ -37,7 +37,7 @@ public abstract class AbstractNetworkTopologySnitch extends AbstractEndpointSnit
      */
     public String getRack(InetAddress endpoint)
     {
-        return getRack(InetAddressAndPort.wrap(endpoint));
+        return getRack(InetAddressAndPort.getByAddress(endpoint));
     }
 
     /**
@@ -52,7 +52,7 @@ public abstract class AbstractNetworkTopologySnitch extends AbstractEndpointSnit
      */
     public String getDatacenter(InetAddress endpoint)
     {
-        return getDatacenter(InetAddressAndPort.wrap(endpoint));
+        return getDatacenter(InetAddressAndPort.getByAddress(endpoint));
     }
 
     public int compareEndpoints(InetAddress address, InetAddress a1, InetAddress a2)

--- a/src/java/org/apache/cassandra/locator/AbstractNetworkTopologySnitch.java
+++ b/src/java/org/apache/cassandra/locator/AbstractNetworkTopologySnitch.java
@@ -32,10 +32,7 @@ public abstract class AbstractNetworkTopologySnitch extends AbstractEndpointSnit
      */
     abstract public String getRack(InetAddressAndPort endpoint);
 
-    /**
-     * @apiNote Only override in tests!
-     */
-    public String getRack(InetAddress endpoint)
+    public final String getRack(InetAddress endpoint)
     {
         return getRack(InetAddressAndPort.getByAddress(endpoint));
     }
@@ -47,10 +44,7 @@ public abstract class AbstractNetworkTopologySnitch extends AbstractEndpointSnit
      */
     abstract public String getDatacenter(InetAddressAndPort endpoint);
 
-    /**
-     * @apiNote Only override in tests!
-     */
-    public String getDatacenter(InetAddress endpoint)
+    public final String getDatacenter(InetAddress endpoint)
     {
         return getDatacenter(InetAddressAndPort.getByAddress(endpoint));
     }

--- a/src/java/org/apache/cassandra/locator/AbstractNetworkTopologySnitch.java
+++ b/src/java/org/apache/cassandra/locator/AbstractNetworkTopologySnitch.java
@@ -32,7 +32,7 @@ public abstract class AbstractNetworkTopologySnitch extends AbstractEndpointSnit
      */
     abstract public String getRack(InetAddressAndPort endpoint);
 
-    public final String getRack(InetAddress endpoint)
+    public String getRack(InetAddress endpoint)
     {
         return getRack(InetAddressAndPort.getByAddress(endpoint));
     }
@@ -44,7 +44,7 @@ public abstract class AbstractNetworkTopologySnitch extends AbstractEndpointSnit
      */
     abstract public String getDatacenter(InetAddressAndPort endpoint);
 
-    public final String getDatacenter(InetAddress endpoint)
+    public String getDatacenter(InetAddress endpoint)
     {
         return getDatacenter(InetAddressAndPort.getByAddress(endpoint));
     }

--- a/src/java/org/apache/cassandra/locator/CloudstackSnitch.java
+++ b/src/java/org/apache/cassandra/locator/CloudstackSnitch.java
@@ -56,7 +56,7 @@ public class CloudstackSnitch extends AbstractNetworkTopologySnitch
     protected static final Logger logger = LoggerFactory.getLogger(CloudstackSnitch.class);
     protected static final String ZONE_NAME_QUERY_URI = "/latest/meta-data/availability-zone";
 
-    private Map<InetAddress, Map<String, String>> savedEndpoints;
+    private Map<InetAddressAndPort, Map<String, String>> savedEndpoints;
 
     private static final String DEFAULT_DC = "UNKNOWN-DC";
     private static final String DEFAULT_RACK = "UNKNOWN-RACK";
@@ -83,16 +83,15 @@ public class CloudstackSnitch extends AbstractNetworkTopologySnitch
         csZoneRack = zone_parts[2];
     }
 
-    public String getRack(InetAddressAndPort endpointAndPort)
+    public String getRack(InetAddressAndPort endpoint)
     {
-        InetAddress endpoint = endpointAndPort.address;
-        if (endpoint.equals(FBUtilities.getBroadcastAddress()))
+        if (endpoint.equals(FBUtilities.getBroadcastAddressAndPort()))
             return csZoneRack;
         EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
         if (state == null || state.getApplicationState(ApplicationState.RACK) == null) 
         {
             if (savedEndpoints == null)
-                savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
+                savedEndpoints = SystemKeyspace.loadDcRackInfo();
             if (savedEndpoints.containsKey(endpoint))
                 return savedEndpoints.get(endpoint).get("rack");
             return DEFAULT_RACK;
@@ -100,16 +99,15 @@ public class CloudstackSnitch extends AbstractNetworkTopologySnitch
         return state.getApplicationState(ApplicationState.RACK).value;
     }
 
-    public String getDatacenter(InetAddressAndPort endpointAndPort)
+    public String getDatacenter(InetAddressAndPort endpoint)
     {
-        InetAddress endpoint = endpointAndPort.address;
-        if (endpoint.equals(FBUtilities.getBroadcastAddress()))
+        if (endpoint.equals(FBUtilities.getBroadcastAddressAndPort()))
             return csZoneDc;
         EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
         if (state == null || state.getApplicationState(ApplicationState.DC) == null) 
         {
             if (savedEndpoints == null)
-                savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
+                savedEndpoints = SystemKeyspace.loadDcRackInfo();
             if (savedEndpoints.containsKey(endpoint))
                 return savedEndpoints.get(endpoint).get("data_center");
             return DEFAULT_DC;

--- a/src/java/org/apache/cassandra/locator/CloudstackSnitch.java
+++ b/src/java/org/apache/cassandra/locator/CloudstackSnitch.java
@@ -83,8 +83,9 @@ public class CloudstackSnitch extends AbstractNetworkTopologySnitch
         csZoneRack = zone_parts[2];
     }
 
-    public String getRack(InetAddress endpoint)
+    public String getRack(InetAddressAndPort endpointAndPort)
     {
+        InetAddress endpoint = endpointAndPort.address;
         if (endpoint.equals(FBUtilities.getBroadcastAddress()))
             return csZoneRack;
         EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
@@ -99,8 +100,9 @@ public class CloudstackSnitch extends AbstractNetworkTopologySnitch
         return state.getApplicationState(ApplicationState.RACK).value;
     }
 
-    public String getDatacenter(InetAddress endpoint)
+    public String getDatacenter(InetAddressAndPort endpointAndPort)
     {
+        InetAddress endpoint = endpointAndPort.address;
         if (endpoint.equals(FBUtilities.getBroadcastAddress()))
             return csZoneDc;
         EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);

--- a/src/java/org/apache/cassandra/locator/CloudstackSnitch.java
+++ b/src/java/org/apache/cassandra/locator/CloudstackSnitch.java
@@ -92,7 +92,7 @@ public class CloudstackSnitch extends AbstractNetworkTopologySnitch
         if (state == null || state.getApplicationState(ApplicationState.RACK) == null) 
         {
             if (savedEndpoints == null)
-                savedEndpoints = SystemKeyspace.loadDcRackInfo();
+                savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
             if (savedEndpoints.containsKey(endpoint))
                 return savedEndpoints.get(endpoint).get("rack");
             return DEFAULT_RACK;
@@ -109,7 +109,7 @@ public class CloudstackSnitch extends AbstractNetworkTopologySnitch
         if (state == null || state.getApplicationState(ApplicationState.DC) == null) 
         {
             if (savedEndpoints == null)
-                savedEndpoints = SystemKeyspace.loadDcRackInfo();
+                savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
             if (savedEndpoints.containsKey(endpoint))
                 return savedEndpoints.get(endpoint).get("data_center");
             return DEFAULT_DC;

--- a/src/java/org/apache/cassandra/locator/Ec2Snitch.java
+++ b/src/java/org/apache/cassandra/locator/Ec2Snitch.java
@@ -46,7 +46,7 @@ public class Ec2Snitch extends AbstractNetworkTopologySnitch
     protected static final String ZONE_NAME_QUERY_URL = "http://169.254.169.254/latest/meta-data/placement/availability-zone";
     private static final String DEFAULT_DC = "UNKNOWN-DC";
     private static final String DEFAULT_RACK = "UNKNOWN-RACK";
-    private Map<InetAddress, Map<String, String>> savedEndpoints;
+    private Map<InetAddressAndPort, Map<String, String>> savedEndpoints;
     protected String ec2zone;
     protected String ec2region;
 
@@ -92,16 +92,15 @@ public class Ec2Snitch extends AbstractNetworkTopologySnitch
         }
     }
 
-    public String getRack(InetAddressAndPort endpointAndPort)
+    public String getRack(InetAddressAndPort endpoint)
     {
-        InetAddress endpoint = endpointAndPort.address;
-        if (endpoint.equals(FBUtilities.getBroadcastAddress()))
+        if (endpoint.equals(FBUtilities.getBroadcastAddressAndPort()))
             return ec2zone;
         EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
         if (state == null || state.getApplicationState(ApplicationState.RACK) == null)
         {
             if (savedEndpoints == null)
-                savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
+                savedEndpoints = SystemKeyspace.loadDcRackInfo();
             if (savedEndpoints.containsKey(endpoint))
                 return savedEndpoints.get(endpoint).get("rack");
             return DEFAULT_RACK;
@@ -109,16 +108,15 @@ public class Ec2Snitch extends AbstractNetworkTopologySnitch
         return state.getApplicationState(ApplicationState.RACK).value;
     }
 
-    public String getDatacenter(InetAddressAndPort endpointAndPort)
+    public String getDatacenter(InetAddressAndPort endpoint)
     {
-        InetAddress endpoint = endpointAndPort.address;
-        if (endpoint.equals(FBUtilities.getBroadcastAddress()))
+        if (endpoint.equals(FBUtilities.getBroadcastAddressAndPort()))
             return ec2region;
         EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
         if (state == null || state.getApplicationState(ApplicationState.DC) == null)
         {
             if (savedEndpoints == null)
-                savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
+                savedEndpoints = SystemKeyspace.loadDcRackInfo();
             if (savedEndpoints.containsKey(endpoint))
                 return savedEndpoints.get(endpoint).get("data_center");
             return DEFAULT_DC;

--- a/src/java/org/apache/cassandra/locator/Ec2Snitch.java
+++ b/src/java/org/apache/cassandra/locator/Ec2Snitch.java
@@ -92,8 +92,9 @@ public class Ec2Snitch extends AbstractNetworkTopologySnitch
         }
     }
 
-    public String getRack(InetAddress endpoint)
+    public String getRack(InetAddressAndPort endpointAndPort)
     {
+        InetAddress endpoint = endpointAndPort.address;
         if (endpoint.equals(FBUtilities.getBroadcastAddress()))
             return ec2zone;
         EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
@@ -108,8 +109,9 @@ public class Ec2Snitch extends AbstractNetworkTopologySnitch
         return state.getApplicationState(ApplicationState.RACK).value;
     }
 
-    public String getDatacenter(InetAddress endpoint)
+    public String getDatacenter(InetAddressAndPort endpointAndPort)
     {
+        InetAddress endpoint = endpointAndPort.address;
         if (endpoint.equals(FBUtilities.getBroadcastAddress()))
             return ec2region;
         EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);

--- a/src/java/org/apache/cassandra/locator/Ec2Snitch.java
+++ b/src/java/org/apache/cassandra/locator/Ec2Snitch.java
@@ -101,7 +101,7 @@ public class Ec2Snitch extends AbstractNetworkTopologySnitch
         if (state == null || state.getApplicationState(ApplicationState.RACK) == null)
         {
             if (savedEndpoints == null)
-                savedEndpoints = SystemKeyspace.loadDcRackInfo();
+                savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
             if (savedEndpoints.containsKey(endpoint))
                 return savedEndpoints.get(endpoint).get("rack");
             return DEFAULT_RACK;
@@ -118,7 +118,7 @@ public class Ec2Snitch extends AbstractNetworkTopologySnitch
         if (state == null || state.getApplicationState(ApplicationState.DC) == null)
         {
             if (savedEndpoints == null)
-                savedEndpoints = SystemKeyspace.loadDcRackInfo();
+                savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
             if (savedEndpoints.containsKey(endpoint))
                 return savedEndpoints.get(endpoint).get("data_center");
             return DEFAULT_DC;

--- a/src/java/org/apache/cassandra/locator/GoogleCloudSnitch.java
+++ b/src/java/org/apache/cassandra/locator/GoogleCloudSnitch.java
@@ -94,8 +94,9 @@ public class GoogleCloudSnitch extends AbstractNetworkTopologySnitch
         }
     }
 
-    public String getRack(InetAddress endpoint)
+    public String getRack(InetAddressAndPort endpointAndPort)
     {
+        InetAddress endpoint = endpointAndPort.address;
         if (endpoint.equals(FBUtilities.getBroadcastAddress()))
             return gceZone;
         EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
@@ -110,8 +111,9 @@ public class GoogleCloudSnitch extends AbstractNetworkTopologySnitch
         return state.getApplicationState(ApplicationState.RACK).value;
     }
 
-    public String getDatacenter(InetAddress endpoint)
+    public String getDatacenter(InetAddressAndPort endpointAndPort)
     {
+        InetAddress endpoint = endpointAndPort.address;
         if (endpoint.equals(FBUtilities.getBroadcastAddress()))
             return gceRegion;
         EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);

--- a/src/java/org/apache/cassandra/locator/GoogleCloudSnitch.java
+++ b/src/java/org/apache/cassandra/locator/GoogleCloudSnitch.java
@@ -103,7 +103,7 @@ public class GoogleCloudSnitch extends AbstractNetworkTopologySnitch
         if (state == null || state.getApplicationState(ApplicationState.RACK) == null)
         {
             if (savedEndpoints == null)
-                savedEndpoints = SystemKeyspace.loadDcRackInfo();
+                savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
             if (savedEndpoints.containsKey(endpoint))
                 return savedEndpoints.get(endpoint).get("rack");
             return DEFAULT_RACK;
@@ -120,7 +120,7 @@ public class GoogleCloudSnitch extends AbstractNetworkTopologySnitch
         if (state == null || state.getApplicationState(ApplicationState.DC) == null)
         {
             if (savedEndpoints == null)
-                savedEndpoints = SystemKeyspace.loadDcRackInfo();
+                savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
             if (savedEndpoints.containsKey(endpoint))
                 return savedEndpoints.get(endpoint).get("data_center");
             return DEFAULT_DC;

--- a/src/java/org/apache/cassandra/locator/GossipingPropertyFileSnitch.java
+++ b/src/java/org/apache/cassandra/locator/GossipingPropertyFileSnitch.java
@@ -81,11 +81,12 @@ public class GossipingPropertyFileSnitch extends AbstractNetworkTopologySnitch//
     /**
      * Return the data center for which an endpoint resides in
      *
-     * @param endpoint the endpoint to process
+     * @param endpointAndPort the endpoint to process
      * @return string of data center
      */
-    public String getDatacenter(InetAddress endpoint)
+    public String getDatacenter(InetAddressAndPort endpointAndPort)
     {
+        InetAddress endpoint = endpointAndPort.address;
         if (endpoint.equals(FBUtilities.getBroadcastAddress()))
             return myDC;
 
@@ -109,11 +110,12 @@ public class GossipingPropertyFileSnitch extends AbstractNetworkTopologySnitch//
     /**
      * Return the rack for which an endpoint resides in
      *
-     * @param endpoint the endpoint to process
+     * @param endpointAndPort the endpoint to process
      * @return string of rack
      */
-    public String getRack(InetAddress endpoint)
+    public String getRack(InetAddressAndPort endpointAndPort)
     {
+        InetAddress endpoint = endpointAndPort.address;
         if (endpoint.equals(FBUtilities.getBroadcastAddress()))
             return myRack;
 

--- a/src/java/org/apache/cassandra/locator/GossipingPropertyFileSnitch.java
+++ b/src/java/org/apache/cassandra/locator/GossipingPropertyFileSnitch.java
@@ -45,7 +45,7 @@ public class GossipingPropertyFileSnitch extends AbstractNetworkTopologySnitch//
     private final boolean preferLocal;
     private final AtomicReference<ReconnectableSnitchHelper> snitchHelperReference;
 
-    private Map<InetAddress, Map<String, String>> savedEndpoints;
+    private Map<InetAddressAndPort, Map<String, String>> savedEndpoints;
     private static final String DEFAULT_DC = "UNKNOWN_DC";
     private static final String DEFAULT_RACK = "UNKNOWN_RACK";
 
@@ -81,13 +81,12 @@ public class GossipingPropertyFileSnitch extends AbstractNetworkTopologySnitch//
     /**
      * Return the data center for which an endpoint resides in
      *
-     * @param endpointAndPort the endpoint to process
+     * @param endpoint the endpoint to process
      * @return string of data center
      */
-    public String getDatacenter(InetAddressAndPort endpointAndPort)
+    public String getDatacenter(InetAddressAndPort endpoint)
     {
-        InetAddress endpoint = endpointAndPort.address;
-        if (endpoint.equals(FBUtilities.getBroadcastAddress()))
+        if (endpoint.equals(FBUtilities.getBroadcastAddressAndPort()))
             return myDC;
 
         EndpointState epState = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
@@ -96,7 +95,7 @@ public class GossipingPropertyFileSnitch extends AbstractNetworkTopologySnitch//
             if (psnitch == null)
             {
                 if (savedEndpoints == null)
-                    savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
+                    savedEndpoints = SystemKeyspace.loadDcRackInfo();
                 if (savedEndpoints.containsKey(endpoint))
                     return savedEndpoints.get(endpoint).get("data_center");
                 return DEFAULT_DC;
@@ -110,13 +109,12 @@ public class GossipingPropertyFileSnitch extends AbstractNetworkTopologySnitch//
     /**
      * Return the rack for which an endpoint resides in
      *
-     * @param endpointAndPort the endpoint to process
+     * @param endpoint the endpoint to process
      * @return string of rack
      */
-    public String getRack(InetAddressAndPort endpointAndPort)
+    public String getRack(InetAddressAndPort endpoint)
     {
-        InetAddress endpoint = endpointAndPort.address;
-        if (endpoint.equals(FBUtilities.getBroadcastAddress()))
+        if (endpoint.equals(FBUtilities.getBroadcastAddressAndPort()))
             return myRack;
 
         EndpointState epState = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
@@ -125,7 +123,7 @@ public class GossipingPropertyFileSnitch extends AbstractNetworkTopologySnitch//
             if (psnitch == null)
             {
                 if (savedEndpoints == null)
-                    savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
+                    savedEndpoints = SystemKeyspace.loadDcRackInfo();
                 if (savedEndpoints.containsKey(endpoint))
                     return savedEndpoints.get(endpoint).get("rack");
                 return DEFAULT_RACK;

--- a/src/java/org/apache/cassandra/locator/GossipingPropertyFileSnitch.java
+++ b/src/java/org/apache/cassandra/locator/GossipingPropertyFileSnitch.java
@@ -96,7 +96,7 @@ public class GossipingPropertyFileSnitch extends AbstractNetworkTopologySnitch//
             if (psnitch == null)
             {
                 if (savedEndpoints == null)
-                    savedEndpoints = SystemKeyspace.loadDcRackInfo();
+                    savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
                 if (savedEndpoints.containsKey(endpoint))
                     return savedEndpoints.get(endpoint).get("data_center");
                 return DEFAULT_DC;
@@ -125,7 +125,7 @@ public class GossipingPropertyFileSnitch extends AbstractNetworkTopologySnitch//
             if (psnitch == null)
             {
                 if (savedEndpoints == null)
-                    savedEndpoints = SystemKeyspace.loadDcRackInfo();
+                    savedEndpoints = SystemKeyspace.loadDcRackInfoLegacy();
                 if (savedEndpoints.containsKey(endpoint))
                     return savedEndpoints.get(endpoint).get("rack");
                 return DEFAULT_RACK;

--- a/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
+++ b/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
@@ -203,4 +203,9 @@ public final class InetAddressAndPort implements Comparable<InetAddressAndPort>,
     {
         return new InetAddressAndPort(address);
     }
+
+    public static InetAddressAndPort getLocalHost()
+    {
+        return FBUtilities.getLocalAddressAndPort();
+    }
 }

--- a/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
+++ b/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
@@ -49,7 +49,7 @@ public final class InetAddressAndPort implements Comparable<InetAddressAndPort>,
     //these when it loads the config. A lot of unit tests won't end up loading DatabaseDescriptor.
     //Tools that might use this class also might not load database descriptor. Those tools are expected
     //to always override the defaults.
-    static volatile int defaultPort = 7000;
+    static volatile int defaultPort = 7001;
 
     public final InetAddress address;
     public final byte[] addressBytes;
@@ -197,11 +197,6 @@ public final class InetAddressAndPort implements Comparable<InetAddressAndPort>,
     public static void initializeDefaultPort(int port)
     {
         defaultPort = port;
-    }
-
-    public static InetAddressAndPort wrap(InetAddress address)
-    {
-        return new InetAddressAndPort(address);
     }
 
     public static InetAddressAndPort getLocalHost()

--- a/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
+++ b/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
@@ -65,13 +65,6 @@ public final class InetAddressAndPort implements Comparable<InetAddressAndPort>,
         this.addressBytes = addressBytes;
     }
 
-    private InetAddressAndPort(InetAddress address)
-    {
-        this.address = address;
-        this.port = -1;
-        this.addressBytes = null;
-    }
-
     private static void validatePortRange(int port)
     {
         if (port < 0 | port > 65535)

--- a/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
+++ b/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
@@ -65,6 +65,13 @@ public final class InetAddressAndPort implements Comparable<InetAddressAndPort>,
         this.addressBytes = addressBytes;
     }
 
+    private InetAddressAndPort(InetAddress address)
+    {
+        this.address = address;
+        this.port = -1;
+        this.addressBytes = null;
+    }
+
     private static void validatePortRange(int port)
     {
         if (port < 0 | port > 65535)
@@ -190,5 +197,10 @@ public final class InetAddressAndPort implements Comparable<InetAddressAndPort>,
     public static void initializeDefaultPort(int port)
     {
         defaultPort = port;
+    }
+
+    static InetAddressAndPort wrap(InetAddress address)
+    {
+        return new InetAddressAndPort(address);
     }
 }

--- a/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
+++ b/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
@@ -199,7 +199,7 @@ public final class InetAddressAndPort implements Comparable<InetAddressAndPort>,
         defaultPort = port;
     }
 
-    static InetAddressAndPort wrap(InetAddress address)
+    public static InetAddressAndPort wrap(InetAddress address)
     {
         return new InetAddressAndPort(address);
     }

--- a/src/java/org/apache/cassandra/locator/PropertyFileSnitch.java
+++ b/src/java/org/apache/cassandra/locator/PropertyFileSnitch.java
@@ -115,28 +115,26 @@ public class PropertyFileSnitch extends AbstractNetworkTopologySnitch
     /**
      * Return the data center for which an endpoint resides in
      *
-     * @param endpointAndPort the endpoint to process
+     * @param endpoint the endpoint to process
      * @return string of data center
      */
-    public String getDatacenter(InetAddressAndPort endpointAndPort)
+    public String getDatacenter(InetAddressAndPort endpoint)
     {
-        InetAddress endpoint = endpointAndPort.address;
-        String[] info = getEndpointInfo(endpoint);
-        assert info != null : "No location defined for endpoint " + endpoint;
+        String[] info = getEndpointInfo(endpoint.address);
+        assert info != null : "No location defined for endpoint " + endpoint.address;
         return info[0];
     }
 
     /**
      * Return the rack for which an endpoint resides in
      *
-     * @param endpointAndPort the endpoint to process
+     * @param endpoint the endpoint to process
      * @return string of rack
      */
-    public String getRack(InetAddressAndPort endpointAndPort)
+    public String getRack(InetAddressAndPort endpoint)
     {
-        InetAddress endpoint = endpointAndPort.address;
-        String[] info = getEndpointInfo(endpoint);
-        assert info != null : "No location defined for endpoint " + endpoint;
+        String[] info = getEndpointInfo(endpoint.address);
+        assert info != null : "No location defined for endpoint " + endpoint.address;
         return info[1];
     }
 

--- a/src/java/org/apache/cassandra/locator/PropertyFileSnitch.java
+++ b/src/java/org/apache/cassandra/locator/PropertyFileSnitch.java
@@ -115,11 +115,12 @@ public class PropertyFileSnitch extends AbstractNetworkTopologySnitch
     /**
      * Return the data center for which an endpoint resides in
      *
-     * @param endpoint the endpoint to process
+     * @param endpointAndPort the endpoint to process
      * @return string of data center
      */
-    public String getDatacenter(InetAddress endpoint)
+    public String getDatacenter(InetAddressAndPort endpointAndPort)
     {
+        InetAddress endpoint = endpointAndPort.address;
         String[] info = getEndpointInfo(endpoint);
         assert info != null : "No location defined for endpoint " + endpoint;
         return info[0];
@@ -128,11 +129,12 @@ public class PropertyFileSnitch extends AbstractNetworkTopologySnitch
     /**
      * Return the rack for which an endpoint resides in
      *
-     * @param endpoint the endpoint to process
+     * @param endpointAndPort the endpoint to process
      * @return string of rack
      */
-    public String getRack(InetAddress endpoint)
+    public String getRack(InetAddressAndPort endpointAndPort)
     {
+        InetAddress endpoint = endpointAndPort.address;
         String[] info = getEndpointInfo(endpoint);
         assert info != null : "No location defined for endpoint " + endpoint;
         return info[1];

--- a/src/java/org/apache/cassandra/locator/RackInferringSnitch.java
+++ b/src/java/org/apache/cassandra/locator/RackInferringSnitch.java
@@ -25,13 +25,13 @@ import java.net.InetAddress;
  */
 public class RackInferringSnitch extends AbstractNetworkTopologySnitch
 {
-    public String getRack(InetAddress endpoint)
+    public String getRack(InetAddressAndPort endpoint)
     {
-        return Integer.toString(endpoint.getAddress()[2] & 0xFF, 10);
+        return Integer.toString(endpoint.address.getAddress()[2] & 0xFF, 10);
     }
 
-    public String getDatacenter(InetAddress endpoint)
+    public String getDatacenter(InetAddressAndPort endpoint)
     {
-        return Integer.toString(endpoint.getAddress()[1] & 0xFF, 10);
+        return Integer.toString(endpoint.address.getAddress()[1] & 0xFF, 10);
     }
 }

--- a/src/java/org/apache/cassandra/locator/SeedProvider.java
+++ b/src/java/org/apache/cassandra/locator/SeedProvider.java
@@ -22,5 +22,5 @@ import java.util.List;
 
 public interface SeedProvider
 {
-    List<InetAddress> getSeeds();
+    List<InetAddressAndPort> getSeeds();
 }

--- a/src/java/org/apache/cassandra/locator/SimpleSeedProvider.java
+++ b/src/java/org/apache/cassandra/locator/SimpleSeedProvider.java
@@ -60,6 +60,6 @@ public class SimpleSeedProvider implements SeedProvider
                 logger.warn("Seed provider couldn't lookup host {}", host);
             }
         }
-        return seeds;
+        return Collections.unmodifiableList(seeds);
     }
 }

--- a/src/java/org/apache/cassandra/locator/SimpleSeedProvider.java
+++ b/src/java/org/apache/cassandra/locator/SimpleSeedProvider.java
@@ -35,7 +35,7 @@ public class SimpleSeedProvider implements SeedProvider
 
     public SimpleSeedProvider(Map<String, String> args) {}
 
-    public List<InetAddress> getSeeds()
+    public List<InetAddressAndPort> getSeeds()
     {
         Config conf;
         try
@@ -47,12 +47,12 @@ public class SimpleSeedProvider implements SeedProvider
             throw new AssertionError(e);
         }
         String[] hosts = conf.seed_provider.parameters.get("seeds").split(",", -1);
-        List<InetAddress> seeds = new ArrayList<InetAddress>(hosts.length);
+        List<InetAddressAndPort> seeds = new ArrayList<>(hosts.length);
         for (String host : hosts)
         {
             try
             {
-                seeds.add(InetAddress.getByName(host.trim()));
+                seeds.add(InetAddressAndPort.wrap(InetAddress.getByName(host.trim())));
             }
             catch (UnknownHostException ex)
             {
@@ -60,6 +60,6 @@ public class SimpleSeedProvider implements SeedProvider
                 logger.warn("Seed provider couldn't lookup host {}", host);
             }
         }
-        return Collections.unmodifiableList(seeds);
+        return seeds;
     }
 }

--- a/src/java/org/apache/cassandra/locator/SimpleSeedProvider.java
+++ b/src/java/org/apache/cassandra/locator/SimpleSeedProvider.java
@@ -52,7 +52,7 @@ public class SimpleSeedProvider implements SeedProvider
         {
             try
             {
-                seeds.add(InetAddressAndPort.wrap(InetAddress.getByName(host.trim())));
+                seeds.add(InetAddressAndPort.getByName(host.trim()));
             }
             catch (UnknownHostException ex)
             {

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -149,7 +149,7 @@ public class FBUtilities
      */
     public static InetAddressAndPort getBroadcastAddressAndPort()
     {
-        return InetAddressAndPort.wrap(getBroadcastAddress());
+        return InetAddressAndPort.getByAddress(getBroadcastAddress());
     }
 
     /**
@@ -158,7 +158,7 @@ public class FBUtilities
      */
     public static InetAddressAndPort getLocalAddressAndPort()
     {
-        return InetAddressAndPort.wrap(FBUtilities.getLocalAddress());
+        return InetAddressAndPort.getByAddress(getLocalAddress());
     }
 
     public static InetAddress getBroadcastAddress()

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -152,6 +152,15 @@ public class FBUtilities
         return InetAddressAndPort.wrap(getBroadcastAddress());
     }
 
+    /**
+     * @return an {@link InetAddressAndPort} that can only contains a value in the address field
+     * @apiNote Shim for plugin forward compatibility. Do not use internally.
+     */
+    public static InetAddressAndPort getLocalAddressAndPort()
+    {
+        return InetAddressAndPort.wrap(FBUtilities.getLocalAddress());
+    }
+
     public static InetAddress getBroadcastAddress()
     {
         if (broadcastInetAddress == null)

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -144,8 +144,9 @@ public class FBUtilities
     }
 
     /**
-     * @return an {@link InetAddressAndPort} that can only contains a value in the address field
-     * @apiNote Shim for plugin forward compatibility. Do not use internally.
+     * Get the broadcast address and port for intra-cluster storage traffic. This the address to advertise that uniquely
+     * identifies the node and is reachable from everywhere. This is the one you want unless you are trying to connect
+     * to the local address specifically.
      */
     public static InetAddressAndPort getBroadcastAddressAndPort()
     {
@@ -153,8 +154,8 @@ public class FBUtilities
     }
 
     /**
-     * @return an {@link InetAddressAndPort} that can only contains a value in the address field
-     * @apiNote Shim for plugin forward compatibility. Do not use internally.
+     * The address and port to listen on for intra-cluster storage traffic (not client). Use this to get the correct
+     * stuff to listen on for intra-cluster communication.
      */
     public static InetAddressAndPort getLocalAddressAndPort()
     {

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -143,6 +143,15 @@ public class FBUtilities
         return localInetAddress;
     }
 
+    /**
+     * @return an {@link InetAddressAndPort} that can only contains a value in the address field
+     * @apiNote Shim for plugin forward compatibility. Do not use internally.
+     */
+    public static InetAddressAndPort getBroadcastAddressAndPort()
+    {
+        return InetAddressAndPort.wrap(getBroadcastAddress());
+    }
+
     public static InetAddress getBroadcastAddress()
     {
         if (broadcastInetAddress == null)

--- a/test/distributed/org/apache/cassandra/distributed/impl/DistributedTestSnitch.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/DistributedTestSnitch.java
@@ -105,7 +105,7 @@ public class DistributedTestSnitch extends AbstractNetworkTopologySnitch
             {
                 savedEndpoints = new HashMap<>();
                 int storage_port = Config.getOverrideLoadConfig().get().storage_port;
-                for (Map.Entry<InetAddress, Map<String, String>> entry : SystemKeyspace.loadDcRackInfoLegacy().entrySet())
+                for (Map.Entry<InetAddressAndPort, Map<String, String>> entry : SystemKeyspace.loadDcRackInfo().entrySet())
                 {
                     savedEndpoints.put(InetAddressAndPort.getByAddressOverrideDefaults(endpoint.address, storage_port),
                                        entry.getValue());

--- a/test/distributed/org/apache/cassandra/distributed/impl/DistributedTestSnitch.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/DistributedTestSnitch.java
@@ -105,7 +105,7 @@ public class DistributedTestSnitch extends AbstractNetworkTopologySnitch
             {
                 savedEndpoints = new HashMap<>();
                 int storage_port = Config.getOverrideLoadConfig().get().storage_port;
-                for (Map.Entry<InetAddress, Map<String, String>> entry : SystemKeyspace.loadDcRackInfo().entrySet())
+                for (Map.Entry<InetAddress, Map<String, String>> entry : SystemKeyspace.loadDcRackInfoLegacy().entrySet())
                 {
                     savedEndpoints.put(InetAddressAndPort.getByAddressOverrideDefaults(endpoint.address, storage_port),
                                        entry.getValue());

--- a/test/unit/org/apache/cassandra/service/LeaveAndBootstrapTest.java
+++ b/test/unit/org/apache/cassandra/service/LeaveAndBootstrapTest.java
@@ -23,6 +23,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.*;
 
+import org.apache.cassandra.locator.InetAddressAndPort;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -672,7 +673,7 @@ public class LeaveAndBootstrapTest
         InetAddress toRemove = hosts.get(1);
         SystemKeyspace.updatePeerInfo(toRemove, "data_center", "dc42");
         SystemKeyspace.updatePeerInfo(toRemove, "rack", "rack42");
-        assertEquals("rack42", SystemKeyspace.loadDcRackInfoLegacy().get(toRemove).get("rack"));
+        assertEquals("rack42", SystemKeyspace.loadDcRackInfo().get(InetAddressAndPort.getByAddress(toRemove)).get("rack"));
 
         // mark the node as removed
         Gossiper.instance.injectApplicationState(toRemove, ApplicationState.STATUS,
@@ -682,7 +683,7 @@ public class LeaveAndBootstrapTest
         // state changes made after the endpoint has left should be ignored
         ss.onChange(hosts.get(1), ApplicationState.RACK,
                 valueFactory.rack("rack9999"));
-        assertEquals("rack42", SystemKeyspace.loadDcRackInfoLegacy().get(toRemove).get("rack"));
+        assertEquals("rack42", SystemKeyspace.loadDcRackInfo().get(InetAddressAndPort.getByAddress(toRemove)).get("rack"));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/service/LeaveAndBootstrapTest.java
+++ b/test/unit/org/apache/cassandra/service/LeaveAndBootstrapTest.java
@@ -672,7 +672,7 @@ public class LeaveAndBootstrapTest
         InetAddress toRemove = hosts.get(1);
         SystemKeyspace.updatePeerInfo(toRemove, "data_center", "dc42");
         SystemKeyspace.updatePeerInfo(toRemove, "rack", "rack42");
-        assertEquals("rack42", SystemKeyspace.loadDcRackInfo().get(toRemove).get("rack"));
+        assertEquals("rack42", SystemKeyspace.loadDcRackInfoLegacy().get(toRemove).get("rack"));
 
         // mark the node as removed
         Gossiper.instance.injectApplicationState(toRemove, ApplicationState.STATUS,
@@ -682,7 +682,7 @@ public class LeaveAndBootstrapTest
         // state changes made after the endpoint has left should be ignored
         ss.onChange(hosts.get(1), ApplicationState.RACK,
                 valueFactory.rack("rack9999"));
-        assertEquals("rack42", SystemKeyspace.loadDcRackInfo().get(toRemove).get("rack"));
+        assertEquals("rack42", SystemKeyspace.loadDcRackInfoLegacy().get(toRemove).get("rack"));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/service/MoveTest.java
+++ b/test/unit/org/apache/cassandra/service/MoveTest.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.marshal.BytesType;
 import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.locator.AbstractNetworkTopologySnitch;
+import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.NetworkTopologyStrategy;
 import org.apache.cassandra.locator.PendingRangeMaps;
 import org.junit.AfterClass;
@@ -106,9 +107,9 @@ public class MoveTest
             //Odd IPs are in DC1 and Even are in DC2. Endpoints upto .14 will have unique racks and
             // then will be same for a set of three.
             @Override
-            public String getRack(InetAddress endpoint)
+            public String getRack(InetAddressAndPort endpoint)
             {
-                int ipLastPart = getIPLastPart(endpoint);
+                int ipLastPart = getIPLastPart(endpoint.address);
                 if (ipLastPart <= 14)
                     return UUID.randomUUID().toString();
                 else
@@ -116,9 +117,9 @@ public class MoveTest
             }
 
             @Override
-            public String getDatacenter(InetAddress endpoint)
+            public String getDatacenter(InetAddressAndPort endpoint)
             {
-                if (getIPLastPart(endpoint) % 2 == 0)
+                if (getIPLastPart(endpoint.address) % 2 == 0)
                     return "DC2";
                 else
                     return "DC1";


### PR DESCRIPTION
Modern versions of Cassandra use InetAdderssAndPort in place of InetAddress. To avoid maintaining two implementations of every custom SeedProvider and AbstractNetworkTopologySnitch we use internally, this PR switches some usage of InetAddress to InetAddressAndPort.

This allows us to maintain implementations of SeedProvider and AbstractNetworkTopologySnitch that are compile-time compatible with this fork, and with OSS trunk.