### PR TITLE
Persist isCompacted status of SSTables and scrub on startup

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -608,13 +608,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
             Descriptor desc = sstableFiles.getKey();
             Set<Component> components = sstableFiles.getValue();
 
-            if (desc.type.isTemporary)
+            if (desc.type.isTemporary || components.contains(Component.OBSOLETE))
             {
-                SSTable.delete(desc, components);
-                continue;
-            }
-
-            if (components.contains(Component.IS_COMPACTED)) {
                 SSTable.delete(desc, components);
                 continue;
             }
@@ -843,7 +838,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
                 continue; // old (initialized) SSTable found, skipping
             if (descriptor.type.isTemporary) // in the process of being written
                 continue;
-            if (entry.getValue().contains(Component.IS_COMPACTED))
+            if (entry.getValue().contains(Component.OBSOLETE))
                 continue;
 
             if (!descriptor.isCompatible())

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -614,6 +614,11 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
                 continue;
             }
 
+            if (components.contains(Component.IS_COMPACTED)) {
+                SSTable.delete(desc, components);
+                continue;
+            }
+
             File dataFile = new File(desc.filenameFor(Component.DATA));
             if (components.contains(Component.DATA) && dataFile.length() > 0)
                 // everything appears to be in order... moving on.

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -615,7 +615,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
             }
             if (components.contains(Component.OBSOLETE))
             {
-                logger.warn("Removing obselete (compacted into new SSTable but not deleted) SSTable {}", desc);
+                logger.warn("Removing obsolete (compacted into new SSTable but not deleted) SSTable {}", desc);
                 SSTable.delete(desc, components);
                 continue;
             }

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -608,9 +608,14 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
             Descriptor desc = sstableFiles.getKey();
             Set<Component> components = sstableFiles.getValue();
 
-            if (desc.type.isTemporary || components.contains(Component.OBSOLETE))
+            if (desc.type.isTemporary)
             {
                 SSTable.delete(desc, components);
+                continue;
+            }
+            if (components.contains(Component.OBSOLETE))
+            {
+                logger.warn("Removing obselete (compacted into new SSTable but not deleted) SSTable {}", desc);
                 continue;
             }
 

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -616,6 +616,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
             if (components.contains(Component.OBSOLETE))
             {
                 logger.warn("Removing obselete (compacted into new SSTable but not deleted) SSTable {}", desc);
+                SSTable.delete(desc, components);
                 continue;
             }
 

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -843,6 +843,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
                 continue; // old (initialized) SSTable found, skipping
             if (descriptor.type.isTemporary) // in the process of being written
                 continue;
+            if (entry.getValue().contains(Component.IS_COMPACTED))
+                continue;
 
             if (!descriptor.isCompatible())
                 throw new RuntimeException(String.format("Can't open incompatible SSTable! Current version %s, found file: %s",

--- a/src/java/org/apache/cassandra/io/sstable/Component.java
+++ b/src/java/org/apache/cassandra/io/sstable/Component.java
@@ -55,6 +55,7 @@ public class Component
         SUMMARY("Summary.db"),
         // table of contents, stores the list of all components for the sstable
         TOC("TOC.txt"),
+        IS_COMPACTED("IsCompacted.txt"),
         // custom component, used by e.g. custom compaction strategy
         CUSTOM(null);
 
@@ -82,6 +83,7 @@ public class Component
     public final static Component DIGEST = new Component(Type.DIGEST);
     public final static Component CRC = new Component(Type.CRC);
     public final static Component SUMMARY = new Component(Type.SUMMARY);
+    public final static Component IS_COMPACTED = new Component(Type.IS_COMPACTED);
     public final static Component TOC = new Component(Type.TOC);
 
     public final Type type;
@@ -136,6 +138,7 @@ public class Component
             case CRC:               component = Component.CRC;                          break;
             case SUMMARY:           component = Component.SUMMARY;                      break;
             case TOC:               component = Component.TOC;                          break;
+            case IS_COMPACTED:      component = Component.IS_COMPACTED;                 break;
             case CUSTOM:            component = new Component(Type.CUSTOM, path.right); break;
             default:
                  throw new IllegalStateException();

--- a/src/java/org/apache/cassandra/io/sstable/Component.java
+++ b/src/java/org/apache/cassandra/io/sstable/Component.java
@@ -55,6 +55,7 @@ public class Component
         SUMMARY("Summary.db"),
         // table of contents, stores the list of all components for the sstable
         TOC("TOC.txt"),
+        // marker that this SSTable should be scrubbed on startup (e.g. has been compacted into a new SSTable)
         OBSOLETE("Obsolete.txt"),
         // custom component, used by e.g. custom compaction strategy
         CUSTOM(null);

--- a/src/java/org/apache/cassandra/io/sstable/Component.java
+++ b/src/java/org/apache/cassandra/io/sstable/Component.java
@@ -55,7 +55,7 @@ public class Component
         SUMMARY("Summary.db"),
         // table of contents, stores the list of all components for the sstable
         TOC("TOC.txt"),
-        IS_COMPACTED("IsCompacted.txt"),
+        OBSOLETE("Obsolete.txt"),
         // custom component, used by e.g. custom compaction strategy
         CUSTOM(null);
 
@@ -83,7 +83,7 @@ public class Component
     public final static Component DIGEST = new Component(Type.DIGEST);
     public final static Component CRC = new Component(Type.CRC);
     public final static Component SUMMARY = new Component(Type.SUMMARY);
-    public final static Component IS_COMPACTED = new Component(Type.IS_COMPACTED);
+    public final static Component OBSOLETE = new Component(Type.OBSOLETE);
     public final static Component TOC = new Component(Type.TOC);
 
     public final Type type;
@@ -138,7 +138,7 @@ public class Component
             case CRC:               component = Component.CRC;                          break;
             case SUMMARY:           component = Component.SUMMARY;                      break;
             case TOC:               component = Component.TOC;                          break;
-            case IS_COMPACTED:      component = Component.IS_COMPACTED;                 break;
+            case OBSOLETE:          component = Component.OBSOLETE;                     break;
             case CUSTOM:            component = new Component(Type.CUSTOM, path.right); break;
             default:
                  throw new IllegalStateException();

--- a/src/java/org/apache/cassandra/io/sstable/SSTable.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTable.java
@@ -114,6 +114,7 @@ public abstract class SSTable
             FileUtils.deleteWithConfirm(desc.filenameFor(component));
         }
         FileUtils.delete(desc.filenameFor(Component.SUMMARY));
+        FileUtils.delete(desc.filenameFor(Component.OBSOLETE));
 
         logger.trace("Deleted {}", desc);
         return true;

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -2263,17 +2263,17 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         }
 
         /**
-         * Mark this SSTable as having been compacted. This will create the {@link Component#IS_COMPACTED} component,
+         * Mark this SSTable as having been compacted. This will create the {@link Component#OBSOLETE} component,
          * which will indicate that this SSTable must be deleted unconditionally on next startup. It may not be deleted
          * immediately during the lifetime of the current JVM, however, if its refcount is not yet zero (e.g. may still
          * be streaming to another node).
          *
          * @return the previous value of isCompacted
-         * @throws IOException if there was an exception while creating the {@link Component#IS_COMPACTED} component
+         * @throws IOException if there was an exception while creating the {@link Component#OBSOLETE} component
          */
         synchronized boolean setCompacted() throws IOException
         {
-            File compactedMarker = new File(desc.filenameFor(Component.IS_COMPACTED));
+            File compactedMarker = new File(desc.filenameFor(Component.OBSOLETE));
             boolean compactedMarkerCreated = compactedMarker.createNewFile();
             isCompacted.set(true);
             return !compactedMarkerCreated;

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableRewriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableRewriterTest.java
@@ -238,7 +238,7 @@ public class SSTableRewriterTest extends SchemaLoader
     }
 
     @Test
-    public void testFileRemoval() throws InterruptedException
+    public void testFileRemoval() throws InterruptedException, IOException
     {
         Keyspace keyspace = Keyspace.open(KEYSPACE);
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF);


### PR DESCRIPTION
When a table finished compaction as it is being streamed, the streaming will still hold a ref on the compaction ancestor. If the node crashes in this state, the next reboot will read both the ancestor and the compacted SSTable without any tombstones that arrived and got compacted during streaming.