### PR TITLE
Alternate method of ensuring no compacted SSTables left at startup

### DIFF
--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -54,6 +54,7 @@ import com.codahale.metrics.jvm.FileDescriptorRatioGauge;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -259,27 +260,21 @@ public class CassandraDaemon
         // load schema from disk
         Schema.instance.loadFromDisk();
 
-        // clean up compaction leftovers
         Map<Pair<String, String>, Map<Integer, UUID>> unfinishedCompactions = SystemKeyspace.getUnfinishedCompactions();
-        for (Pair<String, String> kscf : unfinishedCompactions.keySet())
-        {
-            CFMetaData cfm = Schema.instance.getCFMetaData(kscf.left, kscf.right);
-            // CFMetaData can be null if CF is already dropped
-            if (cfm != null)
-                ColumnFamilyStore.removeUnfinishedCompactionLeftovers(cfm, unfinishedCompactions.get(kscf));
-        }
-        SystemKeyspace.discardCompactionsInProgress();
-
         // clean up debris in the rest of the keyspaces
         for (String keyspaceName : Schema.instance.getKeyspaces())
         {
-            // Skip system as we've already cleaned it
+            // Skip system as we'll already clean it after the other tables
             if (keyspaceName.equals(SystemKeyspace.NAME))
                 continue;
 
             for (CFMetaData cfm : Schema.instance.getKeyspaceMetaData(keyspaceName).values())
+            {
+                ColumnFamilyStore.removeUnfinishedCompactionLeftovers(cfm, unfinishedCompactions.getOrDefault(cfm.ksAndCFName, ImmutableMap.of()));
                 ColumnFamilyStore.scrubDataDirectories(cfm);
+            }
         }
+        SystemKeyspace.discardCompactionsInProgress();
 
         Keyspace.setInitialized();
 


### PR DESCRIPTION
ColumnFamilyStore.removeUnfinishedCompactionLeftovers removes any SSTables that are part of another SSTable's compaction ancestors on startup. The reason this didn't help https://github.com/palantir/cassandra/pull/521 is because it only runs when there are pending compactions on a given ks.cf, which isn't the case if you're just holding a ref post-successful-compaction. This PR changes startup code so that removeUnfinishedCompactionLeftovers runs on every ks.cf unconditionally

Functionally, the only changes are removeUnfinishedCompactionLeftovers is run in more cases than it was previously. It is always safe to run since it will only delete SSTables that are positively listed as an ancestor of another sstable