### PR TITLE
Backport CASSANDRA-16057: Pass output stream from probe

### DIFF
--- a/src/java/com/palantir/cassandra/tools/nodetool/ForceTerminateRepairSessions.java
+++ b/src/java/com/palantir/cassandra/tools/nodetool/ForceTerminateRepairSessions.java
@@ -29,8 +29,8 @@ public class ForceTerminateRepairSessions extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println("Attempting to force terminate all running and already queued repair sessions on this host...");
+        probe.getOutput().println("Attempting to force terminate all running and already queued repair sessions on this host...");
         probe.forceTerminateActiveRepairSessions();
-        System.out.println("Done.");
+        probe.getOutput().println("Done.");
     }
 }

--- a/src/java/com/palantir/cassandra/tools/nodetool/ForceTerminateRepairSessions.java
+++ b/src/java/com/palantir/cassandra/tools/nodetool/ForceTerminateRepairSessions.java
@@ -29,8 +29,8 @@ public class ForceTerminateRepairSessions extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println("Attempting to force terminate all running and already queued repair sessions on this host...");
+        probe.output().out.println("Attempting to force terminate all running and already queued repair sessions on this host...");
         probe.forceTerminateActiveRepairSessions();
-        probe.getOutput().println("Done.");
+        probe.output().out.println("Done.");
     }
 }

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -53,7 +53,6 @@ import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
 
-import net.nicoulaj.compilecommand.annotations.Print;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStoreMBean;
 import org.apache.cassandra.db.HintedHandOffManager;
@@ -102,7 +101,6 @@ public class NodeProbe implements AutoCloseable
     final int port;
     private String username;
     private String password;
-    private final PrintStream output;
 
     protected JMXConnector jmxc;
     protected MBeanServerConnection mbeanServerConn;
@@ -118,6 +116,7 @@ public class NodeProbe implements AutoCloseable
     protected CacheServiceMBean cacheService;
     protected StorageProxyMBean spProxy;
     protected HintedHandOffManagerMBean hhProxy;
+    protected Output output;
     private boolean failed;
 
     /**
@@ -129,11 +128,6 @@ public class NodeProbe implements AutoCloseable
      */
     public NodeProbe(String host, int port, String username, String password) throws IOException
     {
-        this(host, port, username, password, System.out);
-    }
-
-    public NodeProbe(String host, int port, String username, String password, PrintStream output) throws IOException
-    {
         assert username != null && !username.isEmpty() && password != null && !password.isEmpty()
                : "neither username nor password can be blank";
 
@@ -141,7 +135,7 @@ public class NodeProbe implements AutoCloseable
         this.port = port;
         this.username = username;
         this.password = password;
-        this.output = output;
+        this.output = Output.CONSOLE;
         connect();
     }
 
@@ -154,14 +148,9 @@ public class NodeProbe implements AutoCloseable
      */
     public NodeProbe(String host, int port) throws IOException
     {
-        this(host, port, System.out);
-    }
-
-    public NodeProbe(String host, int port, PrintStream output) throws IOException
-    {
         this.host = host;
         this.port = port;
-        this.output = output;
+        this.output = Output.CONSOLE;
         connect();
     }
 
@@ -175,7 +164,7 @@ public class NodeProbe implements AutoCloseable
     {
         this.host = host;
         this.port = defaultPort;
-        output = System.out;
+        this.output = Output.CONSOLE;
         connect();
     }
 
@@ -184,7 +173,7 @@ public class NodeProbe implements AutoCloseable
         // this constructor is only used for extensions to rewrite their own connect method
         this.host = "";
         this.port = 0;
-        output = System.out;
+        this.output = Output.CONSOLE;
     }
 
     /**
@@ -260,6 +249,16 @@ public class NodeProbe implements AutoCloseable
     public void close() throws IOException
     {
         jmxc.close();
+    }
+
+    public void setOutput(Output output)
+    {
+        this.output = output;
+    }
+
+    public Output output()
+    {
+        return output;
     }
 
     public boolean isKeyspaceFullyClean(int jobs, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException
@@ -1457,11 +1456,6 @@ public class NodeProbe implements AutoCloseable
     public MessagingServiceMBean getMessagingServiceProxy()
     {
         return msProxy;
-    }
-
-    public PrintStream getOutput()
-    {
-        return output;
     }
 }
 

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -53,6 +53,7 @@ import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
 
+import net.nicoulaj.compilecommand.annotations.Print;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStoreMBean;
 import org.apache.cassandra.db.HintedHandOffManager;
@@ -101,6 +102,7 @@ public class NodeProbe implements AutoCloseable
     final int port;
     private String username;
     private String password;
+    private final PrintStream output;
 
     protected JMXConnector jmxc;
     protected MBeanServerConnection mbeanServerConn;
@@ -127,6 +129,11 @@ public class NodeProbe implements AutoCloseable
      */
     public NodeProbe(String host, int port, String username, String password) throws IOException
     {
+        this(host, port, username, password, System.out);
+    }
+
+    public NodeProbe(String host, int port, String username, String password, PrintStream output) throws IOException
+    {
         assert username != null && !username.isEmpty() && password != null && !password.isEmpty()
                : "neither username nor password can be blank";
 
@@ -134,6 +141,7 @@ public class NodeProbe implements AutoCloseable
         this.port = port;
         this.username = username;
         this.password = password;
+        this.output = output;
         connect();
     }
 
@@ -146,8 +154,14 @@ public class NodeProbe implements AutoCloseable
      */
     public NodeProbe(String host, int port) throws IOException
     {
+        this(host, port, System.out);
+    }
+
+    public NodeProbe(String host, int port, PrintStream output) throws IOException
+    {
         this.host = host;
         this.port = port;
+        this.output = output;
         connect();
     }
 
@@ -161,6 +175,7 @@ public class NodeProbe implements AutoCloseable
     {
         this.host = host;
         this.port = defaultPort;
+        output = System.out;
         connect();
     }
 
@@ -169,6 +184,7 @@ public class NodeProbe implements AutoCloseable
         // this constructor is only used for extensions to rewrite their own connect method
         this.host = "";
         this.port = 0;
+        output = System.out;
     }
 
     /**
@@ -1441,6 +1457,11 @@ public class NodeProbe implements AutoCloseable
     public MessagingServiceMBean getMessagingServiceProxy()
     {
         return msProxy;
+    }
+
+    public PrintStream getOutput()
+    {
+        return output;
     }
 }
 

--- a/src/java/org/apache/cassandra/tools/Output.java
+++ b/src/java/org/apache/cassandra/tools/Output.java
@@ -15,26 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.tools.nodetool;
 
-import io.airlift.command.Command;
+package org.apache.cassandra.tools;
 
-import java.util.List;
+import java.io.PrintStream;
 
-import org.apache.cassandra.tools.NodeProbe;
-import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
-
-@Command(name = "rangekeysample", description = "Shows the sampled keys held across all keyspaces")
-public class RangeKeySample extends NodeToolCmd
+public class Output
 {
-    @Override
-    public void execute(NodeProbe probe)
+    public final static Output CONSOLE = new Output(System.out, System.err);
+
+    public final PrintStream out;
+    public final PrintStream err;
+
+    public Output(PrintStream out, PrintStream err)
     {
-        probe.output().out.println("RangeKeySample: ");
-        List<String> tokenStrings = probe.sampleKeyRange();
-        for (String tokenString : tokenStrings)
-        {
-            probe.output().out.println("\t" + tokenString);
-        }
+        this.out = out;
+        this.err = err;
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/BootstrapResume.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/BootstrapResume.java
@@ -33,7 +33,7 @@ public class BootstrapResume extends NodeToolCmd
     {
         try
         {
-            probe.resumeBootstrap(probe.getOutput());
+            probe.resumeBootstrap(probe.output().out);
         }
         catch (IOException e)
         {

--- a/src/java/org/apache/cassandra/tools/nodetool/BootstrapResume.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/BootstrapResume.java
@@ -33,7 +33,7 @@ public class BootstrapResume extends NodeToolCmd
     {
         try
         {
-            probe.resumeBootstrap(System.out);
+            probe.resumeBootstrap(probe.getOutput());
         }
         catch (IOException e)
         {

--- a/src/java/org/apache/cassandra/tools/nodetool/Cleanup.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Cleanup.java
@@ -52,7 +52,7 @@ public class Cleanup extends NodeToolCmd
 
             try
             {
-                probe.forceKeyspaceCleanup(probe.getOutput(), jobs, keyspace, cfnames);
+                probe.forceKeyspaceCleanup(probe.output().out, jobs, keyspace, cfnames);
             } catch (Exception e)
             {
                 throw new RuntimeException("Error occurred during cleanup", e);

--- a/src/java/org/apache/cassandra/tools/nodetool/Cleanup.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Cleanup.java
@@ -52,7 +52,7 @@ public class Cleanup extends NodeToolCmd
 
             try
             {
-                probe.forceKeyspaceCleanup(System.out, jobs, keyspace, cfnames);
+                probe.forceKeyspaceCleanup(probe.getOutput(), jobs, keyspace, cfnames);
             } catch (Exception e)
             {
                 throw new RuntimeException("Error occurred during cleanup", e);

--- a/src/java/org/apache/cassandra/tools/nodetool/ClearSnapshot.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/ClearSnapshot.java
@@ -55,7 +55,7 @@ public class ClearSnapshot extends NodeToolCmd
         if (!snapshotName.isEmpty())
             sb.append(" with snapshot name [").append(snapshotName).append("]");
 
-        System.out.println(sb.toString());
+        probe.getOutput().println(sb.toString());
 
         try
         {

--- a/src/java/org/apache/cassandra/tools/nodetool/ClearSnapshot.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/ClearSnapshot.java
@@ -55,7 +55,7 @@ public class ClearSnapshot extends NodeToolCmd
         if (!snapshotName.isEmpty())
             sb.append(" with snapshot name [").append(snapshotName).append("]");
 
-        probe.getOutput().println(sb.toString());
+        probe.output().out.println(sb.toString());
 
         try
         {

--- a/src/java/org/apache/cassandra/tools/nodetool/CompactionHistory.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CompactionHistory.java
@@ -34,24 +34,24 @@ public class CompactionHistory extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println("Compaction History: ");
+        probe.output().out.println("Compaction History: ");
 
         TabularData tabularData = probe.getCompactionHistory();
         if (tabularData.isEmpty())
         {
-            probe.getOutput().printf("There is no compaction history");
+            probe.output().out.printf("There is no compaction history");
             return;
         }
 
         String format = "%-41s%-19s%-29s%-26s%-15s%-15s%s%n";
         List<String> indexNames = tabularData.getTabularType().getIndexNames();
-        probe.getOutput().printf(format, toArray(indexNames, Object.class));
+        probe.output().out.printf(format, toArray(indexNames, Object.class));
 
         Set<?> values = tabularData.keySet();
         for (Object eachValue : values)
         {
             List<?> value = (List<?>) eachValue;
-            probe.getOutput().printf(format, toArray(value, Object.class));
+            probe.output().out.printf(format, toArray(value, Object.class));
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/CompactionHistory.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CompactionHistory.java
@@ -34,24 +34,24 @@ public class CompactionHistory extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println("Compaction History: ");
+        probe.getOutput().println("Compaction History: ");
 
         TabularData tabularData = probe.getCompactionHistory();
         if (tabularData.isEmpty())
         {
-            System.out.printf("There is no compaction history");
+            probe.getOutput().printf("There is no compaction history");
             return;
         }
 
         String format = "%-41s%-19s%-29s%-26s%-15s%-15s%s%n";
         List<String> indexNames = tabularData.getTabularType().getIndexNames();
-        System.out.printf(format, toArray(indexNames, Object.class));
+        probe.getOutput().printf(format, toArray(indexNames, Object.class));
 
         Set<?> values = tabularData.keySet();
         for (Object eachValue : values)
         {
             List<?> value = (List<?>) eachValue;
-            System.out.printf(format, toArray(value, Object.class));
+            probe.getOutput().printf(format, toArray(value, Object.class));
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/CompactionStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CompactionStats.java
@@ -44,7 +44,7 @@ public class CompactionStats extends NodeToolCmd
     public void execute(NodeProbe probe)
     {
         CompactionManagerMBean cm = probe.getCompactionManagerProxy();
-        probe.getOutput().println("pending tasks: " + probe.getCompactionMetric("PendingTasks"));
+        probe.output().out.println("pending tasks: " + probe.getCompactionMetric("PendingTasks"));
         long remainingBytes = 0;
         List<Map<String, String>> compactions = cm.getCompactions();
         if (!compactions.isEmpty())
@@ -82,7 +82,7 @@ public class CompactionStats extends NodeToolCmd
 
             for (String[] line : lines)
             {
-                probe.getOutput().printf(format, line[0], line[1], line[2], line[3], line[4], line[5], line[6], line[7]);
+                probe.output().out.printf(format, line[0], line[1], line[2], line[3], line[4], line[5], line[6], line[7]);
             }
 
             String remainingTime = "n/a";
@@ -91,7 +91,7 @@ public class CompactionStats extends NodeToolCmd
                 long remainingTimeInSecs = remainingBytes / (1024L * 1024L * compactionThroughput);
                 remainingTime = format("%dh%02dm%02ds", remainingTimeInSecs / 3600, (remainingTimeInSecs % 3600) / 60, (remainingTimeInSecs % 60));
             }
-            probe.getOutput().printf("%25s%10s%n", "Active compaction remaining time : ", remainingTime);
+            probe.output().out.printf("%25s%10s%n", "Active compaction remaining time : ", remainingTime);
         }
     }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/CompactionStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CompactionStats.java
@@ -44,7 +44,7 @@ public class CompactionStats extends NodeToolCmd
     public void execute(NodeProbe probe)
     {
         CompactionManagerMBean cm = probe.getCompactionManagerProxy();
-        System.out.println("pending tasks: " + probe.getCompactionMetric("PendingTasks"));
+        probe.getOutput().println("pending tasks: " + probe.getCompactionMetric("PendingTasks"));
         long remainingBytes = 0;
         List<Map<String, String>> compactions = cm.getCompactions();
         if (!compactions.isEmpty())
@@ -82,7 +82,7 @@ public class CompactionStats extends NodeToolCmd
 
             for (String[] line : lines)
             {
-                System.out.printf(format, line[0], line[1], line[2], line[3], line[4], line[5], line[6], line[7]);
+                probe.getOutput().printf(format, line[0], line[1], line[2], line[3], line[4], line[5], line[6], line[7]);
             }
 
             String remainingTime = "n/a";
@@ -91,7 +91,7 @@ public class CompactionStats extends NodeToolCmd
                 long remainingTimeInSecs = remainingBytes / (1024L * 1024L * compactionThroughput);
                 remainingTime = format("%dh%02dm%02ds", remainingTimeInSecs / 3600, (remainingTimeInSecs % 3600) / 60, (remainingTimeInSecs % 60));
             }
-            System.out.printf("%25s%10s%n", "Active compaction remaining time : ", remainingTime);
+            probe.getOutput().printf("%25s%10s%n", "Active compaction remaining time : ", remainingTime);
         }
     }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/DescribeCluster.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/DescribeCluster.java
@@ -33,17 +33,17 @@ public class DescribeCluster extends NodeToolCmd
     public void execute(NodeProbe probe)
     {
         // display cluster name, snitch and partitioner
-        System.out.println("Cluster Information:");
-        System.out.println("\tName: " + probe.getClusterName());
-        System.out.println("\tSnitch: " + probe.getEndpointSnitchInfoProxy().getSnitchName());
-        System.out.println("\tPartitioner: " + probe.getPartitioner());
+        probe.getOutput().println("Cluster Information:");
+        probe.getOutput().println("\tName: " + probe.getClusterName());
+        probe.getOutput().println("\tSnitch: " + probe.getEndpointSnitchInfoProxy().getSnitchName());
+        probe.getOutput().println("\tPartitioner: " + probe.getPartitioner());
 
         // display schema version for each node
-        System.out.println("\tSchema versions:");
+        probe.getOutput().println("\tSchema versions:");
         Map<String, List<String>> schemaVersions = probe.getSpProxy().getSchemaVersions();
         for (String version : schemaVersions.keySet())
         {
-            System.out.println(format("\t\t%s: %s%n", version, schemaVersions.get(version)));
+            probe.getOutput().println(format("\t\t%s: %s%n", version, schemaVersions.get(version)));
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/DescribeCluster.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/DescribeCluster.java
@@ -33,17 +33,17 @@ public class DescribeCluster extends NodeToolCmd
     public void execute(NodeProbe probe)
     {
         // display cluster name, snitch and partitioner
-        probe.getOutput().println("Cluster Information:");
-        probe.getOutput().println("\tName: " + probe.getClusterName());
-        probe.getOutput().println("\tSnitch: " + probe.getEndpointSnitchInfoProxy().getSnitchName());
-        probe.getOutput().println("\tPartitioner: " + probe.getPartitioner());
+        probe.output().out.println("Cluster Information:");
+        probe.output().out.println("\tName: " + probe.getClusterName());
+        probe.output().out.println("\tSnitch: " + probe.getEndpointSnitchInfoProxy().getSnitchName());
+        probe.output().out.println("\tPartitioner: " + probe.getPartitioner());
 
         // display schema version for each node
-        probe.getOutput().println("\tSchema versions:");
+        probe.output().out.println("\tSchema versions:");
         Map<String, List<String>> schemaVersions = probe.getSpProxy().getSchemaVersions();
         for (String version : schemaVersions.keySet())
         {
-            probe.getOutput().println(format("\t\t%s: %s%n", version, schemaVersions.get(version)));
+            probe.output().out.println(format("\t\t%s: %s%n", version, schemaVersions.get(version)));
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/DescribeRing.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/DescribeRing.java
@@ -35,13 +35,13 @@ public class DescribeRing extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println("Schema Version:" + probe.getSchemaVersion());
-        System.out.println("TokenRange: ");
+        probe.getOutput().println("Schema Version:" + probe.getSchemaVersion());
+        probe.getOutput().println("TokenRange: ");
         try
         {
             for (String tokenRangeString : probe.describeRing(keyspace))
             {
-                System.out.println("\t" + tokenRangeString);
+                probe.getOutput().println("\t" + tokenRangeString);
             }
         } catch (IOException e)
         {

--- a/src/java/org/apache/cassandra/tools/nodetool/DescribeRing.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/DescribeRing.java
@@ -35,13 +35,13 @@ public class DescribeRing extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println("Schema Version:" + probe.getSchemaVersion());
-        probe.getOutput().println("TokenRange: ");
+        probe.output().out.println("Schema Version:" + probe.getSchemaVersion());
+        probe.output().out.println("TokenRange: ");
         try
         {
             for (String tokenRangeString : probe.describeRing(keyspace))
             {
-                probe.getOutput().println("\t" + tokenRangeString);
+                probe.output().out.println("\t" + tokenRangeString);
             }
         } catch (IOException e)
         {

--- a/src/java/org/apache/cassandra/tools/nodetool/DynamicEndpointSnitchStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/DynamicEndpointSnitchStats.java
@@ -52,20 +52,20 @@ public class DynamicEndpointSnitchStats extends NodeToolCmd
         try
         {
             DynamicEndpointSnitchMBean dynamicSnitchProxy = probe.getDynamicEndpointSnitchProxy();
-            printConfiguration(probe.getOutput(), dynamicSnitchProxy);
+            printConfiguration(probe.output().out, dynamicSnitchProxy);
             // display snitch scores for each node
-            probe.getOutput().println("Dynamic Endpoint Snitch Scores:");
+            probe.output().out.println("Dynamic Endpoint Snitch Scores:");
             Map<InetAddress, Double> snitchScores = dynamicSnitchProxy.getScores();
             for (InetAddress address : snitchScores.keySet())
             {
-                probe.getOutput().println(format("\t%s: %s", address.getCanonicalHostName(), snitchScores.get(address)));
+                probe.output().out.println(format("\t%s: %s", address.getCanonicalHostName(), snitchScores.get(address)));
             }
             if (timings) {
-                printTimings(probe.getOutput(), dynamicSnitchProxy, snitchScores.keySet());
+                printTimings(probe.output().out, dynamicSnitchProxy, snitchScores.keySet());
             }
         } catch (RuntimeException e) {
             if ((e.getCause() instanceof InstanceNotFoundException)) {
-                probe.getOutput().println("Error getting DynamicEndpointSnitch proxy--Dynamic snitch may not be enabled on this cluster.");
+                probe.output().out.println("Error getting DynamicEndpointSnitch proxy--Dynamic snitch may not be enabled on this cluster.");
             }
         }
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/FailureDetectorInfo.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/FailureDetectorInfo.java
@@ -34,12 +34,12 @@ public class FailureDetectorInfo extends NodeToolCmd
     public void execute(NodeProbe probe)
     {
         TabularData data = probe.getFailureDetectorPhilValues();
-        System.out.printf("%10s,%16s%n", "Endpoint", "Phi");
+        probe.getOutput().printf("%10s,%16s%n", "Endpoint", "Phi");
         for (Object o : data.keySet())
         {
             @SuppressWarnings({ "rawtypes", "unchecked" })
             CompositeData datum = data.get(((List) o).toArray(new Object[((List) o).size()]));
-            System.out.printf("%10s,%16.8f%n",datum.get("Endpoint"), datum.get("PHI"));
+            probe.getOutput().printf("%10s,%16.8f%n",datum.get("Endpoint"), datum.get("PHI"));
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/FailureDetectorInfo.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/FailureDetectorInfo.java
@@ -34,12 +34,12 @@ public class FailureDetectorInfo extends NodeToolCmd
     public void execute(NodeProbe probe)
     {
         TabularData data = probe.getFailureDetectorPhilValues();
-        probe.getOutput().printf("%10s,%16s%n", "Endpoint", "Phi");
+        probe.output().out.printf("%10s,%16s%n", "Endpoint", "Phi");
         for (Object o : data.keySet())
         {
             @SuppressWarnings({ "rawtypes", "unchecked" })
             CompositeData datum = data.get(((List) o).toArray(new Object[((List) o).size()]));
-            probe.getOutput().printf("%10s,%16.8f%n",datum.get("Endpoint"), datum.get("PHI"));
+            probe.output().out.printf("%10s,%16.8f%n",datum.get("Endpoint"), datum.get("PHI"));
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GcStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GcStats.java
@@ -31,7 +31,7 @@ public class GcStats extends NodeToolCmd
         double[] stats = probe.getAndResetGCStats();
         double mean = stats[2] / stats[5];
         double stdev = Math.sqrt((stats[3] / stats[5]) - (mean * mean));
-        probe.getOutput().printf("%20s%20s%20s%20s%20s%20s%25s%n", "Interval (ms)", "Max GC Elapsed (ms)", "Total GC Elapsed (ms)", "Stdev GC Elapsed (ms)", "GC Reclaimed (MB)", "Collections", "Direct Memory Bytes");
-        probe.getOutput().printf("%20.0f%20.0f%20.0f%20.0f%20.0f%20.0f%25d%n", stats[0], stats[1], stats[2], stdev, stats[4], stats[5], (long)stats[6]);
+        probe.output().out.printf("%20s%20s%20s%20s%20s%20s%25s%n", "Interval (ms)", "Max GC Elapsed (ms)", "Total GC Elapsed (ms)", "Stdev GC Elapsed (ms)", "GC Reclaimed (MB)", "Collections", "Direct Memory Bytes");
+        probe.output().out.printf("%20.0f%20.0f%20.0f%20.0f%20.0f%20.0f%25d%n", stats[0], stats[1], stats[2], stdev, stats[4], stats[5], (long)stats[6]);
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GcStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GcStats.java
@@ -31,7 +31,7 @@ public class GcStats extends NodeToolCmd
         double[] stats = probe.getAndResetGCStats();
         double mean = stats[2] / stats[5];
         double stdev = Math.sqrt((stats[3] / stats[5]) - (mean * mean));
-        System.out.printf("%20s%20s%20s%20s%20s%20s%25s%n", "Interval (ms)", "Max GC Elapsed (ms)", "Total GC Elapsed (ms)", "Stdev GC Elapsed (ms)", "GC Reclaimed (MB)", "Collections", "Direct Memory Bytes");
-        System.out.printf("%20.0f%20.0f%20.0f%20.0f%20.0f%20.0f%25d%n", stats[0], stats[1], stats[2], stdev, stats[4], stats[5], (long)stats[6]);
+        probe.getOutput().printf("%20s%20s%20s%20s%20s%20s%25s%n", "Interval (ms)", "Max GC Elapsed (ms)", "Total GC Elapsed (ms)", "Stdev GC Elapsed (ms)", "GC Reclaimed (MB)", "Collections", "Direct Memory Bytes");
+        probe.getOutput().printf("%20.0f%20.0f%20.0f%20.0f%20.0f%20.0f%25d%n", stats[0], stats[1], stats[2], stdev, stats[4], stats[5], (long)stats[6]);
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetCompactionThreshold.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetCompactionThreshold.java
@@ -42,7 +42,7 @@ public class GetCompactionThreshold extends NodeToolCmd
         String cf = args.get(1);
 
         ColumnFamilyStoreMBean cfsProxy = probe.getCfsProxy(ks, cf);
-        probe.getOutput().println("Current compaction thresholds for " + ks + "/" + cf + ": \n" +
+        probe.output().out.println("Current compaction thresholds for " + ks + "/" + cf + ": \n" +
                 " min = " + cfsProxy.getMinimumCompactionThreshold() + ", " +
                 " max = " + cfsProxy.getMaximumCompactionThreshold());
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetCompactionThreshold.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetCompactionThreshold.java
@@ -42,7 +42,7 @@ public class GetCompactionThreshold extends NodeToolCmd
         String cf = args.get(1);
 
         ColumnFamilyStoreMBean cfsProxy = probe.getCfsProxy(ks, cf);
-        System.out.println("Current compaction thresholds for " + ks + "/" + cf + ": \n" +
+        probe.getOutput().println("Current compaction thresholds for " + ks + "/" + cf + ": \n" +
                 " min = " + cfsProxy.getMinimumCompactionThreshold() + ", " +
                 " max = " + cfsProxy.getMaximumCompactionThreshold());
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetCompactionThroughput.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetCompactionThroughput.java
@@ -28,6 +28,6 @@ public class GetCompactionThroughput extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println("Current compaction throughput: " + probe.getCompactionThroughput() + " MB/s");
+        probe.getOutput().println("Current compaction throughput: " + probe.getCompactionThroughput() + " MB/s");
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetCompactionThroughput.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetCompactionThroughput.java
@@ -28,6 +28,6 @@ public class GetCompactionThroughput extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println("Current compaction throughput: " + probe.getCompactionThroughput() + " MB/s");
+        probe.output().out.println("Current compaction throughput: " + probe.getCompactionThroughput() + " MB/s");
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetEndpoints.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetEndpoints.java
@@ -45,7 +45,7 @@ public class GetEndpoints extends NodeToolCmd
         List<InetAddress> endpoints = probe.getEndpoints(ks, table, key);
         for (InetAddress endpoint : endpoints)
         {
-            probe.getOutput().println(endpoint.getHostAddress());
+            probe.output().out.println(endpoint.getHostAddress());
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetEndpoints.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetEndpoints.java
@@ -45,7 +45,7 @@ public class GetEndpoints extends NodeToolCmd
         List<InetAddress> endpoints = probe.getEndpoints(ks, table, key);
         for (InetAddress endpoint : endpoints)
         {
-            System.out.println(endpoint.getHostAddress());
+            probe.getOutput().println(endpoint.getHostAddress());
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetInterDCStreamThroughput.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetInterDCStreamThroughput.java
@@ -28,6 +28,6 @@ public class GetInterDCStreamThroughput extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println("Current inter-datacenter stream throughput: " + probe.getInterDCStreamThroughput() + " Mb/s");
+        probe.getOutput().println("Current inter-datacenter stream throughput: " + probe.getInterDCStreamThroughput() + " Mb/s");
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetInterDCStreamThroughput.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetInterDCStreamThroughput.java
@@ -28,6 +28,6 @@ public class GetInterDCStreamThroughput extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println("Current inter-datacenter stream throughput: " + probe.getInterDCStreamThroughput() + " Mb/s");
+        probe.output().out.println("Current inter-datacenter stream throughput: " + probe.getInterDCStreamThroughput() + " Mb/s");
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetKeyspacesWithAllRangesAvailable.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetKeyspacesWithAllRangesAvailable.java
@@ -37,11 +37,11 @@ public class GetKeyspacesWithAllRangesAvailable extends NodeToolCmd
         try
         {
             Set<String> keyspaces = probe.getKeyspacesWithAllRangesAvailable(sourceDataCenterName);
-            probe.getOutput().print(keyspaces);
+            probe.output().out.print(keyspaces);
         }
         catch (Exception e)
         {
-            probe.getOutput().print("Failed to retrieve keyspaces with all ranges available. Check logs for details");
+            probe.output().out.print("Failed to retrieve keyspaces with all ranges available. Check logs for details");
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetKeyspacesWithAllRangesAvailable.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetKeyspacesWithAllRangesAvailable.java
@@ -37,11 +37,11 @@ public class GetKeyspacesWithAllRangesAvailable extends NodeToolCmd
         try
         {
             Set<String> keyspaces = probe.getKeyspacesWithAllRangesAvailable(sourceDataCenterName);
-            System.out.print(keyspaces);
+            probe.getOutput().print(keyspaces);
         }
         catch (Exception e)
         {
-            System.out.print("Failed to retrieve keyspaces with all ranges available. Check logs for details");
+            probe.getOutput().print("Failed to retrieve keyspaces with all ranges available. Check logs for details");
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetLoggingLevels.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetLoggingLevels.java
@@ -31,8 +31,8 @@ public class GetLoggingLevels extends NodeToolCmd
     public void execute(NodeProbe probe)
     {
         // what if some one set a very long logger name? 50 space may not be enough...
-        probe.getOutput().printf("%n%-50s%10s%n", "Logger Name", "Log Level");
+        probe.output().out.printf("%n%-50s%10s%n", "Logger Name", "Log Level");
         for (Map.Entry<String, String> entry : probe.getLoggingLevels().entrySet())
-            probe.getOutput().printf("%-50s%10s%n", entry.getKey(), entry.getValue());
+            probe.output().out.printf("%-50s%10s%n", entry.getKey(), entry.getValue());
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetLoggingLevels.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetLoggingLevels.java
@@ -31,8 +31,8 @@ public class GetLoggingLevels extends NodeToolCmd
     public void execute(NodeProbe probe)
     {
         // what if some one set a very long logger name? 50 space may not be enough...
-        System.out.printf("%n%-50s%10s%n", "Logger Name", "Log Level");
+        probe.getOutput().printf("%n%-50s%10s%n", "Logger Name", "Log Level");
         for (Map.Entry<String, String> entry : probe.getLoggingLevels().entrySet())
-            System.out.printf("%-50s%10s%n", entry.getKey(), entry.getValue());
+            probe.getOutput().printf("%-50s%10s%n", entry.getKey(), entry.getValue());
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetSSTables.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetSSTables.java
@@ -44,7 +44,7 @@ public class GetSSTables extends NodeToolCmd
         List<String> sstables = probe.getSSTables(ks, cf, key);
         for (String sstable : sstables)
         {
-            System.out.println(sstable);
+            probe.getOutput().println(sstable);
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetSSTables.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetSSTables.java
@@ -44,7 +44,7 @@ public class GetSSTables extends NodeToolCmd
         List<String> sstables = probe.getSSTables(ks, cf, key);
         for (String sstable : sstables)
         {
-            probe.getOutput().println(sstable);
+            probe.output().out.println(sstable);
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetStreamThroughput.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetStreamThroughput.java
@@ -28,6 +28,6 @@ public class GetStreamThroughput extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println("Current stream throughput: " + probe.getStreamThroughput() + " Mb/s");
+        probe.getOutput().println("Current stream throughput: " + probe.getStreamThroughput() + " Mb/s");
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetStreamThroughput.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetStreamThroughput.java
@@ -28,6 +28,6 @@ public class GetStreamThroughput extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println("Current stream throughput: " + probe.getStreamThroughput() + " Mb/s");
+        probe.output().out.println("Current stream throughput: " + probe.getStreamThroughput() + " Mb/s");
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetTraceProbability.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetTraceProbability.java
@@ -28,6 +28,6 @@ public class GetTraceProbability extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println("Current trace probability: " + probe.getTraceProbability());
+        probe.output().out.println("Current trace probability: " + probe.getTraceProbability());
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetTraceProbability.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetTraceProbability.java
@@ -28,6 +28,6 @@ public class GetTraceProbability extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println("Current trace probability: " + probe.getTraceProbability());
+        probe.getOutput().println("Current trace probability: " + probe.getTraceProbability());
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GossipInfo.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GossipInfo.java
@@ -28,6 +28,6 @@ public class GossipInfo extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println(probe.getGossipInfo());
+        probe.output().out.println(probe.getGossipInfo());
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GossipInfo.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GossipInfo.java
@@ -28,6 +28,6 @@ public class GossipInfo extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println(probe.getGossipInfo());
+        probe.getOutput().println(probe.getGossipInfo());
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/Info.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Info.java
@@ -45,28 +45,28 @@ public class Info extends NodeToolCmd
     {
         boolean gossipInitialized = probe.isInitialized();
 
-        System.out.printf("%-23s: %s%n", "ID", probe.getLocalHostId());
-        System.out.printf("%-23s: %s%n", "Gossip active", gossipInitialized);
-        System.out.printf("%-23s: %s%n", "Thrift active", probe.isThriftServerRunning());
-        System.out.printf("%-23s: %s%n", "Native Transport active", probe.isNativeTransportRunning());
-        System.out.printf("%-23s: %s%n", "Load", probe.getLoadString());
+        probe.getOutput().printf("%-23s: %s%n", "ID", probe.getLocalHostId());
+        probe.getOutput().printf("%-23s: %s%n", "Gossip active", gossipInitialized);
+        probe.getOutput().printf("%-23s: %s%n", "Thrift active", probe.isThriftServerRunning());
+        probe.getOutput().printf("%-23s: %s%n", "Native Transport active", probe.isNativeTransportRunning());
+        probe.getOutput().printf("%-23s: %s%n", "Load", probe.getLoadString());
         if (gossipInitialized)
-            System.out.printf("%-23s: %s%n", "Generation No", probe.getCurrentGenerationNumber());
+            probe.getOutput().printf("%-23s: %s%n", "Generation No", probe.getCurrentGenerationNumber());
         else
-            System.out.printf("%-23s: %s%n", "Generation No", 0);
+            probe.getOutput().printf("%-23s: %s%n", "Generation No", 0);
 
         // Uptime
         long secondsUp = probe.getUptime() / 1000;
-        System.out.printf("%-23s: %d%n", "Uptime (seconds)", secondsUp);
+        probe.getOutput().printf("%-23s: %d%n", "Uptime (seconds)", secondsUp);
 
         // Memory usage
         MemoryUsage heapUsage = probe.getHeapMemoryUsage();
         double memUsed = (double) heapUsage.getUsed() / (1024 * 1024);
         double memMax = (double) heapUsage.getMax() / (1024 * 1024);
-        System.out.printf("%-23s: %.2f / %.2f%n", "Heap Memory (MB)", memUsed, memMax);
+        probe.getOutput().printf("%-23s: %.2f / %.2f%n", "Heap Memory (MB)", memUsed, memMax);
         try
         {
-            System.out.printf("%-23s: %.2f%n", "Off Heap Memory (MB)", getOffHeapMemoryUsed(probe));
+            probe.getOutput().printf("%-23s: %.2f%n", "Off Heap Memory (MB)", getOffHeapMemoryUsed(probe));
         }
         catch (RuntimeException e)
         {
@@ -76,16 +76,16 @@ public class Info extends NodeToolCmd
         }
 
         // Data Center/Rack
-        System.out.printf("%-23s: %s%n", "Data Center", probe.getDataCenter());
-        System.out.printf("%-23s: %s%n", "Rack", probe.getRack());
+        probe.getOutput().printf("%-23s: %s%n", "Data Center", probe.getDataCenter());
+        probe.getOutput().printf("%-23s: %s%n", "Rack", probe.getRack());
 
         // Exceptions
-        System.out.printf("%-23s: %s%n", "Exceptions", probe.getStorageMetric("Exceptions"));
+        probe.getOutput().printf("%-23s: %s%n", "Exceptions", probe.getStorageMetric("Exceptions"));
 
         CacheServiceMBean cacheService = probe.getCacheServiceMBean();
 
         // Key Cache: Hits, Requests, RecentHitRate, SavePeriodInSeconds
-        System.out.printf("%-23s: entries %d, size %s, capacity %s, %d hits, %d requests, %.3f recent hit rate, %d save period in seconds%n",
+        probe.getOutput().printf("%-23s: entries %d, size %s, capacity %s, %d hits, %d requests, %.3f recent hit rate, %d save period in seconds%n",
                 "Key Cache",
                 probe.getCacheMetric("KeyCache", "Entries"),
                 FileUtils.stringifyFileSize((long) probe.getCacheMetric("KeyCache", "Size")),
@@ -96,7 +96,7 @@ public class Info extends NodeToolCmd
                 cacheService.getKeyCacheSavePeriodInSeconds());
 
         // Row Cache: Hits, Requests, RecentHitRate, SavePeriodInSeconds
-        System.out.printf("%-23s: entries %d, size %s, capacity %s, %d hits, %d requests, %.3f recent hit rate, %d save period in seconds%n",
+        probe.getOutput().printf("%-23s: entries %d, size %s, capacity %s, %d hits, %d requests, %.3f recent hit rate, %d save period in seconds%n",
                 "Row Cache",
                 probe.getCacheMetric("RowCache", "Entries"),
                 FileUtils.stringifyFileSize((long) probe.getCacheMetric("RowCache", "Size")),
@@ -107,7 +107,7 @@ public class Info extends NodeToolCmd
                 cacheService.getRowCacheSavePeriodInSeconds());
 
         // Counter Cache: Hits, Requests, RecentHitRate, SavePeriodInSeconds
-        System.out.printf("%-23s: entries %d, size %s, capacity %s, %d hits, %d requests, %.3f recent hit rate, %d save period in seconds%n",
+        probe.getOutput().printf("%-23s: entries %d, size %s, capacity %s, %d hits, %d requests, %.3f recent hit rate, %d save period in seconds%n",
                 "Counter Cache",
                 probe.getCacheMetric("CounterCache", "Entries"),
                 FileUtils.stringifyFileSize((long) probe.getCacheMetric("CounterCache", "Size")),
@@ -124,14 +124,14 @@ public class Info extends NodeToolCmd
             List<String> tokens = probe.getTokens();
             if (tokens.size() == 1 || this.tokens)
                 for (String token : tokens)
-                    System.out.printf("%-23s: %s%n", "Token", token);
+                    probe.getOutput().printf("%-23s: %s%n", "Token", token);
             else
-                System.out.printf("%-23s: (invoke with -T/--tokens to see all %d tokens)%n", "Token",
-                                  tokens.size());
+                probe.getOutput().printf("%-23s: (invoke with -T/--tokens to see all %d tokens)%n", "Token",
+                        tokens.size());
         }
         else
         {
-            System.out.printf("%-23s: (node is not joined to the cluster)%n", "Token");
+            probe.getOutput().printf("%-23s: (node is not joined to the cluster)%n", "Token");
         }
     }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/Info.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Info.java
@@ -45,28 +45,28 @@ public class Info extends NodeToolCmd
     {
         boolean gossipInitialized = probe.isInitialized();
 
-        probe.getOutput().printf("%-23s: %s%n", "ID", probe.getLocalHostId());
-        probe.getOutput().printf("%-23s: %s%n", "Gossip active", gossipInitialized);
-        probe.getOutput().printf("%-23s: %s%n", "Thrift active", probe.isThriftServerRunning());
-        probe.getOutput().printf("%-23s: %s%n", "Native Transport active", probe.isNativeTransportRunning());
-        probe.getOutput().printf("%-23s: %s%n", "Load", probe.getLoadString());
+        probe.output().out.printf("%-23s: %s%n", "ID", probe.getLocalHostId());
+        probe.output().out.printf("%-23s: %s%n", "Gossip active", gossipInitialized);
+        probe.output().out.printf("%-23s: %s%n", "Thrift active", probe.isThriftServerRunning());
+        probe.output().out.printf("%-23s: %s%n", "Native Transport active", probe.isNativeTransportRunning());
+        probe.output().out.printf("%-23s: %s%n", "Load", probe.getLoadString());
         if (gossipInitialized)
-            probe.getOutput().printf("%-23s: %s%n", "Generation No", probe.getCurrentGenerationNumber());
+            probe.output().out.printf("%-23s: %s%n", "Generation No", probe.getCurrentGenerationNumber());
         else
-            probe.getOutput().printf("%-23s: %s%n", "Generation No", 0);
+            probe.output().out.printf("%-23s: %s%n", "Generation No", 0);
 
         // Uptime
         long secondsUp = probe.getUptime() / 1000;
-        probe.getOutput().printf("%-23s: %d%n", "Uptime (seconds)", secondsUp);
+        probe.output().out.printf("%-23s: %d%n", "Uptime (seconds)", secondsUp);
 
         // Memory usage
         MemoryUsage heapUsage = probe.getHeapMemoryUsage();
         double memUsed = (double) heapUsage.getUsed() / (1024 * 1024);
         double memMax = (double) heapUsage.getMax() / (1024 * 1024);
-        probe.getOutput().printf("%-23s: %.2f / %.2f%n", "Heap Memory (MB)", memUsed, memMax);
+        probe.output().out.printf("%-23s: %.2f / %.2f%n", "Heap Memory (MB)", memUsed, memMax);
         try
         {
-            probe.getOutput().printf("%-23s: %.2f%n", "Off Heap Memory (MB)", getOffHeapMemoryUsed(probe));
+            probe.output().out.printf("%-23s: %.2f%n", "Off Heap Memory (MB)", getOffHeapMemoryUsed(probe));
         }
         catch (RuntimeException e)
         {
@@ -76,16 +76,16 @@ public class Info extends NodeToolCmd
         }
 
         // Data Center/Rack
-        probe.getOutput().printf("%-23s: %s%n", "Data Center", probe.getDataCenter());
-        probe.getOutput().printf("%-23s: %s%n", "Rack", probe.getRack());
+        probe.output().out.printf("%-23s: %s%n", "Data Center", probe.getDataCenter());
+        probe.output().out.printf("%-23s: %s%n", "Rack", probe.getRack());
 
         // Exceptions
-        probe.getOutput().printf("%-23s: %s%n", "Exceptions", probe.getStorageMetric("Exceptions"));
+        probe.output().out.printf("%-23s: %s%n", "Exceptions", probe.getStorageMetric("Exceptions"));
 
         CacheServiceMBean cacheService = probe.getCacheServiceMBean();
 
         // Key Cache: Hits, Requests, RecentHitRate, SavePeriodInSeconds
-        probe.getOutput().printf("%-23s: entries %d, size %s, capacity %s, %d hits, %d requests, %.3f recent hit rate, %d save period in seconds%n",
+        probe.output().out.printf("%-23s: entries %d, size %s, capacity %s, %d hits, %d requests, %.3f recent hit rate, %d save period in seconds%n",
                 "Key Cache",
                 probe.getCacheMetric("KeyCache", "Entries"),
                 FileUtils.stringifyFileSize((long) probe.getCacheMetric("KeyCache", "Size")),
@@ -96,7 +96,7 @@ public class Info extends NodeToolCmd
                 cacheService.getKeyCacheSavePeriodInSeconds());
 
         // Row Cache: Hits, Requests, RecentHitRate, SavePeriodInSeconds
-        probe.getOutput().printf("%-23s: entries %d, size %s, capacity %s, %d hits, %d requests, %.3f recent hit rate, %d save period in seconds%n",
+        probe.output().out.printf("%-23s: entries %d, size %s, capacity %s, %d hits, %d requests, %.3f recent hit rate, %d save period in seconds%n",
                 "Row Cache",
                 probe.getCacheMetric("RowCache", "Entries"),
                 FileUtils.stringifyFileSize((long) probe.getCacheMetric("RowCache", "Size")),
@@ -107,7 +107,7 @@ public class Info extends NodeToolCmd
                 cacheService.getRowCacheSavePeriodInSeconds());
 
         // Counter Cache: Hits, Requests, RecentHitRate, SavePeriodInSeconds
-        probe.getOutput().printf("%-23s: entries %d, size %s, capacity %s, %d hits, %d requests, %.3f recent hit rate, %d save period in seconds%n",
+        probe.output().out.printf("%-23s: entries %d, size %s, capacity %s, %d hits, %d requests, %.3f recent hit rate, %d save period in seconds%n",
                 "Counter Cache",
                 probe.getCacheMetric("CounterCache", "Entries"),
                 FileUtils.stringifyFileSize((long) probe.getCacheMetric("CounterCache", "Size")),
@@ -124,14 +124,14 @@ public class Info extends NodeToolCmd
             List<String> tokens = probe.getTokens();
             if (tokens.size() == 1 || this.tokens)
                 for (String token : tokens)
-                    probe.getOutput().printf("%-23s: %s%n", "Token", token);
+                    probe.output().out.printf("%-23s: %s%n", "Token", token);
             else
-                probe.getOutput().printf("%-23s: (invoke with -T/--tokens to see all %d tokens)%n", "Token",
+                probe.output().out.printf("%-23s: (invoke with -T/--tokens to see all %d tokens)%n", "Token",
                         tokens.size());
         }
         else
         {
-            probe.getOutput().printf("%-23s: (node is not joined to the cluster)%n", "Token");
+            probe.output().out.printf("%-23s: (node is not joined to the cluster)%n", "Token");
         }
     }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/ListSnapshots.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/ListSnapshots.java
@@ -37,12 +37,12 @@ public class ListSnapshots extends NodeToolCmd
     {
         try
         {
-            probe.getOutput().println("Snapshot Details: ");
+            probe.output().out.println("Snapshot Details: ");
 
             final Map<String,TabularData> snapshotDetails = probe.getSnapshotDetails();
             if (snapshotDetails.isEmpty())
             {
-                probe.getOutput().printf("There are no snapshots");
+                probe.output().out.printf("There are no snapshots");
                 return;
             }
 
@@ -50,7 +50,7 @@ public class ListSnapshots extends NodeToolCmd
             final String format = "%-40s%-45s%-45s%-19s%-19s%-27s%n";
             // display column names only once
             final List<String> indexNames = snapshotDetails.entrySet().iterator().next().getValue().getTabularType().getIndexNames();
-            probe.getOutput().printf(format, (Object[]) indexNames.toArray(new String[indexNames.size()]));
+            probe.output().out.printf(format, (Object[]) indexNames.toArray(new String[indexNames.size()]));
 
             for (final Map.Entry<String, TabularData> snapshotDetail : snapshotDetails.entrySet())
             {
@@ -58,11 +58,11 @@ public class ListSnapshots extends NodeToolCmd
                 for (Object eachValue : values)
                 {
                     final List<?> value = (List<?>) eachValue;
-                    probe.getOutput().printf(format, value.toArray(new Object[value.size()]));
+                    probe.output().out.printf(format, value.toArray(new Object[value.size()]));
                 }
             }
 
-            probe.getOutput().println("\nTotal TrueDiskSpaceUsed: " + FileUtils.stringifyFileSize(trueSnapshotsSize) + "\n");
+            probe.output().out.println("\nTotal TrueDiskSpaceUsed: " + FileUtils.stringifyFileSize(trueSnapshotsSize) + "\n");
         }
         catch (Exception e)
         {

--- a/src/java/org/apache/cassandra/tools/nodetool/ListSnapshots.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/ListSnapshots.java
@@ -37,12 +37,12 @@ public class ListSnapshots extends NodeToolCmd
     {
         try
         {
-            System.out.println("Snapshot Details: ");
+            probe.getOutput().println("Snapshot Details: ");
 
             final Map<String,TabularData> snapshotDetails = probe.getSnapshotDetails();
             if (snapshotDetails.isEmpty())
             {
-                System.out.printf("There are no snapshots");
+                probe.getOutput().printf("There are no snapshots");
                 return;
             }
 
@@ -50,7 +50,7 @@ public class ListSnapshots extends NodeToolCmd
             final String format = "%-40s%-45s%-45s%-19s%-19s%-27s%n";
             // display column names only once
             final List<String> indexNames = snapshotDetails.entrySet().iterator().next().getValue().getTabularType().getIndexNames();
-            System.out.printf(format, (Object[]) indexNames.toArray(new String[indexNames.size()]));
+            probe.getOutput().printf(format, (Object[]) indexNames.toArray(new String[indexNames.size()]));
 
             for (final Map.Entry<String, TabularData> snapshotDetail : snapshotDetails.entrySet())
             {
@@ -58,11 +58,11 @@ public class ListSnapshots extends NodeToolCmd
                 for (Object eachValue : values)
                 {
                     final List<?> value = (List<?>) eachValue;
-                    System.out.printf(format, value.toArray(new Object[value.size()]));
+                    probe.getOutput().printf(format, value.toArray(new Object[value.size()]));
                 }
             }
 
-            System.out.println("\nTotal TrueDiskSpaceUsed: " + FileUtils.stringifyFileSize(trueSnapshotsSize) + "\n");
+            probe.getOutput().println("\nTotal TrueDiskSpaceUsed: " + FileUtils.stringifyFileSize(trueSnapshotsSize) + "\n");
         }
         catch (Exception e)
         {

--- a/src/java/org/apache/cassandra/tools/nodetool/NetStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/NetStats.java
@@ -41,42 +41,42 @@ public class NetStats extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().printf("Mode: %s%n", probe.getOperationMode());
+        probe.output().out.printf("Mode: %s%n", probe.getOperationMode());
         Set<StreamState> statuses = probe.getStreamStatus();
         if (statuses.isEmpty())
-            probe.getOutput().println("Not sending any streams.");
+            probe.output().out.println("Not sending any streams.");
         for (StreamState status : statuses)
         {
-            probe.getOutput().printf("%s %s%n", status.description, status.planId.toString());
+            probe.output().out.printf("%s %s%n", status.description, status.planId.toString());
             for (SessionInfo info : status.sessions)
             {
-                probe.getOutput().printf("    %s", info.peer.toString());
+                probe.output().out.printf("    %s", info.peer.toString());
                 // print private IP when it is used
                 if (!info.peer.equals(info.connecting))
                 {
-                    probe.getOutput().printf(" (using %s)", info.connecting.toString());
+                    probe.output().out.printf(" (using %s)", info.connecting.toString());
                 }
-                probe.getOutput().printf("%n");
+                probe.output().out.printf("%n");
                 if (!info.receivingSummaries.isEmpty())
                 {
                     if (humanReadable)
-                        probe.getOutput().printf("        Receiving %d files, %s total. Already received %d files, %s total%n", info.getTotalFilesToReceive(), FileUtils.stringifyFileSize(info.getTotalSizeToReceive()), info.getTotalFilesReceived(), FileUtils.stringifyFileSize(info.getTotalSizeReceived()));
+                        probe.output().out.printf("        Receiving %d files, %s total. Already received %d files, %s total%n", info.getTotalFilesToReceive(), FileUtils.stringifyFileSize(info.getTotalSizeToReceive()), info.getTotalFilesReceived(), FileUtils.stringifyFileSize(info.getTotalSizeReceived()));
                     else
-                        probe.getOutput().printf("        Receiving %d files, %d bytes total. Already received %d files, %d bytes total%n", info.getTotalFilesToReceive(), info.getTotalSizeToReceive(), info.getTotalFilesReceived(), info.getTotalSizeReceived());
+                        probe.output().out.printf("        Receiving %d files, %d bytes total. Already received %d files, %d bytes total%n", info.getTotalFilesToReceive(), info.getTotalSizeToReceive(), info.getTotalFilesReceived(), info.getTotalSizeReceived());
                     for (ProgressInfo progress : info.getReceivingFiles())
                     {
-                        probe.getOutput().printf("            %s%n", progress.toString());
+                        probe.output().out.printf("            %s%n", progress.toString());
                     }
                 }
                 if (!info.sendingSummaries.isEmpty())
                 {
                     if (humanReadable)
-                        probe.getOutput().printf("        Sending %d files, %s total. Already sent %d files, %s total%n", info.getTotalFilesToSend(), FileUtils.stringifyFileSize(info.getTotalSizeToSend()), info.getTotalFilesSent(), FileUtils.stringifyFileSize(info.getTotalSizeSent()));
+                        probe.output().out.printf("        Sending %d files, %s total. Already sent %d files, %s total%n", info.getTotalFilesToSend(), FileUtils.stringifyFileSize(info.getTotalSizeToSend()), info.getTotalFilesSent(), FileUtils.stringifyFileSize(info.getTotalSizeSent()));
                     else
-                        probe.getOutput().printf("        Sending %d files, %d bytes total. Already sent %d files, %d bytes total%n", info.getTotalFilesToSend(), info.getTotalSizeToSend(), info.getTotalFilesSent(), info.getTotalSizeSent());
+                        probe.output().out.printf("        Sending %d files, %d bytes total. Already sent %d files, %d bytes total%n", info.getTotalFilesToSend(), info.getTotalSizeToSend(), info.getTotalFilesSent(), info.getTotalSizeSent());
                     for (ProgressInfo progress : info.getSendingFiles())
                     {
-                        probe.getOutput().printf("            %s%n", progress.toString());
+                        probe.output().out.printf("            %s%n", progress.toString());
                     }
                 }
             }
@@ -84,14 +84,14 @@ public class NetStats extends NodeToolCmd
 
         if (!probe.isStarting())
         {
-            probe.getOutput().printf("Read Repair Statistics:%nAttempted: %d%nMismatch (Blocking): %d%nMismatch (Background): %d%n", probe.getReadRepairAttempted(), probe.getReadRepairRepairedBlocking(), probe.getReadRepairRepairedBackground());
+            probe.output().out.printf("Read Repair Statistics:%nAttempted: %d%nMismatch (Blocking): %d%nMismatch (Background): %d%n", probe.getReadRepairAttempted(), probe.getReadRepairRepairedBlocking(), probe.getReadRepairRepairedBackground());
 
             MessagingServiceMBean ms = probe.getMessagingServiceProxy();
-            probe.getOutput().printf("%-25s", "Pool Name");
-            probe.getOutput().printf("%10s", "Active");
-            probe.getOutput().printf("%10s", "Pending");
-            probe.getOutput().printf("%15s", "Completed");
-            probe.getOutput().printf("%10s%n", "Dropped");
+            probe.output().out.printf("%-25s", "Pool Name");
+            probe.output().out.printf("%10s", "Active");
+            probe.output().out.printf("%10s", "Pending");
+            probe.output().out.printf("%15s", "Completed");
+            probe.output().out.printf("%10s%n", "Dropped");
 
             int pending;
             long completed;
@@ -106,7 +106,7 @@ public class NetStats extends NodeToolCmd
             dropped = 0;
             for (long n : ms.getLargeMessageDroppedTasks().values())
                 dropped += n;
-            probe.getOutput().printf("%-25s%10s%10s%15s%10s%n", "Large messages", "n/a", pending, completed, dropped);
+            probe.output().out.printf("%-25s%10s%10s%15s%10s%n", "Large messages", "n/a", pending, completed, dropped);
 
             pending = 0;
             for (int n : ms.getSmallMessagePendingTasks().values())
@@ -117,7 +117,7 @@ public class NetStats extends NodeToolCmd
             dropped = 0;
             for (long n : ms.getSmallMessageDroppedTasks().values())
                 dropped += n;
-            probe.getOutput().printf("%-25s%10s%10s%15s%10s%n", "Small messages", "n/a", pending, completed, dropped);
+            probe.output().out.printf("%-25s%10s%10s%15s%10s%n", "Small messages", "n/a", pending, completed, dropped);
 
             pending = 0;
             for (int n : ms.getGossipMessagePendingTasks().values())
@@ -128,7 +128,7 @@ public class NetStats extends NodeToolCmd
             dropped = 0;
             for (long n : ms.getGossipMessageDroppedTasks().values())
                 dropped += n;
-            probe.getOutput().printf("%-25s%10s%10s%15s%10s%n", "Gossip messages", "n/a", pending, completed, dropped);
+            probe.output().out.printf("%-25s%10s%10s%15s%10s%n", "Gossip messages", "n/a", pending, completed, dropped);
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/NetStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/NetStats.java
@@ -41,42 +41,42 @@ public class NetStats extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.printf("Mode: %s%n", probe.getOperationMode());
+        probe.getOutput().printf("Mode: %s%n", probe.getOperationMode());
         Set<StreamState> statuses = probe.getStreamStatus();
         if (statuses.isEmpty())
-            System.out.println("Not sending any streams.");
+            probe.getOutput().println("Not sending any streams.");
         for (StreamState status : statuses)
         {
-            System.out.printf("%s %s%n", status.description, status.planId.toString());
+            probe.getOutput().printf("%s %s%n", status.description, status.planId.toString());
             for (SessionInfo info : status.sessions)
             {
-                System.out.printf("    %s", info.peer.toString());
+                probe.getOutput().printf("    %s", info.peer.toString());
                 // print private IP when it is used
                 if (!info.peer.equals(info.connecting))
                 {
-                    System.out.printf(" (using %s)", info.connecting.toString());
+                    probe.getOutput().printf(" (using %s)", info.connecting.toString());
                 }
-                System.out.printf("%n");
+                probe.getOutput().printf("%n");
                 if (!info.receivingSummaries.isEmpty())
                 {
                     if (humanReadable)
-                        System.out.printf("        Receiving %d files, %s total. Already received %d files, %s total%n", info.getTotalFilesToReceive(), FileUtils.stringifyFileSize(info.getTotalSizeToReceive()), info.getTotalFilesReceived(), FileUtils.stringifyFileSize(info.getTotalSizeReceived()));
+                        probe.getOutput().printf("        Receiving %d files, %s total. Already received %d files, %s total%n", info.getTotalFilesToReceive(), FileUtils.stringifyFileSize(info.getTotalSizeToReceive()), info.getTotalFilesReceived(), FileUtils.stringifyFileSize(info.getTotalSizeReceived()));
                     else
-                        System.out.printf("        Receiving %d files, %d bytes total. Already received %d files, %d bytes total%n", info.getTotalFilesToReceive(), info.getTotalSizeToReceive(), info.getTotalFilesReceived(), info.getTotalSizeReceived());
+                        probe.getOutput().printf("        Receiving %d files, %d bytes total. Already received %d files, %d bytes total%n", info.getTotalFilesToReceive(), info.getTotalSizeToReceive(), info.getTotalFilesReceived(), info.getTotalSizeReceived());
                     for (ProgressInfo progress : info.getReceivingFiles())
                     {
-                        System.out.printf("            %s%n", progress.toString());
+                        probe.getOutput().printf("            %s%n", progress.toString());
                     }
                 }
                 if (!info.sendingSummaries.isEmpty())
                 {
                     if (humanReadable)
-                        System.out.printf("        Sending %d files, %s total. Already sent %d files, %s total%n", info.getTotalFilesToSend(), FileUtils.stringifyFileSize(info.getTotalSizeToSend()), info.getTotalFilesSent(), FileUtils.stringifyFileSize(info.getTotalSizeSent()));
+                        probe.getOutput().printf("        Sending %d files, %s total. Already sent %d files, %s total%n", info.getTotalFilesToSend(), FileUtils.stringifyFileSize(info.getTotalSizeToSend()), info.getTotalFilesSent(), FileUtils.stringifyFileSize(info.getTotalSizeSent()));
                     else
-                        System.out.printf("        Sending %d files, %d bytes total. Already sent %d files, %d bytes total%n", info.getTotalFilesToSend(), info.getTotalSizeToSend(), info.getTotalFilesSent(), info.getTotalSizeSent());
+                        probe.getOutput().printf("        Sending %d files, %d bytes total. Already sent %d files, %d bytes total%n", info.getTotalFilesToSend(), info.getTotalSizeToSend(), info.getTotalFilesSent(), info.getTotalSizeSent());
                     for (ProgressInfo progress : info.getSendingFiles())
                     {
-                        System.out.printf("            %s%n", progress.toString());
+                        probe.getOutput().printf("            %s%n", progress.toString());
                     }
                 }
             }
@@ -84,14 +84,14 @@ public class NetStats extends NodeToolCmd
 
         if (!probe.isStarting())
         {
-            System.out.printf("Read Repair Statistics:%nAttempted: %d%nMismatch (Blocking): %d%nMismatch (Background): %d%n", probe.getReadRepairAttempted(), probe.getReadRepairRepairedBlocking(), probe.getReadRepairRepairedBackground());
+            probe.getOutput().printf("Read Repair Statistics:%nAttempted: %d%nMismatch (Blocking): %d%nMismatch (Background): %d%n", probe.getReadRepairAttempted(), probe.getReadRepairRepairedBlocking(), probe.getReadRepairRepairedBackground());
 
             MessagingServiceMBean ms = probe.getMessagingServiceProxy();
-            System.out.printf("%-25s", "Pool Name");
-            System.out.printf("%10s", "Active");
-            System.out.printf("%10s", "Pending");
-            System.out.printf("%15s", "Completed");
-            System.out.printf("%10s%n", "Dropped");
+            probe.getOutput().printf("%-25s", "Pool Name");
+            probe.getOutput().printf("%10s", "Active");
+            probe.getOutput().printf("%10s", "Pending");
+            probe.getOutput().printf("%15s", "Completed");
+            probe.getOutput().printf("%10s%n", "Dropped");
 
             int pending;
             long completed;
@@ -106,7 +106,7 @@ public class NetStats extends NodeToolCmd
             dropped = 0;
             for (long n : ms.getLargeMessageDroppedTasks().values())
                 dropped += n;
-            System.out.printf("%-25s%10s%10s%15s%10s%n", "Large messages", "n/a", pending, completed, dropped);
+            probe.getOutput().printf("%-25s%10s%10s%15s%10s%n", "Large messages", "n/a", pending, completed, dropped);
 
             pending = 0;
             for (int n : ms.getSmallMessagePendingTasks().values())
@@ -117,7 +117,7 @@ public class NetStats extends NodeToolCmd
             dropped = 0;
             for (long n : ms.getSmallMessageDroppedTasks().values())
                 dropped += n;
-            System.out.printf("%-25s%10s%10s%15s%10s%n", "Small messages", "n/a", pending, completed, dropped);
+            probe.getOutput().printf("%-25s%10s%10s%15s%10s%n", "Small messages", "n/a", pending, completed, dropped);
 
             pending = 0;
             for (int n : ms.getGossipMessagePendingTasks().values())
@@ -128,7 +128,7 @@ public class NetStats extends NodeToolCmd
             dropped = 0;
             for (long n : ms.getGossipMessageDroppedTasks().values())
                 dropped += n;
-            System.out.printf("%-25s%10s%10s%15s%10s%n", "Gossip messages", "n/a", pending, completed, dropped);
+            probe.getOutput().printf("%-25s%10s%10s%15s%10s%n", "Gossip messages", "n/a", pending, completed, dropped);
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/ProxyHistograms.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/ProxyHistograms.java
@@ -34,19 +34,19 @@ public class ProxyHistograms extends NodeToolCmd
         double[] writeLatency = probe.metricPercentilesAsArray(probe.getProxyMetric("Write"));
         double[] rangeLatency = probe.metricPercentilesAsArray(probe.getProxyMetric("RangeSlice"));
 
-        System.out.println("proxy histograms");
-        System.out.println(format("%-10s%18s%18s%18s",
-                "Percentile", "Read Latency", "Write Latency", "Range Latency"));
-        System.out.println(format("%-10s%18s%18s%18s",
-                "", "(micros)", "(micros)", "(micros)"));
+        probe.getOutput().println("proxy histograms");
+        probe.getOutput().println(format("%-10s%18s%18s%18s",
+                        "Percentile", "Read Latency", "Write Latency", "Range Latency"));
+        probe.getOutput().println(format("%-10s%18s%18s%18s",
+                        "", "(micros)", "(micros)", "(micros)"));
         for (int i = 0; i < percentiles.length; i++)
         {
-            System.out.println(format("%-10s%18.2f%18.2f%18.2f",
-                    percentiles[i],
+            probe.getOutput().println(format("%-10s%18.2f%18.2f%18.2f",
+                            percentiles[i],
                     readLatency[i],
                     writeLatency[i],
                     rangeLatency[i]));
         }
-        System.out.println();
+        probe.getOutput().println();
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/ProxyHistograms.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/ProxyHistograms.java
@@ -34,19 +34,19 @@ public class ProxyHistograms extends NodeToolCmd
         double[] writeLatency = probe.metricPercentilesAsArray(probe.getProxyMetric("Write"));
         double[] rangeLatency = probe.metricPercentilesAsArray(probe.getProxyMetric("RangeSlice"));
 
-        probe.getOutput().println("proxy histograms");
-        probe.getOutput().println(format("%-10s%18s%18s%18s",
+        probe.output().out.println("proxy histograms");
+        probe.output().out.println(format("%-10s%18s%18s%18s",
                         "Percentile", "Read Latency", "Write Latency", "Range Latency"));
-        probe.getOutput().println(format("%-10s%18s%18s%18s",
+        probe.output().out.println(format("%-10s%18s%18s%18s",
                         "", "(micros)", "(micros)", "(micros)"));
         for (int i = 0; i < percentiles.length; i++)
         {
-            probe.getOutput().println(format("%-10s%18.2f%18.2f%18.2f",
+            probe.output().out.println(format("%-10s%18.2f%18.2f%18.2f",
                             percentiles[i],
                     readLatency[i],
                     writeLatency[i],
                     rangeLatency[i]));
         }
-        probe.getOutput().println();
+        probe.output().out.println();
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/RangeKeySample.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/RangeKeySample.java
@@ -30,11 +30,11 @@ public class RangeKeySample extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println("RangeKeySample: ");
+        probe.getOutput().println("RangeKeySample: ");
         List<String> tokenStrings = probe.sampleKeyRange();
         for (String tokenString : tokenStrings)
         {
-            System.out.println("\t" + tokenString);
+            probe.getOutput().println("\t" + tokenString);
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/RemoveNode.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/RemoveNode.java
@@ -36,10 +36,10 @@ public class RemoveNode extends NodeToolCmd
         switch (removeOperation)
         {
             case "status":
-                probe.getOutput().println("RemovalStatus: " + probe.getRemovalStatus());
+                probe.output().out.println("RemovalStatus: " + probe.getRemovalStatus());
                 break;
             case "force":
-                probe.getOutput().println("RemovalStatus: " + probe.getRemovalStatus());
+                probe.output().out.println("RemovalStatus: " + probe.getRemovalStatus());
                 probe.forceRemoveCompletion();
                 break;
             default:

--- a/src/java/org/apache/cassandra/tools/nodetool/RemoveNode.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/RemoveNode.java
@@ -36,10 +36,10 @@ public class RemoveNode extends NodeToolCmd
         switch (removeOperation)
         {
             case "status":
-                System.out.println("RemovalStatus: " + probe.getRemovalStatus());
+                probe.getOutput().println("RemovalStatus: " + probe.getRemovalStatus());
                 break;
             case "force":
-                System.out.println("RemovalStatus: " + probe.getRemovalStatus());
+                probe.getOutput().println("RemovalStatus: " + probe.getRemovalStatus());
                 probe.forceRemoveCompletion();
                 break;
             default:

--- a/src/java/org/apache/cassandra/tools/nodetool/Repair.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Repair.java
@@ -123,7 +123,7 @@ public class Repair extends NodeToolCmd
             options.put(RepairOption.HOSTS_KEY, StringUtils.join(specificHosts, ","));
             try
             {
-                probe.repairAsync(System.out, keyspace, options);
+                probe.repairAsync(probe.getOutput(), keyspace, options);
             } catch (Exception e)
             {
                 throw new RuntimeException("Error occurred during repair", e);

--- a/src/java/org/apache/cassandra/tools/nodetool/Repair.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Repair.java
@@ -123,7 +123,7 @@ public class Repair extends NodeToolCmd
             options.put(RepairOption.HOSTS_KEY, StringUtils.join(specificHosts, ","));
             try
             {
-                probe.repairAsync(probe.getOutput(), keyspace, options);
+                probe.repairAsync(probe.output().out, keyspace, options);
             } catch (Exception e)
             {
                 throw new RuntimeException("Error occurred during repair", e);

--- a/src/java/org/apache/cassandra/tools/nodetool/Ring.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Ring.java
@@ -88,22 +88,22 @@ public class Ring extends NodeToolCmd
         }
         catch (IllegalArgumentException ex)
         {
-            System.out.printf("%nError: " + ex.getMessage() + "%n");
+            probe.getOutput().printf("%nError: " + ex.getMessage() + "%n");
             return;
         }
 
 
-        System.out.println();
+        probe.getOutput().println();
         for (Entry<String, SetHostStat> entry : NodeTool.getOwnershipByDc(probe, resolveIp, tokensToEndpoints, ownerships).entrySet())
             printDc(probe, format, entry.getKey(), endpointsToTokens, entry.getValue(),showEffectiveOwnership);
 
         if (haveVnodes)
         {
-            System.out.println("  Warning: \"nodetool ring\" is used to output all the tokens of a node.");
-            System.out.println("  To view status related info of a node use \"nodetool status\" instead.\n");
+            probe.getOutput().println("  Warning: \"nodetool ring\" is used to output all the tokens of a node.");
+            probe.getOutput().println("  To view status related info of a node use \"nodetool status\" instead.\n");
         }
 
-        System.out.printf("%n  " + errors.toString());
+        probe.getOutput().printf("%n  " + errors.toString());
     }
 
     private void printDc(NodeProbe probe, String format,
@@ -118,8 +118,8 @@ public class Ring extends NodeToolCmd
         Collection<String> movingNodes = probe.getMovingNodes();
         Map<String, String> loadMap = probe.getLoadMap();
 
-        System.out.println("Datacenter: " + dc);
-        System.out.println("==========");
+        probe.getOutput().println("Datacenter: " + dc);
+        probe.getOutput().println("==========");
 
         // get the total amount of replicas for this dc and the last token in this dc's ring
         List<String> tokens = new ArrayList<>();
@@ -131,12 +131,12 @@ public class Ring extends NodeToolCmd
             lastToken = tokens.get(tokens.size() - 1);
         }
 
-        System.out.printf(format, "Address", "Rack", "Status", "State", "Load", "Owns", "Token");
+        probe.getOutput().printf(format, "Address", "Rack", "Status", "State", "Load", "Owns", "Token");
 
         if (hoststats.size() > 1)
-            System.out.printf(format, "", "", "", "", "", "", lastToken);
+            probe.getOutput().printf(format, "", "", "", "", "", "", lastToken);
         else
-            System.out.println();
+            probe.getOutput().println();
 
         for (HostStat stat : hoststats)
         {
@@ -170,8 +170,8 @@ public class Ring extends NodeToolCmd
                     ? loadMap.get(endpoint)
                     : "?";
             String owns = stat.owns != null && showEffectiveOwnership? new DecimalFormat("##0.00%").format(stat.owns) : "?";
-            System.out.printf(format, stat.ipOrDns(), rack, status, state, load, owns, stat.token);
+            probe.getOutput().printf(format, stat.ipOrDns(), rack, status, state, load, owns, stat.token);
         }
-        System.out.println();
+        probe.getOutput().println();
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/Ring.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Ring.java
@@ -88,22 +88,22 @@ public class Ring extends NodeToolCmd
         }
         catch (IllegalArgumentException ex)
         {
-            probe.getOutput().printf("%nError: " + ex.getMessage() + "%n");
+            probe.output().out.printf("%nError: " + ex.getMessage() + "%n");
             return;
         }
 
 
-        probe.getOutput().println();
+        probe.output().out.println();
         for (Entry<String, SetHostStat> entry : NodeTool.getOwnershipByDc(probe, resolveIp, tokensToEndpoints, ownerships).entrySet())
             printDc(probe, format, entry.getKey(), endpointsToTokens, entry.getValue(),showEffectiveOwnership);
 
         if (haveVnodes)
         {
-            probe.getOutput().println("  Warning: \"nodetool ring\" is used to output all the tokens of a node.");
-            probe.getOutput().println("  To view status related info of a node use \"nodetool status\" instead.\n");
+            probe.output().out.println("  Warning: \"nodetool ring\" is used to output all the tokens of a node.");
+            probe.output().out.println("  To view status related info of a node use \"nodetool status\" instead.\n");
         }
 
-        probe.getOutput().printf("%n  " + errors.toString());
+        probe.output().out.printf("%n  " + errors.toString());
     }
 
     private void printDc(NodeProbe probe, String format,
@@ -118,8 +118,8 @@ public class Ring extends NodeToolCmd
         Collection<String> movingNodes = probe.getMovingNodes();
         Map<String, String> loadMap = probe.getLoadMap();
 
-        probe.getOutput().println("Datacenter: " + dc);
-        probe.getOutput().println("==========");
+        probe.output().out.println("Datacenter: " + dc);
+        probe.output().out.println("==========");
 
         // get the total amount of replicas for this dc and the last token in this dc's ring
         List<String> tokens = new ArrayList<>();
@@ -131,12 +131,12 @@ public class Ring extends NodeToolCmd
             lastToken = tokens.get(tokens.size() - 1);
         }
 
-        probe.getOutput().printf(format, "Address", "Rack", "Status", "State", "Load", "Owns", "Token");
+        probe.output().out.printf(format, "Address", "Rack", "Status", "State", "Load", "Owns", "Token");
 
         if (hoststats.size() > 1)
-            probe.getOutput().printf(format, "", "", "", "", "", "", lastToken);
+            probe.output().out.printf(format, "", "", "", "", "", "", lastToken);
         else
-            probe.getOutput().println();
+            probe.output().out.println();
 
         for (HostStat stat : hoststats)
         {
@@ -170,8 +170,8 @@ public class Ring extends NodeToolCmd
                     ? loadMap.get(endpoint)
                     : "?";
             String owns = stat.owns != null && showEffectiveOwnership? new DecimalFormat("##0.00%").format(stat.owns) : "?";
-            probe.getOutput().printf(format, stat.ipOrDns(), rack, status, state, load, owns, stat.token);
+            probe.output().out.printf(format, stat.ipOrDns(), rack, status, state, load, owns, stat.token);
         }
-        probe.getOutput().println();
+        probe.output().out.println();
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/Scrub.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Scrub.java
@@ -69,7 +69,7 @@ public class Scrub extends NodeToolCmd
         {
             try
             {
-                probe.scrub(System.out, disableSnapshot, skipCorrupted, !noValidation, reinsertOverflowedTTL, jobs, keyspace, cfnames);
+                probe.scrub(probe.getOutput(), disableSnapshot, skipCorrupted, !noValidation, reinsertOverflowedTTL, jobs, keyspace, cfnames);
             } catch (IllegalArgumentException e)
             {
                 throw e;

--- a/src/java/org/apache/cassandra/tools/nodetool/Scrub.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Scrub.java
@@ -69,7 +69,7 @@ public class Scrub extends NodeToolCmd
         {
             try
             {
-                probe.scrub(probe.getOutput(), disableSnapshot, skipCorrupted, !noValidation, reinsertOverflowedTTL, jobs, keyspace, cfnames);
+                probe.scrub(probe.output().out, disableSnapshot, skipCorrupted, !noValidation, reinsertOverflowedTTL, jobs, keyspace, cfnames);
             } catch (IllegalArgumentException e)
             {
                 throw e;

--- a/src/java/org/apache/cassandra/tools/nodetool/Snapshot.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Snapshot.java
@@ -67,9 +67,9 @@ public class Snapshot extends NodeToolCmd
                 }
                 if (!snapshotName.isEmpty())
                     sb.append(" with snapshot name [").append(snapshotName).append("]");
-                System.out.println(sb.toString());
+                probe.getOutput().println(sb.toString());
                 probe.takeMultipleColumnFamilySnapshot(snapshotName, ktList.split(","));
-                System.out.println("Snapshot directory: " + snapshotName);
+                probe.getOutput().println("Snapshot directory: " + snapshotName);
             }
             else
             {
@@ -81,10 +81,10 @@ public class Snapshot extends NodeToolCmd
                 if (!snapshotName.isEmpty())
                     sb.append(" with snapshot name [").append(snapshotName).append("]");
 
-                System.out.println(sb.toString());
+                probe.getOutput().println(sb.toString());
 
                 probe.takeSnapshot(snapshotName, table, toArray(keyspaces, String.class));
-                System.out.println("Snapshot directory: " + snapshotName);
+                probe.getOutput().println("Snapshot directory: " + snapshotName);
             }
         }
         catch (IOException e)

--- a/src/java/org/apache/cassandra/tools/nodetool/Snapshot.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Snapshot.java
@@ -67,9 +67,9 @@ public class Snapshot extends NodeToolCmd
                 }
                 if (!snapshotName.isEmpty())
                     sb.append(" with snapshot name [").append(snapshotName).append("]");
-                probe.getOutput().println(sb.toString());
+                probe.output().out.println(sb.toString());
                 probe.takeMultipleColumnFamilySnapshot(snapshotName, ktList.split(","));
-                probe.getOutput().println("Snapshot directory: " + snapshotName);
+                probe.output().out.println("Snapshot directory: " + snapshotName);
             }
             else
             {
@@ -81,10 +81,10 @@ public class Snapshot extends NodeToolCmd
                 if (!snapshotName.isEmpty())
                     sb.append(" with snapshot name [").append(snapshotName).append("]");
 
-                probe.getOutput().println(sb.toString());
+                probe.output().out.println(sb.toString());
 
                 probe.takeSnapshot(snapshotName, table, toArray(keyspaces, String.class));
-                probe.getOutput().println("Snapshot directory: " + snapshotName);
+                probe.output().out.println("Snapshot directory: " + snapshotName);
             }
         }
         catch (IOException e)

--- a/src/java/org/apache/cassandra/tools/nodetool/Status.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Status.java
@@ -21,6 +21,7 @@ import io.airlift.command.Arguments;
 import io.airlift.command.Command;
 import io.airlift.command.Option;
 
+import java.io.PrintStream;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.DecimalFormat;
@@ -81,7 +82,7 @@ public class Status extends NodeToolCmd
         }
         catch (IllegalArgumentException ex)
         {
-            System.out.printf("%nError: " + ex.getMessage() + "%n");
+            probe.getOutput().printf("%nError: " + ex.getMessage() + "%n");
             System.exit(1);
         }
 
@@ -97,15 +98,15 @@ public class Status extends NodeToolCmd
         for (Map.Entry<String, SetHostStat> dc : dcs.entrySet())
         {
             String dcHeader = String.format("Datacenter: %s%n", dc.getKey());
-            System.out.printf(dcHeader);
-            for (int i = 0; i < (dcHeader.length() - 1); i++) System.out.print('=');
-            System.out.println();
+            probe.getOutput().printf(dcHeader);
+            for (int i = 0; i < (dcHeader.length() - 1); i++) probe.getOutput().print('=');
+            probe.getOutput().println();
 
             // Legend
-            System.out.println("Status=Up/Down");
-            System.out.println("|/ State=Normal/Leaving/Joining/Moving");
+            probe.getOutput().println("Status=Up/Down");
+            probe.getOutput().println("|/ State=Normal/Leaving/Joining/Moving");
 
-            printNodesHeader(hasEffectiveOwns, isTokenPerNode);
+            printNodesHeader(probe.getOutput(), hasEffectiveOwns, isTokenPerNode);
 
             ArrayListMultimap<InetAddress, HostStat> hostToTokens = ArrayListMultimap.create();
             for (HostStat stat : dc.getValue())
@@ -115,11 +116,11 @@ public class Status extends NodeToolCmd
             {
                 Float owns = ownerships.get(endpoint);
                 List<HostStat> tokens = hostToTokens.get(endpoint);
-                printNode(endpoint.getHostAddress(), owns, tokens, hasEffectiveOwns, isTokenPerNode);
+                printNode(probe.getOutput(), endpoint.getHostAddress(), owns, tokens, hasEffectiveOwns, isTokenPerNode);
             }
         }
 
-        System.out.printf("%n" + errors.toString());
+        probe.getOutput().printf("%n" + errors.toString());
 
     }
 
@@ -135,18 +136,18 @@ public class Status extends NodeToolCmd
         }
     }
 
-    private void printNodesHeader(boolean hasEffectiveOwns, boolean isTokenPerNode)
+    private void printNodesHeader(PrintStream output, boolean hasEffectiveOwns, boolean isTokenPerNode)
     {
         String fmt = getFormat(hasEffectiveOwns, isTokenPerNode);
         String owns = hasEffectiveOwns ? "Owns (effective)" : "Owns";
 
         if (isTokenPerNode)
-            System.out.printf(fmt, "-", "-", "Address", "Load", owns, "Host ID", "Token", "Rack");
+            output.printf(fmt, "-", "-", "Address", "Load", owns, "Host ID", "Token", "Rack");
         else
-            System.out.printf(fmt, "-", "-", "Address", "Load", "Tokens", owns, "Host ID", "Rack");
+            output.printf(fmt, "-", "-", "Address", "Load", "Tokens", owns, "Host ID", "Rack");
     }
 
-    private void printNode(String endpoint, Float owns, List<HostStat> tokens, boolean hasEffectiveOwns, boolean isTokenPerNode)
+    private void printNode(PrintStream output, String endpoint, Float owns, List<HostStat> tokens, boolean hasEffectiveOwns, boolean isTokenPerNode)
     {
         String status, state, load, strOwns, hostID, rack, fmt;
         fmt = getFormat(hasEffectiveOwns, isTokenPerNode);
@@ -172,9 +173,9 @@ public class Status extends NodeToolCmd
 
         String endpointDns = tokens.get(0).ipOrDns();
         if (isTokenPerNode)
-            System.out.printf(fmt, status, state, endpointDns, load, strOwns, hostID, tokens.get(0).token, rack);
+            output.printf(fmt, status, state, endpointDns, load, strOwns, hostID, tokens.get(0).token, rack);
         else
-            System.out.printf(fmt, status, state, endpointDns, load, tokens.size(), strOwns, hostID, rack);
+            output.printf(fmt, status, state, endpointDns, load, tokens.size(), strOwns, hostID, rack);
     }
 
     private String getFormat(

--- a/src/java/org/apache/cassandra/tools/nodetool/Status.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Status.java
@@ -82,7 +82,7 @@ public class Status extends NodeToolCmd
         }
         catch (IllegalArgumentException ex)
         {
-            probe.getOutput().printf("%nError: " + ex.getMessage() + "%n");
+            probe.output().out.printf("%nError: " + ex.getMessage() + "%n");
             System.exit(1);
         }
 
@@ -98,15 +98,15 @@ public class Status extends NodeToolCmd
         for (Map.Entry<String, SetHostStat> dc : dcs.entrySet())
         {
             String dcHeader = String.format("Datacenter: %s%n", dc.getKey());
-            probe.getOutput().printf(dcHeader);
-            for (int i = 0; i < (dcHeader.length() - 1); i++) probe.getOutput().print('=');
-            probe.getOutput().println();
+            probe.output().out.printf(dcHeader);
+            for (int i = 0; i < (dcHeader.length() - 1); i++) probe.output().out.print('=');
+            probe.output().out.println();
 
             // Legend
-            probe.getOutput().println("Status=Up/Down");
-            probe.getOutput().println("|/ State=Normal/Leaving/Joining/Moving");
+            probe.output().out.println("Status=Up/Down");
+            probe.output().out.println("|/ State=Normal/Leaving/Joining/Moving");
 
-            printNodesHeader(probe.getOutput(), hasEffectiveOwns, isTokenPerNode);
+            printNodesHeader(probe.output().out, hasEffectiveOwns, isTokenPerNode);
 
             ArrayListMultimap<InetAddress, HostStat> hostToTokens = ArrayListMultimap.create();
             for (HostStat stat : dc.getValue())
@@ -116,11 +116,11 @@ public class Status extends NodeToolCmd
             {
                 Float owns = ownerships.get(endpoint);
                 List<HostStat> tokens = hostToTokens.get(endpoint);
-                printNode(probe.getOutput(), endpoint.getHostAddress(), owns, tokens, hasEffectiveOwns, isTokenPerNode);
+                printNode(probe.output().out, endpoint.getHostAddress(), owns, tokens, hasEffectiveOwns, isTokenPerNode);
             }
         }
 
-        probe.getOutput().printf("%n" + errors.toString());
+        probe.output().out.printf("%n" + errors.toString());
 
     }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/StatusBackup.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StatusBackup.java
@@ -28,7 +28,7 @@ public class StatusBackup extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println(
+        probe.output().out.println(
                 probe.isIncrementalBackupsEnabled()
                 ? "running"
                 : "not running");

--- a/src/java/org/apache/cassandra/tools/nodetool/StatusBackup.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StatusBackup.java
@@ -28,7 +28,7 @@ public class StatusBackup extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println(
+        probe.getOutput().println(
                 probe.isIncrementalBackupsEnabled()
                 ? "running"
                 : "not running");

--- a/src/java/org/apache/cassandra/tools/nodetool/StatusBinary.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StatusBinary.java
@@ -28,7 +28,7 @@ public class StatusBinary extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println(
+        probe.output().out.println(
                 probe.isNativeTransportRunning()
                 ? "running"
                 : "not running");

--- a/src/java/org/apache/cassandra/tools/nodetool/StatusBinary.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StatusBinary.java
@@ -28,7 +28,7 @@ public class StatusBinary extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println(
+        probe.getOutput().println(
                 probe.isNativeTransportRunning()
                 ? "running"
                 : "not running");

--- a/src/java/org/apache/cassandra/tools/nodetool/StatusGossip.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StatusGossip.java
@@ -28,7 +28,7 @@ public class StatusGossip extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println(
+        probe.output().out.println(
                 probe.isGossipRunning()
                 ? "running"
                 : "not running");

--- a/src/java/org/apache/cassandra/tools/nodetool/StatusGossip.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StatusGossip.java
@@ -28,7 +28,7 @@ public class StatusGossip extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println(
+        probe.getOutput().println(
                 probe.isGossipRunning()
                 ? "running"
                 : "not running");

--- a/src/java/org/apache/cassandra/tools/nodetool/StatusHandoff.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StatusHandoff.java
@@ -28,7 +28,7 @@ public class StatusHandoff extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println(
+        probe.getOutput().println(
                 probe.isHandoffEnabled()
                 ? "running"
                 : "not running");

--- a/src/java/org/apache/cassandra/tools/nodetool/StatusHandoff.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StatusHandoff.java
@@ -28,7 +28,7 @@ public class StatusHandoff extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println(
+        probe.output().out.println(
                 probe.isHandoffEnabled()
                 ? "running"
                 : "not running");

--- a/src/java/org/apache/cassandra/tools/nodetool/StatusThrift.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StatusThrift.java
@@ -28,7 +28,7 @@ public class StatusThrift extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println(
+        probe.output().out.println(
                 probe.isThriftServerRunning()
                 ? "running"
                 : "not running");

--- a/src/java/org/apache/cassandra/tools/nodetool/StatusThrift.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StatusThrift.java
@@ -28,7 +28,7 @@ public class StatusThrift extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println(
+        probe.getOutput().println(
                 probe.isThriftServerRunning()
                 ? "running"
                 : "not running");

--- a/src/java/org/apache/cassandra/tools/nodetool/StopDaemon.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StopDaemon.java
@@ -37,6 +37,6 @@ public class StopDaemon extends NodeToolCmd
             JVMStabilityInspector.inspectThrowable(e);
             // ignored
         }
-        System.out.println("Cassandra has shutdown.");
+        probe.getOutput().println("Cassandra has shutdown.");
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/StopDaemon.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StopDaemon.java
@@ -37,6 +37,6 @@ public class StopDaemon extends NodeToolCmd
             JVMStabilityInspector.inspectThrowable(e);
             // ignored
         }
-        probe.getOutput().println("Cassandra has shutdown.");
+        probe.output().out.println("Cassandra has shutdown.");
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/TableHistograms.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/TableHistograms.java
@@ -106,22 +106,22 @@ public class TableHistograms extends NodeToolCmd
         double[] writeLatency = probe.metricPercentilesAsArray((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspace, table, "WriteLatency"));
         double[] sstablesPerRead = probe.metricPercentilesAsArray((CassandraMetricsRegistry.JmxHistogramMBean) probe.getColumnFamilyMetric(keyspace, table, "SSTablesPerReadHistogram"));
 
-        System.out.println(format("%s/%s histograms", keyspace, table));
-        System.out.println(format("%-10s%10s%18s%18s%18s%18s",
-                "Percentile", "SSTables", "Write Latency", "Read Latency", "Partition Size", "Cell Count"));
-        System.out.println(format("%-10s%10s%18s%18s%18s%18s",
-                "", "", "(micros)", "(micros)", "(bytes)", ""));
+        probe.getOutput().println(format("%s/%s histograms", keyspace, table));
+        probe.getOutput().println(format("%-10s%10s%18s%18s%18s%18s",
+                        "Percentile", "SSTables", "Write Latency", "Read Latency", "Partition Size", "Cell Count"));
+        probe.getOutput().println(format("%-10s%10s%18s%18s%18s%18s",
+                        "", "", "(micros)", "(micros)", "(bytes)", ""));
 
         for (int i = 0; i < percentiles.length; i++)
         {
-            System.out.println(format("%-10s%10.2f%18.2f%18.2f%18.0f%18.0f",
-                    percentiles[i],
+            probe.getOutput().println(format("%-10s%10.2f%18.2f%18.2f%18.0f%18.0f",
+                            percentiles[i],
                     sstablesPerRead[i],
                     writeLatency[i],
                     readLatency[i],
                     estimatedRowSizePercentiles[i],
                     estimatedColumnCountPercentiles[i]));
         }
-        System.out.println();
+        probe.getOutput().println();
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/TableHistograms.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/TableHistograms.java
@@ -106,15 +106,15 @@ public class TableHistograms extends NodeToolCmd
         double[] writeLatency = probe.metricPercentilesAsArray((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspace, table, "WriteLatency"));
         double[] sstablesPerRead = probe.metricPercentilesAsArray((CassandraMetricsRegistry.JmxHistogramMBean) probe.getColumnFamilyMetric(keyspace, table, "SSTablesPerReadHistogram"));
 
-        probe.getOutput().println(format("%s/%s histograms", keyspace, table));
-        probe.getOutput().println(format("%-10s%10s%18s%18s%18s%18s",
+        probe.output().out.println(format("%s/%s histograms", keyspace, table));
+        probe.output().out.println(format("%-10s%10s%18s%18s%18s%18s",
                         "Percentile", "SSTables", "Write Latency", "Read Latency", "Partition Size", "Cell Count"));
-        probe.getOutput().println(format("%-10s%10s%18s%18s%18s%18s",
+        probe.output().out.println(format("%-10s%10s%18s%18s%18s%18s",
                         "", "", "(micros)", "(micros)", "(bytes)", ""));
 
         for (int i = 0; i < percentiles.length; i++)
         {
-            probe.getOutput().println(format("%-10s%10.2f%18.2f%18.2f%18.0f%18.0f",
+            probe.output().out.println(format("%-10s%10.2f%18.2f%18.2f%18.0f%18.0f",
                             percentiles[i],
                     sstablesPerRead[i],
                     writeLatency[i],
@@ -122,6 +122,6 @@ public class TableHistograms extends NodeToolCmd
                     estimatedRowSizePercentiles[i],
                     estimatedColumnCountPercentiles[i]));
         }
-        probe.getOutput().println();
+        probe.output().out.println();
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/TableStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/TableStats.java
@@ -90,7 +90,7 @@ public class TableStats extends NodeToolCmd
             double keyspaceTotalReadTime = 0.0f;
             double keyspaceTotalWriteTime = 0.0f;
 
-            probe.getOutput().println("Keyspace: " + keyspaceName);
+            probe.output().out.println("Keyspace: " + keyspaceName);
             for (ColumnFamilyStoreMBean table : columnFamilies)
             {
                 String tableName = table.getColumnFamilyName();
@@ -117,42 +117,42 @@ public class TableStats extends NodeToolCmd
                                           ? keyspaceTotalWriteTime / keyspaceWriteCount / 1000
                                           : Double.NaN;
 
-            probe.getOutput().println("\tRead Count: " + keyspaceReadCount);
-            probe.getOutput().println("\tRead Latency: " + String.format("%s", keyspaceReadLatency) + " ms.");
-            probe.getOutput().println("\tWrite Count: " + keyspaceWriteCount);
-            probe.getOutput().println("\tWrite Latency: " + String.format("%s", keyspaceWriteLatency) + " ms.");
-            probe.getOutput().println("\tPending Flushes: " + keyspacePendingFlushes);
+            probe.output().out.println("\tRead Count: " + keyspaceReadCount);
+            probe.output().out.println("\tRead Latency: " + String.format("%s", keyspaceReadLatency) + " ms.");
+            probe.output().out.println("\tWrite Count: " + keyspaceWriteCount);
+            probe.output().out.println("\tWrite Latency: " + String.format("%s", keyspaceWriteLatency) + " ms.");
+            probe.output().out.println("\tPending Flushes: " + keyspacePendingFlushes);
 
             // print out column family statistics for this keyspace
             for (ColumnFamilyStoreMBean table : columnFamilies)
             {
                 String tableName = table.getColumnFamilyName();
                 if (tableName.contains("."))
-                    probe.getOutput().println("\t\tTable (index): " + tableName);
+                    probe.output().out.println("\t\tTable (index): " + tableName);
                 else
-                    probe.getOutput().println("\t\tTable: " + tableName);
+                    probe.output().out.println("\t\tTable: " + tableName);
 
-                probe.getOutput().println("\t\tSSTable count: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "LiveSSTableCount"));
+                probe.output().out.println("\t\tSSTable count: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "LiveSSTableCount"));
 
                 int[] leveledSStables = table.getSSTableCountPerLevel();
                 if (leveledSStables != null)
                 {
-                    probe.getOutput().print("\t\tSSTables in each level: [");
+                    probe.output().out.print("\t\tSSTables in each level: [");
                     for (int level = 0; level < leveledSStables.length; level++)
                     {
                         int count = leveledSStables[level];
-                        probe.getOutput().print(count);
+                        probe.output().out.print(count);
                         long maxCount = 4L; // for L0
                         if (level > 0)
                             maxCount = (long) Math.pow(10, level);
                         //  show max threshold for level when exceeded
                         if (count > maxCount)
-                            probe.getOutput().print("/" + maxCount);
+                            probe.output().out.print("/" + maxCount);
 
                         if (level < leveledSStables.length - 1)
-                            probe.getOutput().print(", ");
+                            probe.output().out.print(", ");
                         else
-                            probe.getOutput().println("]");
+                            probe.output().out.println("]");
                     }
                 }
 
@@ -179,12 +179,12 @@ public class TableStats extends NodeToolCmd
                         throw e;
                 }
 
-                probe.getOutput().println("\t\tSpace used (live): " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "LiveDiskSpaceUsed"), humanReadable));
-                probe.getOutput().println("\t\tSpace used (total): " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "TotalDiskSpaceUsed"), humanReadable));
-                probe.getOutput().println("\t\tSpace used by snapshots (total): " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "SnapshotsSize"), humanReadable));
+                probe.output().out.println("\t\tSpace used (live): " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "LiveDiskSpaceUsed"), humanReadable));
+                probe.output().out.println("\t\tSpace used (total): " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "TotalDiskSpaceUsed"), humanReadable));
+                probe.output().out.println("\t\tSpace used by snapshots (total): " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "SnapshotsSize"), humanReadable));
                 if (offHeapSize != null)
-                    probe.getOutput().println("\t\tOff heap memory used (total): " + format(offHeapSize, humanReadable));
-                probe.getOutput().println("\t\tSSTable Compression Ratio: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "CompressionRatio"));
+                    probe.output().out.println("\t\tOff heap memory used (total): " + format(offHeapSize, humanReadable));
+                probe.output().out.println("\t\tSSTable Compression Ratio: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "CompressionRatio"));
 
                 Object estimatedRowCount = probe.getColumnFamilyMetric(keyspaceName, tableName, "EstimatedRowCount");
                 if (Long.valueOf(-1L).equals(estimatedRowCount))
@@ -192,45 +192,45 @@ public class TableStats extends NodeToolCmd
                     estimatedRowCount = 0L;
                 }
 
-                probe.getOutput().println("\t\tNumber of keys (estimate): " + estimatedRowCount);
+                probe.output().out.println("\t\tNumber of keys (estimate): " + estimatedRowCount);
 
-                probe.getOutput().println("\t\tMemtable cell count: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "MemtableColumnsCount"));
-                probe.getOutput().println("\t\tMemtable data size: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MemtableLiveDataSize"), humanReadable));
+                probe.output().out.println("\t\tMemtable cell count: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "MemtableColumnsCount"));
+                probe.output().out.println("\t\tMemtable data size: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MemtableLiveDataSize"), humanReadable));
                 if (memtableOffHeapSize != null)
-                    probe.getOutput().println("\t\tMemtable off heap memory used: " + format(memtableOffHeapSize, humanReadable));
-                probe.getOutput().println("\t\tMemtable switch count: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "MemtableSwitchCount"));
-                probe.getOutput().println("\t\tLocal read count: " + ((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "ReadLatency")).getCount());
+                    probe.output().out.println("\t\tMemtable off heap memory used: " + format(memtableOffHeapSize, humanReadable));
+                probe.output().out.println("\t\tMemtable switch count: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "MemtableSwitchCount"));
+                probe.output().out.println("\t\tLocal read count: " + ((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "ReadLatency")).getCount());
                 double localReadLatency = ((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "ReadLatency")).getMean() / 1000;
                 double localRLatency = localReadLatency > 0 ? localReadLatency : Double.NaN;
-                probe.getOutput().printf("\t\tLocal read latency: %01.3f ms%n", localRLatency);
-                probe.getOutput().println("\t\tLocal write count: " + ((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "WriteLatency")).getCount());
+                probe.output().out.printf("\t\tLocal read latency: %01.3f ms%n", localRLatency);
+                probe.output().out.println("\t\tLocal write count: " + ((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "WriteLatency")).getCount());
                 double localWriteLatency = ((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "WriteLatency")).getMean() / 1000;
                 double localWLatency = localWriteLatency > 0 ? localWriteLatency : Double.NaN;
-                probe.getOutput().printf("\t\tLocal write latency: %01.3f ms%n", localWLatency);
-                probe.getOutput().println("\t\tPending flushes: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "PendingFlushes"));
-                probe.getOutput().println("\t\tBloom filter false positives: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterFalsePositives"));
-                probe.getOutput().printf("\t\tBloom filter false ratio: %s%n", String.format("%01.5f", probe.getColumnFamilyMetric(keyspaceName, tableName, "RecentBloomFilterFalseRatio")));
-                probe.getOutput().println("\t\tBloom filter space used: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterDiskSpaceUsed"), humanReadable));
+                probe.output().out.printf("\t\tLocal write latency: %01.3f ms%n", localWLatency);
+                probe.output().out.println("\t\tPending flushes: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "PendingFlushes"));
+                probe.output().out.println("\t\tBloom filter false positives: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterFalsePositives"));
+                probe.output().out.printf("\t\tBloom filter false ratio: %s%n", String.format("%01.5f", probe.getColumnFamilyMetric(keyspaceName, tableName, "RecentBloomFilterFalseRatio")));
+                probe.output().out.println("\t\tBloom filter space used: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterDiskSpaceUsed"), humanReadable));
                 if (bloomFilterOffHeapSize != null)
-                    probe.getOutput().println("\t\tBloom filter off heap memory used: " + format(bloomFilterOffHeapSize, humanReadable));
+                    probe.output().out.println("\t\tBloom filter off heap memory used: " + format(bloomFilterOffHeapSize, humanReadable));
                 if (indexSummaryOffHeapSize != null)
-                    probe.getOutput().println("\t\tIndex summary off heap memory used: " + format(indexSummaryOffHeapSize, humanReadable));
+                    probe.output().out.println("\t\tIndex summary off heap memory used: " + format(indexSummaryOffHeapSize, humanReadable));
                 if (compressionMetadataOffHeapSize != null)
-                    probe.getOutput().println("\t\tCompression metadata off heap memory used: " + format(compressionMetadataOffHeapSize, humanReadable));
+                    probe.output().out.println("\t\tCompression metadata off heap memory used: " + format(compressionMetadataOffHeapSize, humanReadable));
 
-                probe.getOutput().println("\t\tCompacted partition minimum bytes: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MinRowSize"), humanReadable));
-                probe.getOutput().println("\t\tCompacted partition maximum bytes: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MaxRowSize"), humanReadable));
-                probe.getOutput().println("\t\tCompacted partition mean bytes: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MeanRowSize"), humanReadable));
+                probe.output().out.println("\t\tCompacted partition minimum bytes: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MinRowSize"), humanReadable));
+                probe.output().out.println("\t\tCompacted partition maximum bytes: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MaxRowSize"), humanReadable));
+                probe.output().out.println("\t\tCompacted partition mean bytes: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MeanRowSize"), humanReadable));
                 CassandraMetricsRegistry.JmxHistogramMBean histogram = (CassandraMetricsRegistry.JmxHistogramMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "LiveScannedHistogram");
-                probe.getOutput().println("\t\tAverage live cells per slice (last five minutes): " + histogram.getMean());
-                probe.getOutput().println("\t\tMaximum live cells per slice (last five minutes): " + histogram.getMax());
+                probe.output().out.println("\t\tAverage live cells per slice (last five minutes): " + histogram.getMean());
+                probe.output().out.println("\t\tMaximum live cells per slice (last five minutes): " + histogram.getMax());
                 histogram = (CassandraMetricsRegistry.JmxHistogramMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "TombstoneScannedHistogram");
-                probe.getOutput().println("\t\tAverage tombstones per slice (last five minutes): " + histogram.getMean());
-                probe.getOutput().println("\t\tMaximum tombstones per slice (last five minutes): " + histogram.getMax());
+                probe.output().out.println("\t\tAverage tombstones per slice (last five minutes): " + histogram.getMean());
+                probe.output().out.println("\t\tMaximum tombstones per slice (last five minutes): " + histogram.getMax());
 
-                probe.getOutput().println("");
+                probe.output().out.println("");
             }
-            probe.getOutput().println("----------------");
+            probe.output().out.println("----------------");
         }
     }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/TableStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/TableStats.java
@@ -90,7 +90,7 @@ public class TableStats extends NodeToolCmd
             double keyspaceTotalReadTime = 0.0f;
             double keyspaceTotalWriteTime = 0.0f;
 
-            System.out.println("Keyspace: " + keyspaceName);
+            probe.getOutput().println("Keyspace: " + keyspaceName);
             for (ColumnFamilyStoreMBean table : columnFamilies)
             {
                 String tableName = table.getColumnFamilyName();
@@ -117,42 +117,42 @@ public class TableStats extends NodeToolCmd
                                           ? keyspaceTotalWriteTime / keyspaceWriteCount / 1000
                                           : Double.NaN;
 
-            System.out.println("\tRead Count: " + keyspaceReadCount);
-            System.out.println("\tRead Latency: " + String.format("%s", keyspaceReadLatency) + " ms.");
-            System.out.println("\tWrite Count: " + keyspaceWriteCount);
-            System.out.println("\tWrite Latency: " + String.format("%s", keyspaceWriteLatency) + " ms.");
-            System.out.println("\tPending Flushes: " + keyspacePendingFlushes);
+            probe.getOutput().println("\tRead Count: " + keyspaceReadCount);
+            probe.getOutput().println("\tRead Latency: " + String.format("%s", keyspaceReadLatency) + " ms.");
+            probe.getOutput().println("\tWrite Count: " + keyspaceWriteCount);
+            probe.getOutput().println("\tWrite Latency: " + String.format("%s", keyspaceWriteLatency) + " ms.");
+            probe.getOutput().println("\tPending Flushes: " + keyspacePendingFlushes);
 
             // print out column family statistics for this keyspace
             for (ColumnFamilyStoreMBean table : columnFamilies)
             {
                 String tableName = table.getColumnFamilyName();
                 if (tableName.contains("."))
-                    System.out.println("\t\tTable (index): " + tableName);
+                    probe.getOutput().println("\t\tTable (index): " + tableName);
                 else
-                    System.out.println("\t\tTable: " + tableName);
+                    probe.getOutput().println("\t\tTable: " + tableName);
 
-                System.out.println("\t\tSSTable count: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "LiveSSTableCount"));
+                probe.getOutput().println("\t\tSSTable count: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "LiveSSTableCount"));
 
                 int[] leveledSStables = table.getSSTableCountPerLevel();
                 if (leveledSStables != null)
                 {
-                    System.out.print("\t\tSSTables in each level: [");
+                    probe.getOutput().print("\t\tSSTables in each level: [");
                     for (int level = 0; level < leveledSStables.length; level++)
                     {
                         int count = leveledSStables[level];
-                        System.out.print(count);
+                        probe.getOutput().print(count);
                         long maxCount = 4L; // for L0
                         if (level > 0)
                             maxCount = (long) Math.pow(10, level);
                         //  show max threshold for level when exceeded
                         if (count > maxCount)
-                            System.out.print("/" + maxCount);
+                            probe.getOutput().print("/" + maxCount);
 
                         if (level < leveledSStables.length - 1)
-                            System.out.print(", ");
+                            probe.getOutput().print(", ");
                         else
-                            System.out.println("]");
+                            probe.getOutput().println("]");
                     }
                 }
 
@@ -179,12 +179,12 @@ public class TableStats extends NodeToolCmd
                         throw e;
                 }
 
-                System.out.println("\t\tSpace used (live): " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "LiveDiskSpaceUsed"), humanReadable));
-                System.out.println("\t\tSpace used (total): " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "TotalDiskSpaceUsed"), humanReadable));
-                System.out.println("\t\tSpace used by snapshots (total): " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "SnapshotsSize"), humanReadable));
+                probe.getOutput().println("\t\tSpace used (live): " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "LiveDiskSpaceUsed"), humanReadable));
+                probe.getOutput().println("\t\tSpace used (total): " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "TotalDiskSpaceUsed"), humanReadable));
+                probe.getOutput().println("\t\tSpace used by snapshots (total): " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "SnapshotsSize"), humanReadable));
                 if (offHeapSize != null)
-                    System.out.println("\t\tOff heap memory used (total): " + format(offHeapSize, humanReadable));
-                System.out.println("\t\tSSTable Compression Ratio: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "CompressionRatio"));
+                    probe.getOutput().println("\t\tOff heap memory used (total): " + format(offHeapSize, humanReadable));
+                probe.getOutput().println("\t\tSSTable Compression Ratio: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "CompressionRatio"));
 
                 Object estimatedRowCount = probe.getColumnFamilyMetric(keyspaceName, tableName, "EstimatedRowCount");
                 if (Long.valueOf(-1L).equals(estimatedRowCount))
@@ -192,45 +192,45 @@ public class TableStats extends NodeToolCmd
                     estimatedRowCount = 0L;
                 }
 
-                System.out.println("\t\tNumber of keys (estimate): " + estimatedRowCount);
+                probe.getOutput().println("\t\tNumber of keys (estimate): " + estimatedRowCount);
 
-                System.out.println("\t\tMemtable cell count: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "MemtableColumnsCount"));
-                System.out.println("\t\tMemtable data size: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MemtableLiveDataSize"), humanReadable));
+                probe.getOutput().println("\t\tMemtable cell count: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "MemtableColumnsCount"));
+                probe.getOutput().println("\t\tMemtable data size: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MemtableLiveDataSize"), humanReadable));
                 if (memtableOffHeapSize != null)
-                    System.out.println("\t\tMemtable off heap memory used: " + format(memtableOffHeapSize, humanReadable));
-                System.out.println("\t\tMemtable switch count: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "MemtableSwitchCount"));
-                System.out.println("\t\tLocal read count: " + ((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "ReadLatency")).getCount());
+                    probe.getOutput().println("\t\tMemtable off heap memory used: " + format(memtableOffHeapSize, humanReadable));
+                probe.getOutput().println("\t\tMemtable switch count: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "MemtableSwitchCount"));
+                probe.getOutput().println("\t\tLocal read count: " + ((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "ReadLatency")).getCount());
                 double localReadLatency = ((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "ReadLatency")).getMean() / 1000;
                 double localRLatency = localReadLatency > 0 ? localReadLatency : Double.NaN;
-                System.out.printf("\t\tLocal read latency: %01.3f ms%n", localRLatency);
-                System.out.println("\t\tLocal write count: " + ((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "WriteLatency")).getCount());
+                probe.getOutput().printf("\t\tLocal read latency: %01.3f ms%n", localRLatency);
+                probe.getOutput().println("\t\tLocal write count: " + ((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "WriteLatency")).getCount());
                 double localWriteLatency = ((CassandraMetricsRegistry.JmxTimerMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "WriteLatency")).getMean() / 1000;
                 double localWLatency = localWriteLatency > 0 ? localWriteLatency : Double.NaN;
-                System.out.printf("\t\tLocal write latency: %01.3f ms%n", localWLatency);
-                System.out.println("\t\tPending flushes: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "PendingFlushes"));
-                System.out.println("\t\tBloom filter false positives: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterFalsePositives"));
-                System.out.printf("\t\tBloom filter false ratio: %s%n", String.format("%01.5f", probe.getColumnFamilyMetric(keyspaceName, tableName, "RecentBloomFilterFalseRatio")));
-                System.out.println("\t\tBloom filter space used: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterDiskSpaceUsed"), humanReadable));
+                probe.getOutput().printf("\t\tLocal write latency: %01.3f ms%n", localWLatency);
+                probe.getOutput().println("\t\tPending flushes: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "PendingFlushes"));
+                probe.getOutput().println("\t\tBloom filter false positives: " + probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterFalsePositives"));
+                probe.getOutput().printf("\t\tBloom filter false ratio: %s%n", String.format("%01.5f", probe.getColumnFamilyMetric(keyspaceName, tableName, "RecentBloomFilterFalseRatio")));
+                probe.getOutput().println("\t\tBloom filter space used: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterDiskSpaceUsed"), humanReadable));
                 if (bloomFilterOffHeapSize != null)
-                    System.out.println("\t\tBloom filter off heap memory used: " + format(bloomFilterOffHeapSize, humanReadable));
+                    probe.getOutput().println("\t\tBloom filter off heap memory used: " + format(bloomFilterOffHeapSize, humanReadable));
                 if (indexSummaryOffHeapSize != null)
-                    System.out.println("\t\tIndex summary off heap memory used: " + format(indexSummaryOffHeapSize, humanReadable));
+                    probe.getOutput().println("\t\tIndex summary off heap memory used: " + format(indexSummaryOffHeapSize, humanReadable));
                 if (compressionMetadataOffHeapSize != null)
-                    System.out.println("\t\tCompression metadata off heap memory used: " + format(compressionMetadataOffHeapSize, humanReadable));
+                    probe.getOutput().println("\t\tCompression metadata off heap memory used: " + format(compressionMetadataOffHeapSize, humanReadable));
 
-                System.out.println("\t\tCompacted partition minimum bytes: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MinRowSize"), humanReadable));
-                System.out.println("\t\tCompacted partition maximum bytes: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MaxRowSize"), humanReadable));
-                System.out.println("\t\tCompacted partition mean bytes: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MeanRowSize"), humanReadable));
+                probe.getOutput().println("\t\tCompacted partition minimum bytes: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MinRowSize"), humanReadable));
+                probe.getOutput().println("\t\tCompacted partition maximum bytes: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MaxRowSize"), humanReadable));
+                probe.getOutput().println("\t\tCompacted partition mean bytes: " + format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "MeanRowSize"), humanReadable));
                 CassandraMetricsRegistry.JmxHistogramMBean histogram = (CassandraMetricsRegistry.JmxHistogramMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "LiveScannedHistogram");
-                System.out.println("\t\tAverage live cells per slice (last five minutes): " + histogram.getMean());
-                System.out.println("\t\tMaximum live cells per slice (last five minutes): " + histogram.getMax());
+                probe.getOutput().println("\t\tAverage live cells per slice (last five minutes): " + histogram.getMean());
+                probe.getOutput().println("\t\tMaximum live cells per slice (last five minutes): " + histogram.getMax());
                 histogram = (CassandraMetricsRegistry.JmxHistogramMBean) probe.getColumnFamilyMetric(keyspaceName, tableName, "TombstoneScannedHistogram");
-                System.out.println("\t\tAverage tombstones per slice (last five minutes): " + histogram.getMean());
-                System.out.println("\t\tMaximum tombstones per slice (last five minutes): " + histogram.getMax());
+                probe.getOutput().println("\t\tAverage tombstones per slice (last five minutes): " + histogram.getMean());
+                probe.getOutput().println("\t\tMaximum tombstones per slice (last five minutes): " + histogram.getMax());
 
-                System.out.println("");
+                probe.getOutput().println("");
             }
-            System.out.println("----------------");
+            probe.getOutput().println("----------------");
         }
     }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/TopPartitions.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/TopPartitions.java
@@ -95,21 +95,21 @@ public class TopPartitions extends NodeToolCmd
                 }
             });
             if(!first)
-                probe.getOutput().println();
-            probe.getOutput().println(result.getKey().toString()+ " Sampler:");
-            probe.getOutput().printf("  Cardinality: ~%d (%d capacity)%n", (long) sampling.get("cardinality"), size);
-            probe.getOutput().printf("  Top %d partitions:%n", topCount);
+                probe.output().out.println();
+            probe.output().out.println(result.getKey().toString()+ " Sampler:");
+            probe.output().out.printf("  Cardinality: ~%d (%d capacity)%n", (long) sampling.get("cardinality"), size);
+            probe.output().out.printf("  Top %d partitions:%n", topCount);
             if (topk.size() == 0)
             {
-                probe.getOutput().println("\tNothing recorded during sampling period...");
+                probe.output().out.println("\tNothing recorded during sampling period...");
             } else
             {
                 int offset = 0;
                 for (CompositeData entry : topk)
                     offset = Math.max(offset, entry.get("string").toString().length());
-                probe.getOutput().printf("\t%-" + offset + "s%10s%10s%n", "Partition", "Count", "+/-");
+                probe.output().out.printf("\t%-" + offset + "s%10s%10s%n", "Partition", "Count", "+/-");
                 for (CompositeData entry : topk)
-                    probe.getOutput().printf("\t%-" + offset + "s%10d%10d%n", entry.get("string").toString(), entry.get("count"), entry.get("error"));
+                    probe.output().out.printf("\t%-" + offset + "s%10d%10d%n", entry.get("string").toString(), entry.get("count"), entry.get("error"));
             }
             first = false;
         }

--- a/src/java/org/apache/cassandra/tools/nodetool/TopPartitions.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/TopPartitions.java
@@ -95,21 +95,21 @@ public class TopPartitions extends NodeToolCmd
                 }
             });
             if(!first)
-                System.out.println();
-            System.out.println(result.getKey().toString()+ " Sampler:");
-            System.out.printf("  Cardinality: ~%d (%d capacity)%n", (long) sampling.get("cardinality"), size);
-            System.out.printf("  Top %d partitions:%n", topCount);
+                probe.getOutput().println();
+            probe.getOutput().println(result.getKey().toString()+ " Sampler:");
+            probe.getOutput().printf("  Cardinality: ~%d (%d capacity)%n", (long) sampling.get("cardinality"), size);
+            probe.getOutput().printf("  Top %d partitions:%n", topCount);
             if (topk.size() == 0)
             {
-                System.out.println("\tNothing recorded during sampling period...");
+                probe.getOutput().println("\tNothing recorded during sampling period...");
             } else
             {
                 int offset = 0;
                 for (CompositeData entry : topk)
                     offset = Math.max(offset, entry.get("string").toString().length());
-                System.out.printf("\t%-" + offset + "s%10s%10s%n", "Partition", "Count", "+/-");
+                probe.getOutput().printf("\t%-" + offset + "s%10s%10s%n", "Partition", "Count", "+/-");
                 for (CompositeData entry : topk)
-                    System.out.printf("\t%-" + offset + "s%10d%10d%n", entry.get("string").toString(), entry.get("count"), entry.get("error"));
+                    probe.getOutput().printf("\t%-" + offset + "s%10d%10d%n", entry.get("string").toString(), entry.get("count"), entry.get("error"));
             }
             first = false;
         }

--- a/src/java/org/apache/cassandra/tools/nodetool/TpStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/TpStats.java
@@ -32,14 +32,14 @@ public class TpStats extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.printf("%-25s%10s%10s%15s%10s%18s%n", "Pool Name", "Active", "Pending", "Completed", "Blocked", "All time blocked");
+        probe.getOutput().printf("%-25s%10s%10s%15s%10s%18s%n", "Pool Name", "Active", "Pending", "Completed", "Blocked", "All time blocked");
 
         Multimap<String, String> threadPools = probe.getThreadPools();
 
         for (Map.Entry<String, String> tpool : threadPools.entries())
         {
-            System.out.printf("%-25s%10s%10s%15s%10s%18s%n",
-                              tpool.getValue(),
+            probe.getOutput().printf("%-25s%10s%10s%15s%10s%18s%n",
+                    tpool.getValue(),
                               probe.getThreadPoolMetric(tpool.getKey(), tpool.getValue(), "ActiveTasks"),
                               probe.getThreadPoolMetric(tpool.getKey(), tpool.getValue(), "PendingTasks"),
                               probe.getThreadPoolMetric(tpool.getKey(), tpool.getValue(), "CompletedTasks"),
@@ -47,8 +47,8 @@ public class TpStats extends NodeToolCmd
                               probe.getThreadPoolMetric(tpool.getKey(), tpool.getValue(), "TotalBlockedTasks"));
         }
 
-        System.out.printf("%n%-20s%10s%n", "Message type", "Dropped");
+        probe.getOutput().printf("%n%-20s%10s%n", "Message type", "Dropped");
         for (Map.Entry<String, Integer> entry : probe.getDroppedMessages().entrySet())
-            System.out.printf("%-20s%10s%n", entry.getKey(), entry.getValue());
+            probe.getOutput().printf("%-20s%10s%n", entry.getKey(), entry.getValue());
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/TpStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/TpStats.java
@@ -32,13 +32,13 @@ public class TpStats extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().printf("%-25s%10s%10s%15s%10s%18s%n", "Pool Name", "Active", "Pending", "Completed", "Blocked", "All time blocked");
+        probe.output().out.printf("%-25s%10s%10s%15s%10s%18s%n", "Pool Name", "Active", "Pending", "Completed", "Blocked", "All time blocked");
 
         Multimap<String, String> threadPools = probe.getThreadPools();
 
         for (Map.Entry<String, String> tpool : threadPools.entries())
         {
-            probe.getOutput().printf("%-25s%10s%10s%15s%10s%18s%n",
+            probe.output().out.printf("%-25s%10s%10s%15s%10s%18s%n",
                     tpool.getValue(),
                               probe.getThreadPoolMetric(tpool.getKey(), tpool.getValue(), "ActiveTasks"),
                               probe.getThreadPoolMetric(tpool.getKey(), tpool.getValue(), "PendingTasks"),
@@ -47,8 +47,8 @@ public class TpStats extends NodeToolCmd
                               probe.getThreadPoolMetric(tpool.getKey(), tpool.getValue(), "TotalBlockedTasks"));
         }
 
-        probe.getOutput().printf("%n%-20s%10s%n", "Message type", "Dropped");
+        probe.output().out.printf("%n%-20s%10s%n", "Message type", "Dropped");
         for (Map.Entry<String, Integer> entry : probe.getDroppedMessages().entrySet())
-            probe.getOutput().printf("%-20s%10s%n", entry.getKey(), entry.getValue());
+            probe.output().out.printf("%-20s%10s%n", entry.getKey(), entry.getValue());
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/UpgradeSSTable.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/UpgradeSSTable.java
@@ -51,7 +51,7 @@ public class UpgradeSSTable extends NodeToolCmd
         {
             try
             {
-                probe.upgradeSSTables(probe.getOutput(), keyspace, !includeAll, jobs, cfnames);
+                probe.upgradeSSTables(probe.output().out, keyspace, !includeAll, jobs, cfnames);
             } catch (Exception e)
             {
                 throw new RuntimeException("Error occurred during enabling auto-compaction", e);

--- a/src/java/org/apache/cassandra/tools/nodetool/UpgradeSSTable.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/UpgradeSSTable.java
@@ -51,7 +51,7 @@ public class UpgradeSSTable extends NodeToolCmd
         {
             try
             {
-                probe.upgradeSSTables(System.out, keyspace, !includeAll, jobs, cfnames);
+                probe.upgradeSSTables(probe.getOutput(), keyspace, !includeAll, jobs, cfnames);
             } catch (Exception e)
             {
                 throw new RuntimeException("Error occurred during enabling auto-compaction", e);

--- a/src/java/org/apache/cassandra/tools/nodetool/Verify.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Verify.java
@@ -48,7 +48,7 @@ public class Verify extends NodeToolCmd
         {
             try
             {
-                probe.verify(System.out, extendedVerify, keyspace, cfnames);
+                probe.verify(probe.getOutput(), extendedVerify, keyspace, cfnames);
             } catch (Exception e)
             {
                 throw new RuntimeException("Error occurred during verifying", e);

--- a/src/java/org/apache/cassandra/tools/nodetool/Verify.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Verify.java
@@ -48,7 +48,7 @@ public class Verify extends NodeToolCmd
         {
             try
             {
-                probe.verify(probe.getOutput(), extendedVerify, keyspace, cfnames);
+                probe.verify(probe.output().out, extendedVerify, keyspace, cfnames);
             } catch (Exception e)
             {
                 throw new RuntimeException("Error occurred during verifying", e);

--- a/src/java/org/apache/cassandra/tools/nodetool/Version.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Version.java
@@ -28,6 +28,6 @@ public class Version extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println("ReleaseVersion: " + probe.getReleaseVersion());
+        probe.getOutput().println("ReleaseVersion: " + probe.getReleaseVersion());
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/Version.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Version.java
@@ -28,6 +28,6 @@ public class Version extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.getOutput().println("ReleaseVersion: " + probe.getReleaseVersion());
+        probe.output().out.println("ReleaseVersion: " + probe.getReleaseVersion());
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -95,6 +95,7 @@ import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.service.StorageServiceMBean;
 import org.apache.cassandra.streaming.StreamCoordinator;
 import org.apache.cassandra.tools.NodeTool;
+import org.apache.cassandra.tools.Output;
 import org.apache.cassandra.tracing.TraceState;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.transport.messages.ResultMessage;
@@ -716,7 +717,7 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
     public NodeToolResult nodetoolResult(boolean withNotifications, String... commandAndArgs)
     {
         return sync(() -> {
-            DTestNodeTool nodetool = new DTestNodeTool(withNotifications);
+            DTestNodeTool nodetool = new DTestNodeTool(withNotifications, Output.CONSOLE);
             int rc =  nodetool.execute(commandAndArgs);
             return new NodeToolResult(commandAndArgs, rc, new ArrayList<>(nodetool.notifications.notifications), nodetool.latestError);
         }).call();
@@ -728,8 +729,8 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
 
         private Throwable latestError;
 
-        DTestNodeTool(boolean withNotifications) {
-            super(new InternalNodeProbeFactory(withNotifications));
+        DTestNodeTool(boolean withNotifications, Output output) {
+            super(new InternalNodeProbeFactory(withNotifications), output);
             storageProxy = new InternalNodeProbe(withNotifications).getStorageService();
             storageProxy.addNotificationListener(notifications, null, null);
         }


### PR DESCRIPTION
So that it can be reliably redirected for nodetool commands to a different buffer, without intercepting any unwanted logs

Backport of https://github.com/apache/cassandra/commit/83e1e9e45193322f18f57aa7cc4ad31d9d5a152d