### PR TITLE
Expose Actual Tombstone Counts as Metric

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -3429,7 +3429,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
         return getDroppableTombstoneCount(getSSTables(), useGcGrace);
     }
 
-    private double getDroppableTombstoneCount(Collection<SSTableReader> sstables, boolean useGcGrace) {
+    private double getDroppableTombstoneCount(Collection<SSTableReader> sstables, boolean useGcGrace)
+    {
         double allDroppable = 0;
         int localTime = (int) (System.currentTimeMillis() / 1000);
 

--- a/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
@@ -168,6 +168,12 @@ public class ColumnFamilyMetrics
     public final Gauge<Double> liveTombstoneRatio;
     /** Estimated ratio of tombstones and number of cells in this table */
     public final Gauge<Double> tombstoneRatio;
+    /** Estimated count of droppable tombstones and number of cells in this table */
+    public final Gauge<Double> droppableTombstoneCount;
+    /** Estimated count of live tombstones and number of cells in this table */
+    public final Gauge<Double> liveTombstoneCount;
+    /** Estimated count of tombstones and number of cells in this table */
+    public final Gauge<Double> tombstoneCount;
 
     /** Bytes read on range scans **/
     public final Meter rangeScanBytesRead;
@@ -735,6 +741,27 @@ public class ColumnFamilyMetrics
             public Double getValue()
             {
                 return cfs.getTombstoneRatio();
+            }
+        });
+        droppableTombstoneCount = createColumnFamilyGauge("DroppableTombstoneCount", new Gauge<Double>()
+        {
+            public Double getValue()
+            {
+                return cfs.getDroppableTombstoneCount();
+            }
+        });
+        liveTombstoneCount = createColumnFamilyGauge("LiveTombstoneCount", new Gauge<Double>()
+        {
+            public Double getValue()
+            {
+                return cfs.getLiveTombstoneCount();
+            }
+        });
+        tombstoneCount = createColumnFamilyGauge("TombstoneCount", new Gauge<Double>()
+        {
+            public Double getValue()
+            {
+                return cfs.getTombstoneCount();
             }
         });
 

--- a/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
@@ -722,48 +722,12 @@ public class ColumnFamilyMetrics
         casPropose = new LatencyMetrics(factory, "CasPropose", cfs.keyspace.metric.casPropose);
         casCommit = new LatencyMetrics(factory, "CasCommit", cfs.keyspace.metric.casCommit);
 
-        droppableTombstoneRatio = createColumnFamilyGauge("DroppableTombstoneRatio", new Gauge<Double>()
-        {
-            public Double getValue()
-            {
-                return cfs.getDroppableTombstoneRatio();
-            }
-        });
-        liveTombstoneRatio = createColumnFamilyGauge("LiveTombstoneRatio", new Gauge<Double>()
-        {
-            public Double getValue()
-            {
-                return cfs.getLiveTombstoneRatio();
-            }
-        });
-        tombstoneRatio = createColumnFamilyGauge("TombstoneRatio", new Gauge<Double>()
-        {
-            public Double getValue()
-            {
-                return cfs.getTombstoneRatio();
-            }
-        });
-        droppableTombstoneCount = createColumnFamilyGauge("DroppableTombstoneCount", new Gauge<Double>()
-        {
-            public Double getValue()
-            {
-                return cfs.getDroppableTombstoneCount();
-            }
-        });
-        liveTombstoneCount = createColumnFamilyGauge("LiveTombstoneCount", new Gauge<Double>()
-        {
-            public Double getValue()
-            {
-                return cfs.getLiveTombstoneCount();
-            }
-        });
-        tombstoneCount = createColumnFamilyGauge("TombstoneCount", new Gauge<Double>()
-        {
-            public Double getValue()
-            {
-                return cfs.getTombstoneCount();
-            }
-        });
+        droppableTombstoneRatio = createColumnFamilyGauge("DroppableTombstoneRatio", cfs::getDroppableTombstoneRatio);
+        liveTombstoneRatio = createColumnFamilyGauge("LiveTombstoneRatio", cfs::getLiveTombstoneRatio);
+        tombstoneRatio = createColumnFamilyGauge("TombstoneRatio", cfs::getTombstoneRatio);
+        droppableTombstoneCount = createColumnFamilyGauge("DroppableTombstoneCount", cfs::getDroppableTombstoneCount);
+        liveTombstoneCount = createColumnFamilyGauge("LiveTombstoneCount", cfs::getLiveTombstoneCount);
+        tombstoneCount = createColumnFamilyGauge("TombstoneCount", cfs::getTombstoneCount);
 
         rangeScanBytesRead = Metrics.meter(factory.createMetricName("RangeScanBytesRead"));
         readBytesRead = Metrics.meter(factory.createMetricName("ReadBytesRead"));


### PR DESCRIPTION
We typically look at the read droppable tombstones metric to evaluate performance and compaction progress. This PR exposes Cassandra's internal estimate of droppable tombstones, regardless if they are being scanned. This is helpful for making sure compactions are keeping up as expected.