### PR TITLE
Expose CF Validation Hook and re-enable full ancestor cleanup

### DIFF
--- a/src/java/com/palantir/cassandra/db/ColumnFamilyStoreManager.java
+++ b/src/java/com/palantir/cassandra/db/ColumnFamilyStoreManager.java
@@ -33,7 +33,8 @@ public class ColumnFamilyStoreManager implements IColumnFamilyStoreValidator
     public static final ColumnFamilyStoreManager instance = new ColumnFamilyStoreManager();
     private final List<IColumnFamilyStoreValidator> validators;
 
-    private ColumnFamilyStoreManager() {
+    private ColumnFamilyStoreManager()
+    {
         this.validators = new CopyOnWriteArrayList<>();
     }
 

--- a/src/java/com/palantir/cassandra/db/ColumnFamilyStoreManager.java
+++ b/src/java/com/palantir/cassandra/db/ColumnFamilyStoreManager.java
@@ -43,7 +43,7 @@ public class ColumnFamilyStoreManager implements IColumnFamilyStoreValidator
         validators.add(validator);
     }
 
-    public void deregisterValidator(IColumnFamilyStoreValidator validator)
+    public void unregisterValidator(IColumnFamilyStoreValidator validator)
     {
         validators.remove(validator);
     }

--- a/src/java/com/palantir/cassandra/db/ColumnFamilyStoreManager.java
+++ b/src/java/com/palantir/cassandra/db/ColumnFamilyStoreManager.java
@@ -43,6 +43,11 @@ public class ColumnFamilyStoreManager implements IColumnFamilyStoreValidator
         validators.add(validator);
     }
 
+    public void deregisterValidator(IColumnFamilyStoreValidator validator)
+    {
+        validators.remove(validator);
+    }
+
     public Map<Descriptor, Set<Integer>> filterValidAncestors(CFMetaData cfMetaData, Map<Descriptor, Set<Integer>> sstableToCompletedAncestors, Map<Integer, UUID> unfinishedCompactions)
     {
         Map<Descriptor, Set<Integer>> filtered = sstableToCompletedAncestors;

--- a/src/java/com/palantir/cassandra/db/ColumnFamilyStoreManager.java
+++ b/src/java/com/palantir/cassandra/db/ColumnFamilyStoreManager.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.db;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.io.sstable.Descriptor;
+
+
+public class ColumnFamilyStoreManager implements IColumnFamilyStoreValidator
+{
+    public static final ColumnFamilyStoreManager instance = new ColumnFamilyStoreManager();
+    private final List<IColumnFamilyStoreValidator> validators;
+
+    private ColumnFamilyStoreManager() {
+        this.validators = new CopyOnWriteArrayList<>();
+    }
+
+    public void registerValidator(IColumnFamilyStoreValidator validator)
+    {
+        validators.add(validator);
+    }
+
+    public Map<Descriptor, Set<Integer>> filterValidAncestors(CFMetaData cfMetaData, Map<Descriptor, Set<Integer>> sstableToCompletedAncestors, Map<Integer, UUID> unfinishedCompactions)
+    {
+        Map<Descriptor, Set<Integer>> filtered = sstableToCompletedAncestors;
+        for (IColumnFamilyStoreValidator validator : validators)
+        {
+            filtered = validator.filterValidAncestors(cfMetaData, filtered, unfinishedCompactions);
+        }
+        return filtered;
+    }
+}

--- a/src/java/com/palantir/cassandra/db/IColumnFamilyStoreValidator.java
+++ b/src/java/com/palantir/cassandra/db/IColumnFamilyStoreValidator.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.db;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.io.sstable.Descriptor;
+
+public interface IColumnFamilyStoreValidator
+{
+    /**
+     * Depending on the operations which have taken place on this node, some sstables may point to others as ancestors
+     * from which they are not actually derived.
+     */
+    Map<Descriptor, Set<Integer>> filterValidAncestors(CFMetaData cfMetaData,
+                   Map<Descriptor, Set<Integer>> sstableToCompletedAncestors, Map<Integer, UUID> unfinishedCompactions);
+}

--- a/src/java/com/palantir/cassandra/db/IColumnFamilyStoreValidator.java
+++ b/src/java/com/palantir/cassandra/db/IColumnFamilyStoreValidator.java
@@ -32,5 +32,5 @@ public interface IColumnFamilyStoreValidator
      * from which they are not actually derived.
      */
     Map<Descriptor, Set<Integer>> filterValidAncestors(CFMetaData cfMetaData,
-                   Map<Descriptor, Set<Integer>> sstableToCompletedAncestors, Map<Integer, UUID> unfinishedCompactions);
+                                                       Map<Descriptor, Set<Integer>> sstableToCompletedAncestors, Map<Integer, UUID> unfinishedCompactions);
 }

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -836,7 +836,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
     {
         if (assumeCfIsEmpty)
         {
-            throw new UnsupportedOperationException("Loading new SSTables is not supported on this version");
+            throw new UnsupportedOperationException("Loading new SSTables is not supported on version 2.2.18-1.164.0+.");
         }
         logger.info("Loading new SSTables for {}/{}{}...",
                 keyspace.getName(), name,

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -725,10 +725,12 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
         }
 
         allSstableToAncestors = ColumnFamilyStoreManager.instance.filterValidAncestors(metadata, allSstableToAncestors, unfinishedCompactions);
-        SafeArg<Map<Integer, Set<Integer>>> ancestorsArg = SafeArg.of("sstableToAncestors",
-                                             allSstableToAncestors.entrySet().stream()
-                                                                  .collect(Collectors.toMap(e -> e.getKey().generation,
-                                                                                            Map.Entry::getValue)));
+        SafeArg<Map<Integer, Set<Integer>>> ancestorsArg = SafeArg.of(
+        "sstableToAncestors",
+        allSstableToAncestors.entrySet().stream()
+                             .collect(Collectors.toMap(
+                             (Map.Entry<Descriptor, Set<Integer>> e) -> e.getKey().generation,
+                             Map.Entry::getValue)));
 
         Set<UUID> cleanedUnfinishedCompactions = new HashSet<>();
         for (Map.Entry<Descriptor, Set<Integer>> sstableToAncestors : allSstableToAncestors.entrySet())

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -726,11 +726,11 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
 
         allSstableToAncestors = ColumnFamilyStoreManager.instance.filterValidAncestors(metadata, allSstableToAncestors, unfinishedCompactions);
         SafeArg<Map<Integer, Set<Integer>>> ancestorsArg = SafeArg.of(
-        "sstableToAncestors",
-        allSstableToAncestors.entrySet().stream()
-                             .collect(Collectors.toMap(
-                             (Map.Entry<Descriptor, Set<Integer>> e) -> e.getKey().generation,
-                             Map.Entry::getValue)));
+            "sstableToAncestors",
+            allSstableToAncestors.entrySet().stream()
+                 .collect(Collectors.toMap(
+                         (Map.Entry<Descriptor, Set<Integer>> e) -> e.getKey().generation,
+                         Map.Entry::getValue)));
 
         Set<UUID> cleanedUnfinishedCompactions = new HashSet<>();
         for (Map.Entry<Descriptor, Set<Integer>> sstableToAncestors : allSstableToAncestors.entrySet())

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -860,7 +860,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
     {
         if (assumeCfIsEmpty)
         {
-            throw new UnsupportedOperationException("Loading new SSTables is not supported on version 2.2.18-1.164.0+.");
+            throw new UnsupportedOperationException("Loading new SSTables is not supported on version 2.2.18-1.165.0+.");
         }
         logger.info("Loading new SSTables for {}/{}{}...",
                 keyspace.getName(), name,

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -721,7 +721,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
         for (Map.Entry<Descriptor, Set<Component>> sstableFiles : directories.sstableLister().skipTemporary(true).list().entrySet())
         {
             Descriptor desc = sstableFiles.getKey();
-            if (!sstableToAncestors.containsKey(desc)) {
+            if (!sstableToAncestors.containsKey(desc))
+            {
                 continue;
             }
 
@@ -835,7 +836,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
 
     public synchronized int loadNewSSTablesWithCount(boolean assumeCfIsEmpty)
     {
-        if (assumeCfIsEmpty) {
+        if (assumeCfIsEmpty)
+        {
             throw new UnsupportedOperationException("Loading new SSTables is not supported on this version");
         }
         logger.info("Loading new SSTables for {}/{}{}...",

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -669,7 +669,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
      * compactions, we remove the new ones (since those may be incomplete -- under LCS, we may create multiple
      * sstables from any given ancestor).
      */
-    public static void removeUnfinishedCompactionLeftovers(CFMetaData metadata, Map<Integer, UUID> unfinishedCompactions)
+    public static void removeUnusedSstables(CFMetaData metadata, Map<Integer, UUID> unfinishedCompactions)
     {
         Directories directories = new Directories(metadata);
         Set<Integer> allGenerations = new HashSet<>();

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -775,9 +775,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
                                 SafeArg.of("keyspace", desc.ksname), SafeArg.of("cf", desc.cfname),
                                 SafeArg.of("generation", desc.generation), ancestorsArg);
                     SSTable.delete(desc, sstableFiles.getValue());
-                    UUID compactionTaskID = unfinishedCompactions.get(desc.generation);
-                    if (compactionTaskID != null)
-                        SystemKeyspace.finishCompaction(unfinishedCompactions.get(desc.generation));
+                    Optional.ofNullable(unfinishedCompactions.get(desc.generation))
+                            .ifPresent(SystemKeyspace::finishCompaction);
                 }
             }
         }

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -820,6 +820,9 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
 
     public synchronized int loadNewSSTablesWithCount(boolean assumeCfIsEmpty)
     {
+        if (assumeCfIsEmpty) {
+            throw new UnsupportedOperationException("Loading new SSTables is not supported on this version");
+        }
         logger.info("Loading new SSTables for {}/{}{}...",
                 keyspace.getName(), name,
                 assumeCfIsEmpty ? " assuming the columnfamily is empty" : "");

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -719,6 +719,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
 
         allSstableToAncestors = ColumnFamilyStoreManager.instance.filterValidAncestors(metadata, allSstableToAncestors, unfinishedCompactions);
 
+        Set<UUID> cleanedUnfinishedCompactions = new HashSet<>();
         for (Map.Entry<Descriptor, Set<Integer>> sstableToAncestors : allSstableToAncestors.entrySet())
         {
             Descriptor desc = sstableToAncestors.getKey();
@@ -732,13 +733,14 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
                 assert compactionTaskID != null;
                 logger.info("Going to delete unfinished compaction product {}", desc);
                 SSTable.delete(desc, allNonTempSstableFiles.get(desc));
-                SystemKeyspace.finishCompaction(compactionTaskID);
+                cleanedUnfinishedCompactions.add(compactionTaskID);
             }
             else
             {
                 completedAncestors.addAll(ancestors);
             }
         }
+        cleanedUnfinishedCompactions.forEach(SystemKeyspace::finishCompaction);
 
         // remove old sstables from compactions that did complete
         for (Map.Entry<Descriptor, Set<Component>> sstableFiles : directories.sstableLister().list().entrySet())

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -279,6 +279,11 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
         }
     }
 
+    @VisibleForTesting
+    public void insertWriterTestingOnly(int index, SSTableWriter newWriter) {
+        writers.add(index, newWriter);
+    }
+
     public void switchWriter(SSTableWriter newWriter)
     {
         if (newWriter != null)

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -1696,7 +1696,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         {
             if (logger.isDebugEnabled())
             {
-                logger.debug("Marking sstable compacted and obsolete",
+                logger.debug("Marking sstable compacted and obsolete: {}.{} generation {}",
                              SafeArg.of("keyspace", descriptor.ksname),
                              SafeArg.of("cf", descriptor.cfname),
                              SafeArg.of("generation", descriptor.generation));

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -1694,13 +1694,10 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         }
         if (!tidy.global.isCompacted.getAndSet(true))
         {
-            if (logger.isDebugEnabled())
-            {
-                logger.debug("Marking sstable compacted and obsolete: {}.{} generation {}",
-                             SafeArg.of("keyspace", descriptor.ksname),
-                             SafeArg.of("cf", descriptor.cfname),
-                             SafeArg.of("generation", descriptor.generation));
-            }
+            logger.info("Marking sstable compacted and obsolete: {}.{} generation {}",
+                         SafeArg.of("keyspace", descriptor.ksname),
+                         SafeArg.of("cf", descriptor.cfname),
+                         SafeArg.of("generation", descriptor.generation));
             tidy.type.markObsolete(this, tracker);
             return true;
         }

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -36,6 +36,7 @@ import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
 import com.clearspring.analytics.stream.cardinality.ICardinality;
 import com.codahale.metrics.Counter;
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.cache.CachingOptions;
 import org.apache.cassandra.cache.InstrumentingCache;
 import org.apache.cassandra.cache.KeyCacheKey;
@@ -1693,6 +1694,13 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         }
         if (!tidy.global.isCompacted.getAndSet(true))
         {
+            if (logger.isDebugEnabled())
+            {
+                logger.debug("Marking sstable compacted and obsolete",
+                             SafeArg.of("keyspace", descriptor.ksname),
+                             SafeArg.of("cf", descriptor.cfname),
+                             SafeArg.of("generation", descriptor.generation));
+            }
             tidy.type.markObsolete(this, tracker);
             return true;
         }

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -54,6 +54,7 @@ import com.codahale.metrics.jvm.FileDescriptorRatioGauge;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -259,27 +260,21 @@ public class CassandraDaemon
         // load schema from disk
         Schema.instance.loadFromDisk();
 
-        // clean up compaction leftovers
         Map<Pair<String, String>, Map<Integer, UUID>> unfinishedCompactions = SystemKeyspace.getUnfinishedCompactions();
-        for (Pair<String, String> kscf : unfinishedCompactions.keySet())
-        {
-            CFMetaData cfm = Schema.instance.getCFMetaData(kscf.left, kscf.right);
-            // CFMetaData can be null if CF is already dropped
-            if (cfm != null)
-                ColumnFamilyStore.removeUnfinishedCompactionLeftovers(cfm, unfinishedCompactions.get(kscf));
-        }
-        SystemKeyspace.discardCompactionsInProgress();
-
         // clean up debris in the rest of the keyspaces
         for (String keyspaceName : Schema.instance.getKeyspaces())
         {
-            // Skip system as we've already cleaned it
+            // Skip system as we'll already clean it after the other tables
             if (keyspaceName.equals(SystemKeyspace.NAME))
                 continue;
 
             for (CFMetaData cfm : Schema.instance.getKeyspaceMetaData(keyspaceName).values())
+            {
+                ColumnFamilyStore.removeUnfinishedCompactionLeftovers(cfm, unfinishedCompactions.getOrDefault(cfm.ksAndCFName, ImmutableMap.of()));
                 ColumnFamilyStore.scrubDataDirectories(cfm);
+            }
         }
+        SystemKeyspace.discardCompactionsInProgress();
 
         Keyspace.setInitialized();
 

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -270,7 +270,7 @@ public class CassandraDaemon
 
             for (CFMetaData cfm : Schema.instance.getKeyspaceMetaData(keyspaceName).values())
             {
-                ColumnFamilyStore.removeUnfinishedCompactionLeftovers(cfm, unfinishedCompactions.getOrDefault(cfm.ksAndCFName, ImmutableMap.of()));
+                ColumnFamilyStore.removeUnusedSstables(cfm, unfinishedCompactions.getOrDefault(cfm.ksAndCFName, ImmutableMap.of()));
                 ColumnFamilyStore.scrubDataDirectories(cfm);
             }
         }

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -261,7 +261,6 @@ public class CassandraDaemon
         Schema.instance.loadFromDisk();
 
         Map<Pair<String, String>, Map<Integer, UUID>> unfinishedCompactions = SystemKeyspace.getUnfinishedCompactions();
-        // clean up debris in the rest of the keyspaces
         for (String keyspaceName : Schema.instance.getKeyspaces())
         {
             // Skip system as we'll already clean it after the other tables

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5046,7 +5046,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public void loadNewSSTables(String ksName, String cfName)
     {
         //ColumnFamilyStore.loadNewSSTables(ksName, cfName, false);
-        throw new UnsupportedOperationException("Cannot load SSTables on version 2.2.18-1.164.0+.");
+        throw new UnsupportedOperationException("Cannot load SSTables on version 2.2.18-1.165.0+.");
     }
 
     /**
@@ -5055,7 +5055,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public void loadNewSSTables(String ksName, String cfName, boolean assumeCfIsEmpty)
     {
         //ColumnFamilyStore.loadNewSSTables(ksName, cfName, assumeCfIsEmpty);
-        throw new UnsupportedOperationException("Cannot load SSTables on version 2.2.18-1.164.0+.");
+        throw new UnsupportedOperationException("Cannot load SSTables on version 2.2.18-1.165.0+.");
     }
 
     /**
@@ -5064,7 +5064,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public int loadNewSSTablesWithCount(String ksName, String cfName)
     {
         //return ColumnFamilyStore.loadNewSSTablesWithCount(ksName, cfName, false);
-        throw new UnsupportedOperationException("Cannot load SSTables on version 2.2.18-1.164.0+.");
+        throw new UnsupportedOperationException("Cannot load SSTables on version 2.2.18-1.165.0+.");
     }
 
     /**
@@ -5073,7 +5073,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public int loadNewSSTablesWithCount(String ksName, String cfName, boolean assumeCfIsEmpty)
     {
         //return ColumnFamilyStore.loadNewSSTablesWithCount(ksName, cfName, assumeCfIsEmpty);
-        throw new UnsupportedOperationException("Cannot load SSTables on version 2.2.18-1.164.0+.");
+        throw new UnsupportedOperationException("Cannot load SSTables on version 2.2.18-1.165.0+.");
     }
 
     /**

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5046,7 +5046,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public void loadNewSSTables(String ksName, String cfName)
     {
         //ColumnFamilyStore.loadNewSSTables(ksName, cfName, false);
-        throw new UnsupportedOperationException("Cannot load SSTables on this version.");
+        throw new UnsupportedOperationException("Cannot load SSTables on version 2.2.18-1.164.0+.");
     }
 
     /**
@@ -5055,7 +5055,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public void loadNewSSTables(String ksName, String cfName, boolean assumeCfIsEmpty)
     {
         //ColumnFamilyStore.loadNewSSTables(ksName, cfName, assumeCfIsEmpty);
-        throw new UnsupportedOperationException("Cannot load SSTables on this version.");
+        throw new UnsupportedOperationException("Cannot load SSTables on version 2.2.18-1.164.0+.");
     }
 
     /**
@@ -5064,7 +5064,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public int loadNewSSTablesWithCount(String ksName, String cfName)
     {
         //return ColumnFamilyStore.loadNewSSTablesWithCount(ksName, cfName, false);
-        throw new UnsupportedOperationException("Cannot load SSTables on this version.");
+        throw new UnsupportedOperationException("Cannot load SSTables on version 2.2.18-1.164.0+.");
     }
 
     /**
@@ -5073,7 +5073,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public int loadNewSSTablesWithCount(String ksName, String cfName, boolean assumeCfIsEmpty)
     {
         //return ColumnFamilyStore.loadNewSSTablesWithCount(ksName, cfName, assumeCfIsEmpty);
-        throw new UnsupportedOperationException("Cannot load SSTables on this version.");
+        throw new UnsupportedOperationException("Cannot load SSTables on version 2.2.18-1.164.0+.");
     }
 
     /**

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5045,7 +5045,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
      */
     public void loadNewSSTables(String ksName, String cfName)
     {
-        ColumnFamilyStore.loadNewSSTables(ksName, cfName, false);
+        //ColumnFamilyStore.loadNewSSTables(ksName, cfName, false);
+        throw new UnsupportedOperationException("Cannot load SSTables on this version.");
     }
 
     /**
@@ -5053,7 +5054,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
      */
     public void loadNewSSTables(String ksName, String cfName, boolean assumeCfIsEmpty)
     {
-        ColumnFamilyStore.loadNewSSTables(ksName, cfName, assumeCfIsEmpty);
+        //ColumnFamilyStore.loadNewSSTables(ksName, cfName, assumeCfIsEmpty);
+        throw new UnsupportedOperationException("Cannot load SSTables on this version.");
     }
 
     /**
@@ -5061,7 +5063,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
      */
     public int loadNewSSTablesWithCount(String ksName, String cfName)
     {
-        return ColumnFamilyStore.loadNewSSTablesWithCount(ksName, cfName, false);
+        //return ColumnFamilyStore.loadNewSSTablesWithCount(ksName, cfName, false);
+        throw new UnsupportedOperationException("Cannot load SSTables on this version.");
     }
 
     /**
@@ -5069,7 +5072,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
      */
     public int loadNewSSTablesWithCount(String ksName, String cfName, boolean assumeCfIsEmpty)
     {
-        return ColumnFamilyStore.loadNewSSTablesWithCount(ksName, cfName, assumeCfIsEmpty);
+        //return ColumnFamilyStore.loadNewSSTablesWithCount(ksName, cfName, assumeCfIsEmpty);
+        throw new UnsupportedOperationException("Cannot load SSTables on this version.");
     }
 
     /**

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
@@ -1836,7 +1836,7 @@ public class ColumnFamilyStoreTest
     }
 
     @Test
-    public void testRemoveUnfinishedCompactionLeftovers() throws Throwable
+    public void testRemoveUnusedSstables() throws Throwable
     {
         String ks = KEYSPACE1;
         String cf = CF_STANDARD3; // should be empty
@@ -1888,7 +1888,7 @@ public class ColumnFamilyStoreTest
 
         Map<Integer, UUID> unfinishedCompaction = new HashMap<>();
         unfinishedCompaction.put(sstable1.descriptor.generation, compactionTaskID);
-        ColumnFamilyStore.removeUnfinishedCompactionLeftovers(cfmeta, unfinishedCompaction);
+        ColumnFamilyStore.removeUnusedSstables(cfmeta, unfinishedCompaction);
 
         // 2nd sstable should be removed (only 1st sstable exists in set of size 1)
         sstables = dir.sstableLister().list();
@@ -1905,7 +1905,7 @@ public class ColumnFamilyStoreTest
      * @see <a href="https://issues.apache.org/jira/browse/CASSANDRA-6086">CASSANDRA-6086</a>
      */
     @Test
-    public void testFailedToRemoveUnfinishedCompactionLeftovers() throws Throwable
+    public void testFailedToRemoveUnusedSstables() throws Throwable
     {
         final String ks = KEYSPACE1;
         final String cf = CF_STANDARD4; // should be empty
@@ -1948,7 +1948,7 @@ public class ColumnFamilyStoreTest
         UUID compactionTaskID = UUID.randomUUID();
         for (Integer ancestor : ancestors)
             unfinishedCompactions.put(ancestor, compactionTaskID);
-        ColumnFamilyStore.removeUnfinishedCompactionLeftovers(cfmeta, unfinishedCompactions);
+        ColumnFamilyStore.removeUnusedSstables(cfmeta, unfinishedCompactions);
 
         // SSTable should not be deleted
         sstables = dir.sstableLister().list();
@@ -1957,7 +1957,7 @@ public class ColumnFamilyStoreTest
     }
 
     @Test
-    public void testRemoveUnfinishedCompactionLeftoversOnlyRemovesFiltered() throws IOException
+    public void testRemoveUnusedSstablesOnlyRemovesFiltered() throws IOException
     {
         final String ks = KEYSPACE1;
         final String cf = CF_STANDARD7;
@@ -1986,7 +1986,7 @@ public class ColumnFamilyStoreTest
 
         try {
             ColumnFamilyStoreManager.instance.registerValidator(validator);
-            ColumnFamilyStore.removeUnfinishedCompactionLeftovers(cfmeta, ImmutableMap.of());
+            ColumnFamilyStore.removeUnusedSstables(cfmeta, ImmutableMap.of());
         }
         finally
         {

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
@@ -1990,7 +1990,7 @@ public class ColumnFamilyStoreTest
         }
         finally
         {
-            ColumnFamilyStoreManager.instance.deregisterValidator(validator);
+            ColumnFamilyStoreManager.instance.unregisterValidator(validator);
         }
 
         sstables = dir.sstableLister().list();

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -33,6 +33,7 @@ import junit.framework.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -421,6 +422,7 @@ public class LeveledCompactionStrategyTest
     }
 
     @Test
+    @Ignore
     public void testLevelSettingOnLoadNewSSTables() throws InterruptedException
     {
         byte [] b = new byte[100 * 1024];


### PR DESCRIPTION
Re-enables https://github.com/palantir/cassandra/pull/523 with configurable ancestor filtering

This also fixes a couple of other preexisting bugs related to compaction scheduling and cleanup