### PR TITLE
Handle failed abort from in-progress compaction

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -719,7 +719,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
 
         allSstableToAncestors = ColumnFamilyStoreManager.instance.filterValidAncestors(metadata, allSstableToAncestors, unfinishedCompactions);
 
-        Set<UUID> cleanedCompactions = new HashSet<>();
+        Set<UUID> cleanedUnfinishedCompactions = new HashSet<>();
         for (Map.Entry<Descriptor, Set<Integer>> sstableToAncestors : allSstableToAncestors.entrySet())
         {
             Descriptor desc = sstableToAncestors.getKey();
@@ -733,14 +733,14 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
                 assert compactionTaskID != null;
                 logger.info("Going to delete unfinished compaction product {}", desc);
                 SSTable.delete(desc, allNonTempSstableFiles.get(desc));
-                cleanedCompactions.add(compactionTaskID);
+                cleanedUnfinishedCompactions.add(compactionTaskID);
             }
             else
             {
                 completedAncestors.addAll(ancestors);
             }
         }
-        cleanedCompactions.forEach(SystemKeyspace::finishCompaction);
+        cleanedUnfinishedCompactions.forEach(SystemKeyspace::finishCompaction);
 
         // remove old sstables from compactions that did complete
         for (Map.Entry<Descriptor, Set<Component>> sstableFiles : directories.sstableLister().list().entrySet())

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -279,6 +279,7 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
         }
     }
 
+    @VisibleForTesting
     public void insertWriterTestingOnly(int index, SSTableWriter newWriter) {
         writers.add(index, newWriter);
     }

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -279,6 +279,10 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
         }
     }
 
+    public void insertWriterTestingOnly(int index, SSTableWriter newWriter) {
+        writers.add(index, newWriter);
+    }
+
     public void switchWriter(SSTableWriter newWriter)
     {
         if (newWriter != null)

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
@@ -578,6 +578,9 @@ public class CompactionsTest
         catch (Throwable e)
         {
             assertNotNull(e);
+            assertTrue(e.getMessage().contains("Exception on compaction task"));
+            assertTrue(e.getCause().getMessage().contains("Exception thrown while some sstables in finish"));
+            assertTrue(e.getCause().getSuppressed()[0].getMessage().contains("Failed to do anything for abort"));
         }
 
         Collection<SSTableReader> sstablesAfter = cfs.getSSTables();
@@ -619,7 +622,6 @@ public class CompactionsTest
 
         @Override
         public void doPrepare() {
-            // figure out how to make this crash in the rewriter
             SSTableWriter writer = mock(SSTableWriter.class);
             doThrow(new SafeRuntimeException("Exception thrown while some sstables in finish, for testing")).when(writer).getFilePointer();
             sstableWriter.insertWriterTestingOnly(2, writer);
@@ -628,7 +630,7 @@ public class CompactionsTest
 
         @Override
         protected Throwable doAbort(Throwable _accumulate) {
-            return new SafeRuntimeException("Failed to do anything");
+            return new SafeRuntimeException("Failed to do anything for abort");
         }
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
@@ -39,7 +39,7 @@ import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.columniterator.IdentityQueryFilter;
 import org.apache.cassandra.db.columniterator.OnDiskAtomIterator;
 import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
-import org.apache.cassandra.db.compaction.writers.MajorLeveledCompactionWriter;
+import org.apache.cassandra.db.compaction.writers.MaxSSTableSizeWriter;
 import org.apache.cassandra.db.filter.QueryFilter;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.marshal.BytesType;
@@ -609,11 +609,12 @@ public class CompactionsTest
         assertEquals(ImmutableSet.of(1, 2, 3), allGenerations);
     }
 
-    private static class FailedAbortCompactionWriter extends MajorLeveledCompactionWriter
+    private static class FailedAbortCompactionWriter extends MaxSSTableSizeWriter
     {
-        public FailedAbortCompactionWriter(ColumnFamilyStore cfs, LifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables, long maxSSTableSize, boolean offline, OperationType compactionType)
+
+        public FailedAbortCompactionWriter(ColumnFamilyStore cfs, LifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables, long maxSSTableSize, int level, boolean offline, OperationType compactionType)
         {
-            super(cfs, txn, nonExpiredSSTables, maxSSTableSize, offline, compactionType);
+            super(cfs, txn, nonExpiredSSTables, maxSSTableSize, level, offline, compactionType);
         }
 
         @Override
@@ -641,7 +642,7 @@ public class CompactionsTest
         @Override
         public CompactionAwareWriter getCompactionAwareWriter(ColumnFamilyStore cfs, LifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables)
         {
-            return new FailedAbortCompactionWriter(cfs, txn, nonExpiredSSTables, 1024 * 1024, false, compactionType);
+            return new FailedAbortCompactionWriter(cfs, txn, nonExpiredSSTables, 1024 * 1024, 0, false, compactionType);
         }
     }
 


### PR DESCRIPTION
If we have a failure while changing sstables from tmp to final during a compaction, this should normally be handled correctly by the Transactional interface.

However, as @inespot noticed if closing the writer also fails, so we do not fully abort all the new sstables, the in-progress compaction entry will still be removed despite the compaction not being fully rolled back.

If you're doing a leveled compaction where you may have multiple product sstables per ancestor, the lack of in-progress compaction log means you'll prefer to delete the ancestors than the product on startup when cleaning unused sstables. This, plus deleting all the tmp sstables, can mean data loss.

Instead if the compaction log is retained if the abort doesn't succeed, on startup the couple non-tmp products will be deleted, all tmp files deleted, and ancestor files retained

Also note that if the process just crashed mid-compaction, this is fine on first startup since we'll still have the record. However you could still hit the case where if you failed mid-startup and cleaned the record, the next startup would have problems.