### PR TITLE
update is_new_cluster error messages

### DIFF
--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -707,7 +707,7 @@ public class DatabaseDescriptor
                     && StorageService.joinRing)
                 {
                     throw new ConfigurationException("is_new_cluster flag is still set to true at least 4 days after cluster creation."
-                        + " Please remove this flag from configuration as it could cause split brain.", false);
+                        + " You must remove this flag from configuration as it could cause SEVERE DATA CORRUPTION.", false);
                 }
             }
             catch (IOException e)

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -1414,8 +1414,10 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                 slept += 1000;
                 if (slept > StorageService.RING_DELAY)
                 {
-                    logger.error("Unable to gossip with any seeds.  If this is the first time that you are starting the cluster," +
-                                 "ensure that `conf.cassandra-env_sh.is_new_cluster` is set to true");
+                    logger.error("Unable to gossip with any seeds. If this is the first time that you are starting" +
+                                 "the cluster ensure that `conf.cassandra-env_sh.is_new_cluster` is set to true. " +
+                                 "If this is NOT a new cluster, or if there are ANY other nodes in this cluster with data, " +
+                                 "setting this option WILL cause SEVERE DATA CORRUPTION.");
                     throw new RuntimeException("Unable to gossip with any seeds");
                 }
             }


### PR DESCRIPTION
We should warn users to not set this option unless they are fully aware of the safety mechanisms they are disabling.