### PR TITLE
writePredictedSpeculativeRetryPerformanceMetrics computes extra replica snapshot once

### DIFF
--- a/src/java/com/palantir/cassandra/utils/RangeTombstoneCountingIterator.java
+++ b/src/java/com/palantir/cassandra/utils/RangeTombstoneCountingIterator.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.Snapshot;
 import org.apache.cassandra.db.ColumnFamily;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DeletionInfo;

--- a/src/java/com/palantir/cassandra/utils/RangeTombstoneCountingIterator.java
+++ b/src/java/com/palantir/cassandra/utils/RangeTombstoneCountingIterator.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.codahale.metrics.Snapshot;
 import org.apache.cassandra.db.ColumnFamily;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DeletionInfo;

--- a/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
+++ b/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
@@ -254,7 +254,7 @@ public class DynamicEndpointSnitch extends AbstractEndpointSnitch implements ILa
     public Optional<Snapshot> getSnapshot(InetAddress endpoint) {
         ExponentiallyDecayingReservoir endpointSamples = samples.get(endpoint);
         if (endpointSamples != null) {
-            return Optional.ofNullable(samples.get(endpoint).getSnapshot());
+            return Optional.ofNullable(endpointSamples.getSnapshot());
         } else {
             return Optional.empty();
         }


### PR DESCRIPTION
While reviewing some JFRs, `AbstractReadExecutor.writePredictedSpeculativeRetryPerformanceMetrics()` and `PredictedSpeculativeRetryPerformanceMetrics.maybeWriteMetrics(ColumnFamilyStore cfs, Collection<Long> latencies, Optional<Snapshot> extraReplicaSnapshot)` pop up with heavy allocations that we can reduce by computing the extra replica snapshot once per `writePredictedSpeculativeRetryPerformanceMetrics` invocation

![image](https://github.com/user-attachments/assets/9df3671f-adaa-479f-999e-49d5b445dabe)
![image](https://github.com/user-attachments/assets/f89c6a86-13bb-44ee-b710-23ab505c2f7d)
![image](https://github.com/user-attachments/assets/b0a7516f-5a0c-480b-8a8e-f42db5312dd9)
