### PR TITLE
Log changes to TokenMetadata

### DIFF
--- a/src/java/com/palantir/cassandra/utils/MapUtils.java
+++ b/src/java/com/palantir/cassandra/utils/MapUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.utils;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.locator.PendingRangeMaps;
+import org.apache.cassandra.utils.BiMultiValMap;
+import org.apache.cassandra.utils.Pair;
+
+
+public final class MapUtils
+{
+    private MapUtils()
+    {
+    }
+
+    /**
+     * For each key in the union of all keys, find their symmetric difference between the versions of the map.
+     * For a given key, {@link Pair#left} are values that exist only in the first map and {@link Pair#right} are values
+     * that exist only in the second map.
+     */
+    public static <U, V> Map<U, Pair<Collection<V>, Collection<V>>> symmetricDifference(Multimap<U, V> v1, Multimap<U, V> v2)
+    {
+        Set<U> keys = Sets.union(v1.keySet(), v2.keySet()).immutableCopy();
+        Map<U, Pair<Collection<V>, Collection<V>>> symmetricDifference = new HashMap<>();
+
+        for (U key : keys)
+        {
+            Set<V> valuesFromV1 = new HashSet<>(v1.get(key));
+            Set<V> valuesFromV2 = new HashSet<>(v2.get(key));
+            symmetricDifference.put(key, Pair.create(Sets.difference(valuesFromV1, valuesFromV2), Sets.difference(valuesFromV2, valuesFromV1)));
+        }
+
+        return symmetricDifference;
+    }
+
+    /**
+     * Returns a list of endpoints where its token range intersect with any token ranges in the input list.
+     */
+    public static Set<InetAddress> intersection(Multimap<Range<Token>, InetAddress> addressRanges, Collection<Range<Token>> tokenRanges)
+    {
+        Set<InetAddress> intersection = new HashSet<>();
+
+        for (Map.Entry<Range<Token>, InetAddress> entry : addressRanges.entries())
+        {
+            for (Range<Token> range : tokenRanges)
+            {
+                if (entry.getKey().intersects(range))
+                {
+                    intersection.add(entry.getValue());
+                }
+            }
+        }
+
+        return intersection;
+    }
+}

--- a/src/java/com/palantir/cassandra/utils/MapUtils.java
+++ b/src/java/com/palantir/cassandra/utils/MapUtils.java
@@ -48,10 +48,10 @@ public final class MapUtils
      * For a given key, {@link Pair#left} are values that exist only in the first map and {@link Pair#right} are values
      * that exist only in the second map.
      */
-    public static <U, V> Map<U, Pair<Collection<V>, Collection<V>>> symmetricDifference(Multimap<U, V> v1, Multimap<U, V> v2)
+    public static <U, V> Map<U, Pair<Set<V>, Set<V>>> symmetricDifference(Multimap<U, V> v1, Multimap<U, V> v2)
     {
         Set<U> keys = Sets.union(v1.keySet(), v2.keySet()).immutableCopy();
-        Map<U, Pair<Collection<V>, Collection<V>>> symmetricDifference = new HashMap<>();
+        Map<U, Pair<Set<V>, Set<V>>> symmetricDifference = new HashMap<>();
 
         for (U key : keys)
         {

--- a/src/java/com/palantir/cassandra/utils/MapUtils.java
+++ b/src/java/com/palantir/cassandra/utils/MapUtils.java
@@ -38,26 +38,6 @@ public final class MapUtils
     }
 
     /**
-     * For each key in the union of all keys, find their symmetric difference between the versions of the map.
-     * For a given key, {@link Pair#left} are values that exist only in the first map and {@link Pair#right} are values
-     * that exist only in the second map.
-     */
-    public static <U, V> Map<U, Pair<Set<V>, Set<V>>> symmetricDifference(Multimap<U, V> v1, Multimap<U, V> v2)
-    {
-        Set<U> keys = Sets.union(v1.keySet(), v2.keySet()).immutableCopy();
-        Map<U, Pair<Set<V>, Set<V>>> symmetricDifference = new HashMap<>();
-
-        for (U key : keys)
-        {
-            Set<V> valuesFromV1 = new HashSet<>(v1.get(key));
-            Set<V> valuesFromV2 = new HashSet<>(v2.get(key));
-            symmetricDifference.put(key, Pair.create(Sets.difference(valuesFromV1, valuesFromV2), Sets.difference(valuesFromV2, valuesFromV1)));
-        }
-
-        return symmetricDifference;
-    }
-
-    /**
      * Returns a list of endpoints where its token range intersect with any token ranges in the input list.
      */
     public static Set<InetAddress> intersection(Multimap<Range<Token>, InetAddress> addressRanges, Collection<Range<Token>> tokenRanges)
@@ -92,8 +72,27 @@ public final class MapUtils
                 coalesced.computeIfAbsent(endpoint, _k -> new ArrayList<>()).add(entry.getKey());
             }
         }
-        coalesced.replaceAll((_k, tokenRanges) -> tokenRanges.stream().sorted().collect(Collectors.toList()));
+        coalesced.replaceAll((_k, tokenRanges) -> sort(tokenRanges));
 
         return coalesced;
+    }
+
+    /**
+     * Similar to {@link MapUtils#coalesce(Multimap)}
+     */
+    public static Map<InetAddress, List<Token>> coalesce(Multimap<InetAddress, Token> endpointToken)
+    {
+        Map<InetAddress, List<Token>> coalesced = new HashMap<>();
+
+        for (InetAddress endpoint : endpointToken.keys())
+        {
+            coalesced.put(endpoint, sort(endpointToken.get(endpoint)));
+        }
+
+        return coalesced;
+    }
+
+    private static <T> List<T> sort(Collection<T> collection) {
+        return collection.stream().sorted().collect(Collectors.toList());
     }
 }

--- a/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
+++ b/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
@@ -107,6 +107,7 @@ public class MutationVerificationUtils
 
     private static void refreshCache()
     {
+        logger.info("Refreshing TokenMetadata cache");
         StorageService.instance.getTokenMetadata().invalidateCachedRings();
         lastTokenRingCacheUpdate = Instant.now();
     }

--- a/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
+++ b/src/java/com/palantir/cassandra/utils/MutationVerificationUtils.java
@@ -107,7 +107,6 @@ public class MutationVerificationUtils
 
     private static void refreshCache()
     {
-        logger.info("Refreshing TokenMetadata cache");
         StorageService.instance.getTokenMetadata().invalidateCachedRings();
         lastTokenRingCacheUpdate = Instant.now();
     }

--- a/src/java/org/apache/cassandra/locator/TokenMetadata.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadata.java
@@ -28,6 +28,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.*;
+import com.palantir.logsafe.UnsafeArg;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -955,7 +956,7 @@ public class TokenMetadata
             }
         }
 
-        logLeavingEndpointDifference(leavingEndpoints, newPendingRanges);
+        logLeavingEndpointDifference(strategy.keyspaceName, leavingEndpoints, newPendingRanges);
 
         // At this stage newPendingRanges has been updated according to leave operations. We can
         // now continue the calculation by checking bootstrapping nodes.
@@ -1365,11 +1366,12 @@ public class TokenMetadata
         }
     }
 
-    private void logLeavingEndpointDifference(Set<InetAddress> leavingEndpoints, PendingRangeMaps pendingRangeMaps)
+    private void logLeavingEndpointDifference(String keyspace, Set<InetAddress> leavingEndpoints, PendingRangeMaps pendingRangeMaps)
     {
         if (shouldLogTokenChanges && !leavingEndpoints.isEmpty())
         {
             logger.info("Pending ranges after endpoints leave",
+                        UnsafeArg.of("keyspace", keyspace),
                         SafeArg.of("leavingEndpoints", leavingEndpoints),
                         SafeArg.of("pendingRangeMaps", MapUtils.coalesce(pendingRangeMaps)));
         }

--- a/src/java/org/apache/cassandra/locator/TokenMetadata.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadata.java
@@ -968,14 +968,14 @@ public class TokenMetadata
         {
             Collection<Token> tokens = bootstrapAddresses.get(endpoint);
             allLeftMetadata.updateNormalTokens(tokens, endpoint);
-            Collection<Range<Token>> addressRangesForEndpoint = strategy.getAddressRanges(allLeftMetadata).get(endpoint);
-            for (Range<Token> range : addressRangesForEndpoint)
+            Collection<Range<Token>> tokenRangeForEndpoint = strategy.getAddressRanges(allLeftMetadata).get(endpoint);
+            for (Range<Token> range : tokenRangeForEndpoint)
             {
                 newPendingRanges.addPendingRange(range, endpoint);
             }
             allLeftMetadata.removeEndpoint(endpoint);
 
-            logBootstrapDifference(endpoint, addressRangesSnapshot, addressRangesForEndpoint);
+            logBootstrapDifference(strategy.keyspaceName, endpoint, addressRangesSnapshot, tokenRangeForEndpoint);
         }
 
         // At this stage newPendingRanges has been updated according to leaving and bootstrapping nodes.
@@ -1385,16 +1385,16 @@ public class TokenMetadata
         }
     }
 
-    private void logBootstrapDifference(String keyspace, InetAddress endpoint, Multimap<Range<Token>, InetAddress> snapshot, Collection<Range<Token>> newTokenRanges)
+    private void logBootstrapDifference(String keyspace, InetAddress endpoint, Multimap<Range<Token>, InetAddress> snapshot, Collection<Range<Token>> tokenRangeForEndpoint)
     {
         if (shouldLogTokenChanges)
         {
             logger.info("Pending ranges for bootstrapping endpoint",
                         SafeArg.of("keyspace", keyspace),
                         SafeArg.of("bootstrapingEndpoint", endpoint),
-                        SafeArg.of("previousOwners", MapUtils.intersection(snapshot, newTokenRanges)),
-                        SafeArg.of("pendingRangeCount", newTokenRanges.size()));
-            logger.debug("Pending range for endpoint", newTokenRanges);
+                        SafeArg.of("previousOwners", MapUtils.intersection(snapshot, tokenRangeForEndpoint)),
+                        SafeArg.of("pendingRangeCount", tokenRangeForEndpoint.size()));
+            logger.debug("Pending range for endpoint", SafeArg.of("pendingRange", tokenRangeForEndpoint));
         }
     }
 

--- a/src/java/org/apache/cassandra/locator/TokenMetadata.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadata.java
@@ -1371,7 +1371,7 @@ public class TokenMetadata
         {
             logger.info("Pending ranges after endpoints leave",
                         SafeArg.of("leavingEndpoints", leavingEndpoints),
-                        SafeArg.of("pendingRangeMaps", pendingRangeMaps.printPendingRanges()));
+                        SafeArg.of("pendingRangeMaps", MapUtils.coalesce(pendingRangeMaps)));
         }
     }
 

--- a/src/java/org/apache/cassandra/locator/TokenMetadata.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadata.java
@@ -198,7 +198,7 @@ public class TokenMetadata
         if (endpointTokens.isEmpty())
             return;
 
-        if (StorageService.instance.isSetupCompleted())
+        if (StorageService.instance.isSetupCompleted() && shouldLogTokenChanges)
         {
             logger.info("updateNormalTokens", SafeArg.of("endpointTokens", MapUtils.coalesce(endpointTokens)));
         }

--- a/src/java/org/apache/cassandra/locator/TokenMetadata.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadata.java
@@ -198,12 +198,15 @@ public class TokenMetadata
         if (endpointTokens.isEmpty())
             return;
 
+        if (StorageService.instance.isSetupCompleted())
+        {
+            logger.info("updateNormalTokens", SafeArg.of("endpointTokens", MapUtils.coalesce(endpointTokens)));
+        }
+
         publicLock.readLock().lock();
         lock.writeLock().lock();
         try
         {
-            Multimap<InetAddress, Token> tokenToEndpointMapSnapshot = HashMultimap.create(tokenToEndpointMap.inverse());
-
             boolean shouldSortTokens = false;
             for (InetAddress endpoint : endpointTokens.keySet())
             {
@@ -232,8 +235,6 @@ public class TokenMetadata
 
             if (shouldSortTokens)
                 sortedTokens = sortTokens();
-
-            logMultiMapDifference("tokenToEndpointMap changes", tokenToEndpointMapSnapshot, tokenToEndpointMap.inverse());
         }
         finally
         {
@@ -351,8 +352,6 @@ public class TokenMetadata
         lock.writeLock().lock();
         try
         {
-            Multimap<InetAddress, Token> bootstrapTokensSnapshot = HashMultimap.create(bootstrapTokens.inverse());
-
             InetAddress oldEndpoint;
 
             for (Token token : tokens)
@@ -370,8 +369,6 @@ public class TokenMetadata
 
             for (Token token : tokens)
                 bootstrapTokens.put(token, endpoint);
-
-            logMultiMapDifference(String.format("bootstrapTokens changes for %s", original == null ? "bootstrap" : "node replacement"), bootstrapTokensSnapshot, bootstrapTokens.inverse());
         }
         finally
         {
@@ -1348,25 +1345,6 @@ public class TokenMetadata
         cachedTokenMap.set(null);
     }
 
-    private void logMultiMapDifference(String messagePrefix, Multimap<InetAddress, Token> snapshot, Multimap<InetAddress, Token> changes)
-    {
-        if (shouldLogTokenChanges)
-        {
-            Map<InetAddress, Pair<Set<Token>, Set<Token>>> symmetricDifference = MapUtils.symmetricDifference(snapshot, changes);
-            Map<InetAddress, Pair<List<Token>, List<Token>>> sortedSymmetricDifference = new HashMap<>();
-
-            for (Map.Entry<InetAddress, Pair<Set<Token>, Set<Token>>> entry : symmetricDifference.entrySet()) {
-                if (entry.getValue().left.size() + entry.getValue().right.size() > 0) {
-                    List<Token> before = new ArrayList<>(entry.getValue().left).stream().sorted().collect(Collectors.toList());
-                    List<Token> after = new ArrayList<>(entry.getValue().right).stream().sorted().collect(Collectors.toList());
-                    sortedSymmetricDifference.put(entry.getKey(), Pair.create(before, after));
-                }
-            }
-
-            logger.info(messagePrefix, SafeArg.of("Symmetric difference", sortedSymmetricDifference));
-        }
-    }
-
     private void logLeavingEndpointDifference(String keyspace, Set<InetAddress> leavingEndpoints, PendingRangeMaps pendingRangeMaps)
     {
         if (shouldLogTokenChanges && !leavingEndpoints.isEmpty())
@@ -1394,7 +1372,7 @@ public class TokenMetadata
                         SafeArg.of("bootstrapingEndpoint", endpoint),
                         SafeArg.of("previousOwners", MapUtils.intersection(snapshot, tokenRangeForEndpoint)),
                         SafeArg.of("pendingRangeCount", tokenRangeForEndpoint.size()));
-            logger.debug("Pending range for endpoint", SafeArg.of("pendingRange", tokenRangeForEndpoint));
+            logger.debug("Pending range for endpoint", SafeArg.of("pendingRange", tokenRangeForEndpoint.stream().sorted().collect(Collectors.toList())));
         }
     }
 

--- a/src/java/org/apache/cassandra/locator/TokenMetadata.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadata.java
@@ -28,6 +28,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.*;
+import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -198,7 +199,7 @@ public class TokenMetadata
         if (endpointTokens.isEmpty())
             return;
 
-        if (StorageService.instance.isSetupCompleted() && shouldLogTokenChanges)
+        if (StorageService.instance.hasJoined() && shouldLogTokenChanges)
         {
             logger.info("updateNormalTokens", SafeArg.of("endpointTokens", MapUtils.coalesce(endpointTokens)));
         }

--- a/src/java/org/apache/cassandra/locator/TokenMetadata.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadata.java
@@ -128,7 +128,7 @@ public class TokenMetadata
              new Topology(), shouldLogTokenChanges);
     }
 
-    private TokenMetadata(BiMultiValMap<Token, InetAddress> tokenToEndpointMap, BiMap<InetAddress, UUID> endpointsMap , Topology topology, boolean shouldLogTokenChanges)
+    private TokenMetadata(BiMultiValMap<Token, InetAddress> tokenToEndpointMap, BiMap<InetAddress, UUID> endpointsMap, Topology topology, boolean shouldLogTokenChanges)
     {
         this.tokenToEndpointMap = tokenToEndpointMap;
         this.topology = topology;

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -141,7 +141,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     }
 
     /* This abstraction maintains the token/endpoint metadata information */
-    private TokenMetadata tokenMetadata = new TokenMetadata();
+    private TokenMetadata tokenMetadata = new TokenMetadata(true);
 
     public volatile VersionedValue.VersionedValueFactory valueFactory = new VersionedValue.VersionedValueFactory(getPartitioner());
 

--- a/test/unit/com/palantir/cassandra/utils/MapUtilsTest.java
+++ b/test/unit/com/palantir/cassandra/utils/MapUtilsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.utils;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.utils.Pair;
+
+import static org.apache.cassandra.Util.token;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class MapUtilsTest
+{
+    private static final String KEY_1 = "key1";
+
+    private static final Token TOKEN_1 = token("token1");
+
+    private static final Token TOKEN_2 = token("token2");
+
+    private Multimap<String, Token> v1;
+
+    private Multimap<String, Token> v2;
+
+    @Before
+    public void before()
+    {
+        v1 = HashMultimap.<String, Token>create();
+        v2 = HashMultimap.<String, Token>create();
+    }
+
+    @Test
+    public void symmetricDifference_sameMapContentHasEmptySet()
+    {
+        putAll(v1, KEY_1, TOKEN_1);
+        putAll(v2, KEY_1, TOKEN_1);
+        Map<String, Pair<Collection<Token>, Collection<Token>>> symmetricDifference = MapUtils.symmetricDifference(v1, v2);
+        assertThat(symmetricDifference.keySet()).containsExactly(KEY_1);
+        assertThat(symmetricDifference.get(KEY_1)).isNotNull().satisfies(pair -> {
+            assertThat(pair.left).isEmpty();
+            assertThat(pair.right).isEmpty();
+        });
+    }
+
+    @Test
+    public void symmetricDifference_appendedValuesAreIncludedInSet2()
+    {
+        putAll(v1, KEY_1, TOKEN_1);
+        putAll(v2, KEY_1, TOKEN_1, TOKEN_2);
+        Map<String, Pair<Collection<Token>, Collection<Token>>> symmetricDifference = MapUtils.symmetricDifference(v1, v2);
+        assertThat(symmetricDifference.keySet()).containsExactly(KEY_1);
+        assertThat(symmetricDifference.get(KEY_1)).isNotNull().satisfies(pair -> {
+            assertThat(pair.left).isEmpty();
+            assertThat(pair.right).containsExactlyInAnyOrder(TOKEN_2);
+        });
+    }
+
+    @Test
+    public void symmetricDifference_remainingValuesAreIncludedInSet1()
+    {
+        putAll(v1, KEY_1, TOKEN_1, TOKEN_2);
+        putAll(v2, KEY_1, TOKEN_1);
+        Map<String, Pair<Collection<Token>, Collection<Token>>> symmetricDifference = MapUtils.symmetricDifference(v1, v2);
+        assertThat(symmetricDifference.keySet()).containsExactly(KEY_1);
+        assertThat(symmetricDifference.get(KEY_1)).isNotNull().satisfies(pair -> {
+            assertThat(pair.left).containsExactlyInAnyOrder(TOKEN_2);
+            assertThat(pair.right).isEmpty();
+        });
+    }
+
+    private void putAll(Multimap<String, Token> map, String key, Token... tokens)
+    {
+        map.putAll(key, Arrays.asList(tokens));
+    }
+}

--- a/test/unit/com/palantir/cassandra/utils/MapUtilsTest.java
+++ b/test/unit/com/palantir/cassandra/utils/MapUtilsTest.java
@@ -26,81 +26,30 @@ import com.google.common.collect.Multimap;
 import org.apache.cassandra.dht.RandomPartitioner;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.locator.PendingRangeMaps;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.dht.Token;
-import org.apache.cassandra.utils.Pair;
 
-import static org.apache.cassandra.Util.token;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class MapUtilsTest
 {
-    private static final String KEY_1 = "key1";
-
-    private static final Token TOKEN_1 = token("token1");
-
-    private static final Token TOKEN_2 = token("token2");
-
     private InetAddress ep1;
 
     private InetAddress ep2;
-
-    private Multimap<String, Token> v1;
-
-    private Multimap<String, Token> v2;
 
     private Multimap<Range<Token>, InetAddress> addressRange;
 
     @Before
     public void before() throws Exception
     {
-        v1 = HashMultimap.<String, Token>create();
-        v2 = HashMultimap.<String, Token>create();
         addressRange = HashMultimap.create();
 
         ep1 = InetAddress.getByName("127.0.0.1");
         ep2 = InetAddress.getByName("127.0.0.2");
-    }
-
-    @Test
-    public void symmetricDifference_sameMapContentHasEmptySet()
-    {
-        putAll(v1, KEY_1, TOKEN_1);
-        putAll(v2, KEY_1, TOKEN_1);
-        Map<String, Pair<Set<Token>, Set<Token>>> symmetricDifference = MapUtils.symmetricDifference(v1, v2);
-        assertThat(symmetricDifference.keySet()).containsExactly(KEY_1);
-        assertThat(symmetricDifference.get(KEY_1)).isNotNull().satisfies(pair -> {
-            assertThat(pair.left).isEmpty();
-            assertThat(pair.right).isEmpty();
-        });
-    }
-
-    @Test
-    public void symmetricDifference_appendedValuesAreIncludedInSet2()
-    {
-        putAll(v1, KEY_1, TOKEN_1);
-        putAll(v2, KEY_1, TOKEN_1, TOKEN_2);
-        Map<String, Pair<Set<Token>, Set<Token>>> symmetricDifference = MapUtils.symmetricDifference(v1, v2);
-        assertThat(symmetricDifference.keySet()).containsExactly(KEY_1);
-        assertThat(symmetricDifference.get(KEY_1)).isNotNull().satisfies(pair -> {
-            assertThat(pair.left).isEmpty();
-            assertThat(pair.right).containsExactlyInAnyOrder(TOKEN_2);
-        });
-    }
-
-    @Test
-    public void symmetricDifference_remainingValuesAreIncludedInSet1()
-    {
-        putAll(v1, KEY_1, TOKEN_1, TOKEN_2);
-        putAll(v2, KEY_1, TOKEN_1);
-        Map<String, Pair<Set<Token>, Set<Token>>> symmetricDifference = MapUtils.symmetricDifference(v1, v2);
-        assertThat(symmetricDifference.keySet()).containsExactly(KEY_1);
-        assertThat(symmetricDifference.get(KEY_1)).isNotNull().satisfies(pair -> {
-            assertThat(pair.left).containsExactlyInAnyOrder(TOKEN_2);
-            assertThat(pair.right).isEmpty();
-        });
     }
 
     @Test
@@ -135,6 +84,18 @@ public final class MapUtilsTest
                 .containsExactly(range2, range3, range1);
     }
 
+    @Test
+    public void coalesce_sortTokens()
+    {
+        Multimap<InetAddress, Token> endpointToken = HashMultimap.create();
+        putAll(endpointToken, ep1, token("f"), token("0"), token("a"));
+        Map<InetAddress, List<Token>> sortedEndpointToken = MapUtils.coalesce(endpointToken);
+        assertThat(sortedEndpointToken.keySet()).containsExactly(ep1);
+        assertThat(sortedEndpointToken.get(ep1))
+                .isNotNull()
+                .containsExactly(token("0"), token("a"), token("f"));
+    }
+
     @SafeVarargs
     private final <U, V> void putAll(Multimap<U, V> map, U key, V... tokens)
     {
@@ -150,5 +111,10 @@ public final class MapUtilsTest
     private Range<Token> rangeOf(String leftBound, String rightBound)
     {
         return new Range<>(new RandomPartitioner.BigIntegerToken(leftBound), new RandomPartitioner.BigIntegerToken(rightBound));
+    }
+
+    public static Token token(String key)
+    {
+        return StorageService.getPartitioner().getToken(ByteBufferUtil.bytes(key));
     }
 }


### PR DESCRIPTION
# Description

v0 implementation for logging changes to `TokenMetadata`. The changes include:

* For `TokenMetadata#updateNormalTokens`, log the argument after `StorageService#joined` evaluates to true.
* For `TokenMetadata#calculatePendingRanges`, differentiate between endpoint leaving and bootstrap. When a node is bootstrapping, we calculate the previous owner that this node would have taken the ranges from.

## updateNormalTokens

We only log the changes after the set up has completed to reduce noises on [first startup](https://github.com/palantir/cassandra/blob/palantir-cassandra-2.2.18/src/java/org/apache/cassandra/service/StorageService.java#L691), where `StorageService` update tokens from `System.peers`. If this is an existing node that is restarting, we will get an extra log line for ownership that we already know about from `System.local`, but I reason this one extra log line should be fine.