### PR TITLE
mark OperationMode logs as safe

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -41,7 +41,12 @@ import com.google.common.collect.*;
 import com.google.common.util.concurrent.*;
 import com.palantir.cassandra.db.BootstrappingSafetyException;
 import com.palantir.cassandra.settings.LocalQuorumReadForSerialCasSetting;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.schema.LegacySchemaTables;
+
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1533,14 +1538,13 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     }
 
     @VisibleForTesting
-    void setMode(Mode m, String msg, boolean log)
+    void setMode(Mode m, @Safe String msg, boolean log)
     {
         operationMode = m;
-        String logMsg = msg == null ? m.toString() : String.format("%s: %s", m, msg);
         if (log)
-            logger.info(logMsg);
+            logger.info(m.toString(), SafeArg.of("msg", msg));
         else
-            logger.debug(logMsg);
+            logger.debug(m.toString(), SafeArg.of("msg", msg));
     }
 
     /**

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -44,7 +44,6 @@ import com.palantir.cassandra.settings.LocalQuorumReadForSerialCasSetting;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.schema.LegacySchemaTables;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -41,12 +41,10 @@ import com.google.common.collect.*;
 import com.google.common.util.concurrent.*;
 import com.palantir.cassandra.db.BootstrappingSafetyException;
 import com.palantir.cassandra.settings.LocalQuorumReadForSerialCasSetting;
-import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.schema.LegacySchemaTables;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
Our logging infrastructure excludes non-annotated log messages if they are not compile-time constants.

By inspecting usages, we can see that all calls to `setMode` have messages that are safe to log, so we can just mark all of those log messages as safe.

The only message that might be questionable are the ones for `MOVING`. I believe these are safe because the variables included in the log are endpoints and Token range endpoints, which we've determined to be Safe.