### PR TITLE
[Draft] Guarding Writes by Logical Timestamps

### DIFF
--- a/src/java/com/palantir/cassandra/logicalts/CollectionBasedFrozenTimestampTracker.java
+++ b/src/java/com/palantir/cassandra/logicalts/CollectionBasedFrozenTimestampTracker.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.logicalts;
+
+import java.util.NavigableSet;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class CollectionBasedFrozenTimestampTracker implements FrozenTimestampTracker
+{
+    public static final FrozenTimestampTracker INSTANCE = new CollectionBasedFrozenTimestampTracker();
+    private final NavigableSet<Long> activeReaders = new ConcurrentSkipListSet<>();
+    private static final long UNINITIALIZED_TIMESTAMP = -1;
+
+    private final AtomicLong frozenTimestamp = new AtomicLong(UNINITIALIZED_TIMESTAMP);
+
+    @Override
+    public void advanceFrozenTimestamp(long desiredTimestamp) throws InProgressMutationConflictException
+    {
+        if (timestampIsLocked(desiredTimestamp))
+        {
+            throw new InProgressMutationConflictException("There are in-progress mutations before the sweep timestamp. Sweep can not proceed.");
+        }
+        frozenTimestamp.updateAndGet(current -> Long.max(current, desiredTimestamp));
+    }
+
+    private boolean timestampIsLocked(long desiredTimestamp)
+    {
+        return activeReaders.floor(desiredTimestamp) != null;
+    }
+
+    @Override
+    public UncheckedAutoCloseable checkAndLockForMutation(long mutationTimestamp) throws IllegalLogicalTimestampException
+    {
+        long frozenTimestamp = this.frozenTimestamp.get();
+        if (frozenTimestamp == UNINITIALIZED_TIMESTAMP)
+        {
+            throw new IllegalLogicalTimestampException("Frozen timestamp has not been initialized");
+        }
+        if (mutationTimestamp < frozenTimestamp)
+        {
+            throw new IllegalLogicalTimestampException("Mutation start timestamp is before the frozen timestamp");
+        }
+
+        activeReaders.add(mutationTimestamp);
+
+        if (mutationTimestamp < this.frozenTimestamp.get())
+        {
+            activeReaders.remove(mutationTimestamp);
+            throw new IllegalLogicalTimestampException("Frozen timestamp was updated before we were able to lock our start timestamp");
+        }
+
+        // TODO: How can we ensure that this closable is ALWAYS executed? Or expire stale locks?
+        return () -> activeReaders.remove(mutationTimestamp);
+    }
+}

--- a/src/java/com/palantir/cassandra/logicalts/FrozenTimestampMutationVerifier.java
+++ b/src/java/com/palantir/cassandra/logicalts/FrozenTimestampMutationVerifier.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.cassandra.db.Cell;
 import org.apache.cassandra.db.ColumnFamily;
 import org.apache.cassandra.db.IMutation;
+import org.apache.cassandra.io.sstable.ColumnStats;
 
 public class FrozenTimestampMutationVerifier implements MutationVerifier
 {
@@ -71,8 +73,7 @@ public class FrozenTimestampMutationVerifier implements MutationVerifier
         {
             for (ColumnFamily columnFamily : mutation.getColumnFamilies())
             {
-                // TODO(rhuffman): getColumnStats() is expensive. Replace this
-                long maxTimestamp = columnFamily.getColumnStats().maxTimestamp;
+                long maxTimestamp = maxTimestamp(columnFamily);
 
                 keyspaceToMaxWriteTimestamp.compute(
                     mutation.getKeyspaceName(),
@@ -80,5 +81,15 @@ public class FrozenTimestampMutationVerifier implements MutationVerifier
             }
         }
         return keyspaceToMaxWriteTimestamp;
+    }
+
+    private static long maxTimestamp(ColumnFamily columnFamily)
+    {
+        ColumnStats.MaxLongTracker tracker = new ColumnStats.MaxLongTracker(Long.MIN_VALUE);
+        for (Cell cell : columnFamily)
+        {
+            tracker.update(cell.timestamp());
+        }
+        return tracker.get();
     }
 }

--- a/src/java/com/palantir/cassandra/logicalts/FrozenTimestampMutationVerifier.java
+++ b/src/java/com/palantir/cassandra/logicalts/FrozenTimestampMutationVerifier.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.logicalts;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.cassandra.db.ColumnFamily;
+import org.apache.cassandra.db.IMutation;
+
+public class FrozenTimestampMutationVerifier implements MutationVerifier
+{
+    private final FrozenTimestampTrackerFactory frozenTimestampTrackerFactory;
+    private final Map<String, FrozenTimestampTracker> namespaceToFrozenTimestampTracker;
+
+    public FrozenTimestampMutationVerifier(FrozenTimestampTrackerFactory frozenTimestampTrackerFactory)
+    {
+        this.frozenTimestampTrackerFactory = frozenTimestampTrackerFactory;
+        this.namespaceToFrozenTimestampTracker = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public UncheckedAutoCloseable verifyMutations(Collection<? extends IMutation> mutations) throws IllegalLogicalTimestampException
+    {
+        Map<String, Long> keyspaceToMaxWriteTimestamp = computeKeyspaceToMaxWriteTimestamp(mutations);
+        List<UncheckedAutoCloseable> locks = acquireAllLocks(keyspaceToMaxWriteTimestamp);
+
+        return () -> locks.forEach(UncheckedAutoCloseable::close);
+    }
+
+    private List<UncheckedAutoCloseable> acquireAllLocks(Map<String, Long> keyspaceToMaxWriteTimestamp) throws IllegalLogicalTimestampException
+    {
+        List<UncheckedAutoCloseable> locks = new ArrayList<>();
+
+        for (Map.Entry<String, Long> keyspaceAndMaxWriteTimestamp : keyspaceToMaxWriteTimestamp.entrySet())
+        {
+            String keyspaceName = keyspaceAndMaxWriteTimestamp.getKey();
+            Long maxWriteTimestamp = keyspaceAndMaxWriteTimestamp.getValue();
+            locks.add(namespaceToFrozenTimestampTracker.computeIfAbsent(
+                keyspaceName,
+                ignored -> frozenTimestampTrackerFactory.create()).checkAndLockForMutation(maxWriteTimestamp));
+        }
+        return locks;
+    }
+
+    private static Map<String, Long> computeKeyspaceToMaxWriteTimestamp(Collection<? extends IMutation> mutations)
+    {
+        Map<String, Long> keyspaceToMaxWriteTimestamp = new HashMap<>();
+
+        for (IMutation mutation : mutations)
+        {
+            for (ColumnFamily columnFamily : mutation.getColumnFamilies())
+            {
+                // TODO(rhuffman): getColumnStats() is expensive. Replace this
+                long maxTimestamp = columnFamily.getColumnStats().maxTimestamp;
+
+                keyspaceToMaxWriteTimestamp.compute(
+                    mutation.getKeyspaceName(),
+                    (ignored, current) -> current != null ? Long.max(current, maxTimestamp) : maxTimestamp);
+            }
+        }
+        return keyspaceToMaxWriteTimestamp;
+    }
+}

--- a/src/java/com/palantir/cassandra/logicalts/FrozenTimestampMutationVerifier.java
+++ b/src/java/com/palantir/cassandra/logicalts/FrozenTimestampMutationVerifier.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.google.common.collect.Iterables;
+
 import org.apache.cassandra.db.Cell;
 import org.apache.cassandra.db.ColumnFamily;
 import org.apache.cassandra.db.IMutation;
@@ -44,10 +46,20 @@ public class FrozenTimestampMutationVerifier implements MutationVerifier
     @Override
     public UncheckedAutoCloseable verifyMutations(Collection<? extends IMutation> mutations) throws IllegalLogicalTimestampException
     {
+        if (mutations.size() == 1)
+        {
+            return verifyMutation(Iterables.getOnlyElement(mutations));
+        }
         Map<String, Long> keyspaceToMaxWriteTimestamp = computeKeyspaceToMaxWriteTimestamp(mutations);
         List<UncheckedAutoCloseable> locks = acquireAllLocks(keyspaceToMaxWriteTimestamp);
 
         return () -> locks.forEach(UncheckedAutoCloseable::close);
+    }
+
+    @Override
+    public UncheckedAutoCloseable verifyMutation(IMutation mutation) throws IllegalLogicalTimestampException
+    {
+        return acquireLock(mutation.getKeyspaceName(), maxTimestamp(mutation));
     }
 
     private List<UncheckedAutoCloseable> acquireAllLocks(Map<String, Long> keyspaceToMaxWriteTimestamp) throws IllegalLogicalTimestampException
@@ -58,11 +70,16 @@ public class FrozenTimestampMutationVerifier implements MutationVerifier
         {
             String keyspaceName = keyspaceAndMaxWriteTimestamp.getKey();
             Long maxWriteTimestamp = keyspaceAndMaxWriteTimestamp.getValue();
-            locks.add(namespaceToFrozenTimestampTracker.computeIfAbsent(
-                keyspaceName,
-                ignored -> frozenTimestampTrackerFactory.create()).checkAndLockForMutation(maxWriteTimestamp));
+            locks.add(acquireLock(keyspaceName, maxWriteTimestamp));
         }
         return locks;
+    }
+
+    private UncheckedAutoCloseable acquireLock(String keyspaceName, Long maxWriteTimestamp) throws IllegalLogicalTimestampException
+    {
+        return namespaceToFrozenTimestampTracker.computeIfAbsent(
+                    keyspaceName,
+                    ignored -> frozenTimestampTrackerFactory.create()).checkAndLockForMutation(maxWriteTimestamp);
     }
 
     private static Map<String, Long> computeKeyspaceToMaxWriteTimestamp(Collection<? extends IMutation> mutations)
@@ -71,24 +88,24 @@ public class FrozenTimestampMutationVerifier implements MutationVerifier
 
         for (IMutation mutation : mutations)
         {
-            for (ColumnFamily columnFamily : mutation.getColumnFamilies())
-            {
-                long maxTimestamp = maxTimestamp(columnFamily);
-
-                keyspaceToMaxWriteTimestamp.compute(
-                    mutation.getKeyspaceName(),
-                    (ignored, current) -> current != null ? Long.max(current, maxTimestamp) : maxTimestamp);
-            }
+            String keyspaceName = mutation.getKeyspaceName();
+            long maxTimestamp = maxTimestamp(mutation);
+            keyspaceToMaxWriteTimestamp.compute(
+                keyspaceName,
+                (ignored, current) -> current != null ? Long.max(current, maxTimestamp) : maxTimestamp);
         }
         return keyspaceToMaxWriteTimestamp;
     }
 
-    private static long maxTimestamp(ColumnFamily columnFamily)
+    private static long maxTimestamp(IMutation mutation)
     {
         ColumnStats.MaxLongTracker tracker = new ColumnStats.MaxLongTracker(Long.MIN_VALUE);
-        for (Cell cell : columnFamily)
+        for (ColumnFamily columnFamily : mutation.getColumnFamilies())
         {
-            tracker.update(cell.timestamp());
+            for (Cell cell : columnFamily)
+            {
+                tracker.update(cell.timestamp());
+            }
         }
         return tracker.get();
     }

--- a/src/java/com/palantir/cassandra/logicalts/FrozenTimestampTracker.java
+++ b/src/java/com/palantir/cassandra/logicalts/FrozenTimestampTracker.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.logicalts;
+
+public interface FrozenTimestampTracker
+{
+    /**
+     * Advance the frozenTimestamp to the desiredTimestamp. This method throws
+     * if there are in-progress mutations holding a lock at or before the desiredTimestamp.
+     * If the implementation persists the frozenTimestamp, the timestamp
+     * must be persisted durably before this method returns.
+     *
+     * @param desiredTimestamp An observed Sweep timestamp
+     * @throws InProgressMutationConflictException if there are in-progress mutations holding a lock at or before the given timestamp
+     */
+    void advanceFrozenTimestamp(long desiredTimestamp) throws InProgressMutationConflictException;
+
+    /**
+     * Lock a Mutation timestamp. This lock must be held while applying a Mutation.
+     *
+     * @param mutationTimestamp The write time of the Mutation. We will hold a lock on this timestamp,
+     *                          and the frozen timestamp will not be allowed to increase past this
+     *                          timestamp while we hold this lock.
+     * @return An AutoClosable that releases the lock on the mutationTimestamp when closed
+     * @throws IllegalLogicalTimestampException if the provided startTimestamp < the current Frozen Timestamp
+     */
+    UncheckedAutoCloseable checkAndLockForMutation(long mutationTimestamp) throws IllegalLogicalTimestampException;
+}

--- a/src/java/com/palantir/cassandra/logicalts/FrozenTimestampTrackerFactory.java
+++ b/src/java/com/palantir/cassandra/logicalts/FrozenTimestampTrackerFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.logicalts;
+
+@FunctionalInterface
+public interface FrozenTimestampTrackerFactory
+{
+    FrozenTimestampTracker create();
+}

--- a/src/java/com/palantir/cassandra/logicalts/IllegalLogicalTimestampException.java
+++ b/src/java/com/palantir/cassandra/logicalts/IllegalLogicalTimestampException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.logicalts;
+
+public class IllegalLogicalTimestampException extends Exception
+{
+    public IllegalLogicalTimestampException(String message)
+    {
+        super(message);
+    }
+}

--- a/src/java/com/palantir/cassandra/logicalts/InProgressMutationConflictException.java
+++ b/src/java/com/palantir/cassandra/logicalts/InProgressMutationConflictException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.logicalts;
+
+public class InProgressMutationConflictException extends Exception
+{
+    public InProgressMutationConflictException(String message)
+    {
+        super(message);
+    }
+}

--- a/src/java/com/palantir/cassandra/logicalts/LockingFrozenTimestampTracker.java
+++ b/src/java/com/palantir/cassandra/logicalts/LockingFrozenTimestampTracker.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.logicalts;
+
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public final class LockingFrozenTimestampTracker implements FrozenTimestampTracker
+{
+    private static final long UNINITIALIZED_TIMESTAMP = -1;
+
+    private final AtomicLong frozenTimestamp = new AtomicLong(UNINITIALIZED_TIMESTAMP);
+
+    private final ConcurrentMap<Long, ReadWriteLock> startTimestampLocks = new ConcurrentHashMap<>();
+
+    @Override
+    public void advanceFrozenTimestamp(long desiredTimestamp)
+    {
+        TreeMap<Long, ReadWriteLock> sortedLocks = new TreeMap<>();
+        for (Map.Entry<Long, ReadWriteLock> entry : startTimestampLocks.entrySet())
+        {
+            if (entry.getKey() < desiredTimestamp)
+            {
+                sortedLocks.put(entry.getKey(), entry.getValue());
+            }
+        }
+        try
+        {
+            for (ReadWriteLock lock : sortedLocks.values())
+            {
+                lock.writeLock().lockInterruptibly();
+            }
+            frozenTimestamp.updateAndGet(current -> Long.max(current, desiredTimestamp));
+        }
+        catch (InterruptedException ignored)
+        {
+        }
+        finally
+        {
+            for (ReadWriteLock lock : sortedLocks.values())
+            {
+                if (lock.writeLock().tryLock())
+                {
+                    lock.writeLock().unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public UncheckedAutoCloseable checkAndLockForMutation(long mutationTimestamp) throws IllegalLogicalTimestampException
+    {
+        long frozenTimestamp = this.frozenTimestamp.get();
+        if (mutationTimestamp < frozenTimestamp || frozenTimestamp == UNINITIALIZED_TIMESTAMP)
+        {
+            throw new IllegalLogicalTimestampException("Cannot read data with a start timestamp less than the frozen timestamp");
+        }
+        ReadWriteLock lock = startTimestampLocks.computeIfAbsent(mutationTimestamp, ignored -> new ReentrantReadWriteLock());
+        lock.readLock().lock();
+
+        return () -> {
+            startTimestampLocks.remove(mutationTimestamp);
+            if (lock.readLock().tryLock())
+            {
+                lock.readLock().unlock();
+            }
+        };
+    }
+}

--- a/src/java/com/palantir/cassandra/logicalts/MutationVerifier.java
+++ b/src/java/com/palantir/cassandra/logicalts/MutationVerifier.java
@@ -24,6 +24,8 @@ import org.apache.cassandra.db.IMutation;
 
 public interface MutationVerifier
 {
+    MutationVerifier INSTANCE = new FrozenTimestampMutationVerifier(CollectionBasedFrozenTimestampTracker::new);
+
     UncheckedAutoCloseable verifyMutations(Collection<? extends IMutation> mutations) throws IllegalLogicalTimestampException;
 
     UncheckedAutoCloseable verifyMutation(IMutation mutation) throws IllegalLogicalTimestampException;

--- a/src/java/com/palantir/cassandra/logicalts/MutationVerifier.java
+++ b/src/java/com/palantir/cassandra/logicalts/MutationVerifier.java
@@ -25,4 +25,6 @@ import org.apache.cassandra.db.IMutation;
 public interface MutationVerifier
 {
     UncheckedAutoCloseable verifyMutations(Collection<? extends IMutation> mutations) throws IllegalLogicalTimestampException;
+
+    UncheckedAutoCloseable verifyMutation(IMutation mutation) throws IllegalLogicalTimestampException;
 }

--- a/src/java/com/palantir/cassandra/logicalts/MutationVerifier.java
+++ b/src/java/com/palantir/cassandra/logicalts/MutationVerifier.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.logicalts;
+
+import java.util.Collection;
+
+import org.apache.cassandra.db.IMutation;
+
+public interface MutationVerifier
+{
+    UncheckedAutoCloseable verifyMutations(Collection<? extends IMutation> mutations) throws IllegalLogicalTimestampException;
+}

--- a/src/java/com/palantir/cassandra/logicalts/UncheckedAutoCloseable.java
+++ b/src/java/com/palantir/cassandra/logicalts/UncheckedAutoCloseable.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.logicalts;
+
+public interface UncheckedAutoCloseable extends AutoCloseable
+{
+    @Override
+    void close();
+}

--- a/src/java/org/apache/cassandra/db/MutationVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/MutationVerbHandler.java
@@ -21,6 +21,9 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 
+import com.palantir.cassandra.logicalts.IllegalLogicalTimestampException;
+import com.palantir.cassandra.logicalts.MutationVerifier;
+import com.palantir.cassandra.logicalts.UncheckedAutoCloseable;
 import com.palantir.cassandra.utils.OwnershipVerificationUtils;
 import org.apache.cassandra.io.util.FastByteArrayInputStream;
 import org.apache.cassandra.net.*;
@@ -48,11 +51,17 @@ public class MutationVerbHandler implements IVerbHandler<Mutation>
             }
 
             OwnershipVerificationUtils.verifyMutation(message.payload);
-
-            message.payload.apply();
-            WriteResponse response = new WriteResponse();
-            Tracing.trace("Enqueuing response to {}", replyTo);
-            MessagingService.instance().sendReply(response.createMessage(), id, replyTo);
+            try (UncheckedAutoCloseable ignored = MutationVerifier.INSTANCE.verifyMutation(message.payload))
+            {
+                message.payload.apply();
+                WriteResponse response = new WriteResponse();
+                Tracing.trace("Enqueuing response to {}", replyTo);
+                MessagingService.instance().sendReply(response.createMessage(), id, replyTo);
+            }
+            catch (IllegalLogicalTimestampException e)
+            {
+                throw new RuntimeException(e);
+            }
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/ReadRepairVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/ReadRepairVerbHandler.java
@@ -17,6 +17,9 @@
  */
 package org.apache.cassandra.db;
 
+import com.palantir.cassandra.logicalts.IllegalLogicalTimestampException;
+import com.palantir.cassandra.logicalts.MutationVerifier;
+import com.palantir.cassandra.logicalts.UncheckedAutoCloseable;
 import com.palantir.cassandra.utils.OwnershipVerificationUtils;
 import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.MessageIn;
@@ -27,8 +30,15 @@ public class ReadRepairVerbHandler implements IVerbHandler<Mutation>
     public void doVerb(MessageIn<Mutation> message, int id)
     {
         OwnershipVerificationUtils.verifyMutation(message.payload);
-        message.payload.apply();
-        WriteResponse response = new WriteResponse();
-        MessagingService.instance().sendReply(response.createMessage(), id, message.from);
+        try(UncheckedAutoCloseable ignored = MutationVerifier.INSTANCE.verifyMutation(message.payload))
+        {
+            message.payload.apply();
+            WriteResponse response = new WriteResponse();
+            MessagingService.instance().sendReply(response.createMessage(), id, message.from);
+        }
+        catch (IllegalLogicalTimestampException e)
+        {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -105,8 +105,6 @@ public class StorageProxy implements StorageProxyMBean
 
     private static final double CONCURRENT_SUBREQUESTS_MARGIN = 0.10;
 
-    private static final MutationVerifier mutationVerifier = new FrozenTimestampMutationVerifier(CollectionBasedFrozenTimestampTracker::new);
-
     private StorageProxy() {}
 
     static
@@ -577,7 +575,7 @@ public class StorageProxy implements StorageProxyMBean
 
         ClientRequestMetrics writeMetrics = consistencyLevelWriteMetrics.get(consistency_level);
 
-        try (UncheckedAutoCloseable ignored = mutationVerifier.verifyMutations(mutations))
+        try (UncheckedAutoCloseable ignored = MutationVerifier.INSTANCE.verifyMutations(mutations))
         {
             for (IMutation mutation : mutations)
             {

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -33,6 +33,11 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.cassandra.concurrent.LocalReadRunnableTimeoutWatcher;
 import com.palantir.cassandra.db.RowCountOverwhelmingException;
 
+import com.palantir.cassandra.logicalts.CollectionBasedFrozenTimestampTracker;
+import com.palantir.cassandra.logicalts.FrozenTimestampMutationVerifier;
+import com.palantir.cassandra.logicalts.IllegalLogicalTimestampException;
+import com.palantir.cassandra.logicalts.MutationVerifier;
+import com.palantir.cassandra.logicalts.UncheckedAutoCloseable;
 import com.palantir.cassandra.settings.LocalQuorumReadForSerialCasSetting;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -99,6 +104,8 @@ public class StorageProxy implements StorageProxyMBean
     private static final CASClientRequestMetrics casReadMetrics = new CASClientRequestMetrics("CASRead");
 
     private static final double CONCURRENT_SUBREQUESTS_MARGIN = 0.10;
+
+    private static final MutationVerifier mutationVerifier = new FrozenTimestampMutationVerifier(CollectionBasedFrozenTimestampTracker::new);
 
     private StorageProxy() {}
 
@@ -570,7 +577,7 @@ public class StorageProxy implements StorageProxyMBean
 
         ClientRequestMetrics writeMetrics = consistencyLevelWriteMetrics.get(consistency_level);
 
-        try
+        try (UncheckedAutoCloseable ignored = mutationVerifier.verifyMutations(mutations))
         {
             for (IMutation mutation : mutations)
             {
@@ -626,6 +633,11 @@ public class StorageProxy implements StorageProxyMBean
             writeMetrics.unavailables.mark();
             Tracing.trace("Overloaded");
             throw e;
+        }
+        catch (IllegalLogicalTimestampException e)
+        {
+            // TODO(rhuffman): handle properly
+            throw new RuntimeException(e);
         }
         finally
         {

--- a/test/unit/com/palantir/cassandra/logicalts/FrozenTimestampTrackerTest.java
+++ b/test/unit/com/palantir/cassandra/logicalts/FrozenTimestampTrackerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.logicalts;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class FrozenTimestampTrackerTest
+{
+
+    @Test
+    public void testLockAndUnlock() throws Exception
+    {
+        FrozenTimestampTracker tracker = new CollectionBasedFrozenTimestampTracker();
+
+        tracker.advanceFrozenTimestamp(10);
+
+        AutoCloseable closable = tracker.checkAndLockForMutation(15);
+        closable.close();
+    }
+
+    @Test
+    public void testReject() throws Exception
+    {
+        FrozenTimestampTracker tracker = new CollectionBasedFrozenTimestampTracker();
+
+        tracker.advanceFrozenTimestamp(10);
+
+        assertThatThrownBy(() -> tracker.checkAndLockForMutation(5)).isInstanceOf(IllegalLogicalTimestampException.class);
+    }
+
+    @Test
+    public void testReportThrowsOnReader() throws Exception
+    {
+        FrozenTimestampTracker tracker = new CollectionBasedFrozenTimestampTracker();
+
+        tracker.advanceFrozenTimestamp(10);
+
+        AutoCloseable closeable = tracker.checkAndLockForMutation(15);
+
+        assertThatThrownBy(() -> tracker.advanceFrozenTimestamp(20)).isInstanceOf(InProgressMutationConflictException.class);
+
+        closeable.close();
+
+        tracker.advanceFrozenTimestamp(20);
+    }
+
+    @Test
+    public void testReportThrowsOnMultipleReaders() throws Exception
+    {
+        FrozenTimestampTracker tracker = new CollectionBasedFrozenTimestampTracker();
+
+        tracker.advanceFrozenTimestamp(10);
+
+        AutoCloseable closeable = tracker.checkAndLockForMutation(15);
+        AutoCloseable closeable2 = tracker.checkAndLockForMutation(16);
+
+        assertThatThrownBy(() -> tracker.advanceFrozenTimestamp(20)).isInstanceOf(InProgressMutationConflictException.class);
+
+        closeable.close();
+
+        assertThatThrownBy(() -> tracker.advanceFrozenTimestamp(20)).isInstanceOf(InProgressMutationConflictException.class);
+
+        closeable2.close();
+
+        tracker.advanceFrozenTimestamp(20);
+    }
+}


### PR DESCRIPTION
This PR contains a draft implementation of changes described in the following RFC.

Notable interfaces are
- `FrozenTimestampTracker` - responsible for tracking the frozen timestamp of a single namespace
- `MutationVerifier` - Maintains a `FrozenTimestampTracker` per keyspace, and provides methods for verifying mutations.

https://pl.ntr/guarding-writes