### PR TITLE
Remove commons-codec

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -368,7 +368,6 @@
           <dependency groupId="com.google.guava" artifactId="guava" version="33.1.0-jre"/>
           <dependency groupId="com.github.luben" artifactId="zstd-jni" version="1.5.0-4"/>
           <dependency groupId="commons-cli" artifactId="commons-cli" version="1.1"/>
-          <dependency groupId="commons-codec" artifactId="commons-codec" version="1.2"/>
           <dependency groupId="org.apache.commons" artifactId="commons-lang3" version="3.1"/>
           <dependency groupId="org.apache.commons" artifactId="commons-math3" version="3.2"/>
           <dependency groupId="com.googlecode.concurrentlinkedhashmap" artifactId="concurrentlinkedhashmap-lru" version="1.4"/>
@@ -612,7 +611,6 @@
         <dependency groupId="com.ning" artifactId="compress-lzf"/>
         <dependency groupId="com.google.guava" artifactId="guava"/>
         <dependency groupId="commons-cli" artifactId="commons-cli"/>
-        <dependency groupId="commons-codec" artifactId="commons-codec"/>
         <dependency groupId="org.apache.commons" artifactId="commons-lang3"/>
         <dependency groupId="org.apache.commons" artifactId="commons-math3"/>
         <dependency groupId="com.googlecode.concurrentlinkedhashmap" artifactId="concurrentlinkedhashmap-lru"/>


### PR DESCRIPTION
# Description

`commons-codec` 1.2 has [vulnerability](https://issues.apache.org/jira/browse/CODEC-114), which is resolved in 1.5. During investigation, I found that we don't use this package directly. In fact, Cassandra 5 removes this [dependency](https://issues.apache.org/jira/browse/CASSANDRA-18772). The closest usage I found for `commons-codec` is for metrics-reporter in [Cassandra 3](https://issues.apache.org/jira/browse/CASSANDRA-12790) - however, upon inspecting Cassandra startup flags, I don't see any usage of `-Dcassandra.metricsReporterConfigFile`.

I've confirmed that logs and metrics are still shipped with an RC.