### PR TITLE
Reduce schema pull request volume

### DIFF
--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -31,8 +31,9 @@ import com.palantir.tracing.CloseableTracer;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
-import java.util.function.BiFunction;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +66,8 @@ public class MigrationManager
 
     private static final RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
 
-    private static final ConcurrentHashMap<UUID, Set<InetAddress>> scheduledSchemaPulls = new ConcurrentHashMap<>();
+    @VisibleForTesting
+    static final ConcurrentHashMap<UUID, Set<InetAddress>> scheduledSchemaPulls = new ConcurrentHashMap<>();
 
     public static final int MIGRATION_DELAY_IN_MS = 60000;
     public static final int MAX_SCHEDULED_SCHEMA_PULL_REQUESTS = 3;
@@ -173,9 +175,17 @@ public class MigrationManager
                     submitMigrationTask(endpoint, currentVersion);
                 }
             };
-            scheduledSchemaPulls.computeIfAbsent(theirVersion, v -> new HashSet<>()).add(endpoint);
+            addEndointToSchemaPullVersion(theirVersion, endpoint);
             ScheduledExecutors.nonPeriodicTasks.schedule(runnable, MIGRATION_DELAY_IN_MS, TimeUnit.MILLISECONDS);
         }
+    }
+
+    public static void addEndointToSchemaPullVersion(UUID version, InetAddress endpoint) {
+        scheduledSchemaPulls.putIfAbsent(version, new HashSet<>());
+        scheduledSchemaPulls.computeIfPresent(version, (v, s) -> {
+            s.add(endpoint);
+            return s;
+        });
     }
 
     public static void removeEndpointFromSchemaPullVersion(UUID version, InetAddress endpoint) {

--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -25,6 +25,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.*;
+
+import com.palantir.logsafe.SafeArg;
 import com.palantir.tracing.CloseableTracer;
 
 import java.lang.management.ManagementFactory;
@@ -165,9 +167,9 @@ public class MigrationManager
                         return;
                     }
                     logger.debug("submitting migration task for endpoint {}, endpoint schema version {}, and our schema version {}",
-                            endpoint,
-                            currentVersion,
-                            Schema.instance.getVersion());
+                            SafeArg.of("endpoint", endpoint),
+                            SafeArg.of("endpointVersion", currentVersion),
+                            SafeArg.of("schemaVersion", Schema.instance.getVersion()));
                     submitMigrationTask(endpoint, currentVersion);
                 }
             };
@@ -178,7 +180,10 @@ public class MigrationManager
 
     static BiFunction<UUID, Set<InetAddress>, Set<InetAddress>> removeEndpointFromSchemaPulls(InetAddress endpoint) {
         return (v, s) -> {
-            logger.debug("Removing endpoint from scheduled schema pulls {}: {} ({})", endpoint, v, s);
+            logger.debug("Removing endpoint from scheduled schema pulls",
+                         SafeArg.of("endpoint", endpoint),
+                         SafeArg.of("schemaVersion", v),
+                         SafeArg.of("scheduledPulls", s));
             s.remove(endpoint);
             if (!s.isEmpty()) {
                 return s;
@@ -211,7 +216,7 @@ public class MigrationManager
     public static boolean shouldPullSchemaFrom(InetAddress endpoint)
     {
         /*
-         * Don't request schema from nodes with a differnt or unknonw major version (may have incompatible schema)
+         * Don't request schema from nodes with a differnt or unknown major version (may have incompatible schema)
          * Don't request schema from fat clients
          */
         return MessagingService.instance().knowsVersion(endpoint)
@@ -222,7 +227,7 @@ public class MigrationManager
     public static boolean shouldPullSchemaFrom(InetAddress endpoint, UUID theirVersion)
     {
         /*
-         * Don't request schema from nodes with a differnt or unknonw major version (may have incompatible schema)
+         * Don't request schema from nodes with a differnt or unknown major version (may have incompatible schema)
          * Don't request schema from fat clients
          * Don't request schema from bootstrapping nodes (?)
          * Don't request schema if we have scheduled a pull request for that schema version
@@ -230,7 +235,7 @@ public class MigrationManager
         Set<InetAddress> currentlyScheduledRequests = scheduledSchemaPulls.getOrDefault(theirVersion, Collections.emptySet());
         boolean noScheduledRequests = currentlyScheduledRequests.size() < MAX_SCHEDULED_SCHEMA_PULL_REQUESTS
                                       && !currentlyScheduledRequests.contains(endpoint);
-        logger.debug("Evaluating schema pull criteria: currently scheduled requests for version {}: {}", theirVersion, currentlyScheduledRequests);
+        logger.debug("Evaluating schema pull criteria", SafeArg.of("schemaVersion", theirVersion), SafeArg.of("scheduledPulls", currentlyScheduledRequests));
         return MessagingService.instance().knowsVersion(endpoint)
                && MessagingService.instance().getRawVersion(endpoint) == MessagingService.current_version
                && !Gossiper.instance.isGossipOnlyMember(endpoint)

--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -62,10 +62,13 @@ public class MigrationManager
 
     private static final RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
 
+    public static final Set<UUID> outstandingSchemaPulls = new ConcurrentSkipListSet<>();
+
     public static final int MIGRATION_DELAY_IN_MS = 60000;
 
     private final List<MigrationListener> listeners = new CopyOnWriteArrayList<>();
-    
+
+
     private MigrationManager() {}
 
     public void register(MigrationListener listener)
@@ -103,7 +106,7 @@ public class MigrationManager
             return;
         }
 
-        if ((Schema.instance.getVersion() != null && Schema.instance.getVersion().equals(theirVersion)) || !shouldPullSchemaFrom(endpoint))
+        if ((Schema.instance.getVersion() != null && Schema.instance.getVersion().equals(theirVersion)) || !shouldPullSchemaFrom(endpoint, theirVersion))
         {
             logger.debug("Not pulling schema because versions match or shouldPullSchemaFrom returned false");
             return;
@@ -113,7 +116,7 @@ public class MigrationManager
         {
             // If we think we may be bootstrapping or have recently started, submit MigrationTask immediately
             logger.debug("Submitting migration task for {}", endpoint);
-            submitMigrationTask(endpoint);
+            submitMigrationTask(endpoint, theirVersion);
         }
 
         if (onChange && Boolean.getBoolean("palantir_cassandra.unsafe_schema_migration"))
@@ -161,7 +164,7 @@ public class MigrationManager
                             endpoint,
                             currentVersion,
                             Schema.instance.getVersion());
-                    submitMigrationTask(endpoint);
+                    submitMigrationTask(endpoint, currentVersion);
                 }
             };
             ScheduledExecutors.nonPeriodicTasks.schedule(runnable, MIGRATION_DELAY_IN_MS, TimeUnit.MILLISECONDS);
@@ -177,6 +180,19 @@ public class MigrationManager
         return StageManager.getStage(Stage.MIGRATION).submit(new MigrationTask(endpoint));
     }
 
+    /**
+     *
+     */
+    private static Future<?> submitMigrationTask(InetAddress endpoint, UUID theirVersion)
+    {
+        /*
+         * Do not de-ref the future because that causes distributed deadlock (CASSANDRA-3832) because we are
+         * running in the gossip stage.
+         */
+        outstandingSchemaPulls.add(theirVersion);
+        return StageManager.getStage(Stage.MIGRATION).submit(new MigrationTask(endpoint, theirVersion));
+    }
+
     public static boolean shouldPullSchemaFrom(InetAddress endpoint)
     {
         /*
@@ -186,6 +202,21 @@ public class MigrationManager
         return MessagingService.instance().knowsVersion(endpoint)
                 && MessagingService.instance().getRawVersion(endpoint) == MessagingService.current_version
                 && !Gossiper.instance.isGossipOnlyMember(endpoint);
+    }
+
+    public static boolean shouldPullSchemaFrom(InetAddress endpoint, UUID theirVersion)
+    {
+        /*
+         * Don't request schema from nodes with a differnt or unknonw major version (may have incompatible schema)
+         * Don't request schema from fat clients
+         * Don't request schema from bootstrapping nodes (?)
+         * Don't request schema if we have an outstanding request for that schema version
+         */
+        return MessagingService.instance().knowsVersion(endpoint)
+               && MessagingService.instance().getRawVersion(endpoint) == MessagingService.current_version
+               && !Gossiper.instance.isGossipOnlyMember(endpoint)
+               && !Schema.emptyVersion.equals(theirVersion)
+               && !outstandingSchemaPulls.contains(theirVersion);
     }
 
     public static boolean isReadyForBootstrap()

--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -31,9 +31,7 @@ import com.palantir.tracing.CloseableTracer;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
-import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,14 +172,16 @@ public class MigrationManager
                     submitMigrationTask(endpoint, currentVersion);
                 }
             };
-            addEndointToSchemaPullVersion(theirVersion, endpoint);
+            addEndpointToSchemaPullVersion(theirVersion, endpoint);
             ScheduledExecutors.nonPeriodicTasks.schedule(runnable, MIGRATION_DELAY_IN_MS, TimeUnit.MILLISECONDS);
         }
     }
 
-    public static void addEndointToSchemaPullVersion(UUID version, InetAddress endpoint) {
-        scheduledSchemaPulls.putIfAbsent(version, new HashSet<>());
-        scheduledSchemaPulls.computeIfPresent(version, (v, s) -> {
+    public static void addEndpointToSchemaPullVersion(UUID version, InetAddress endpoint) {
+        scheduledSchemaPulls.compute(version, (v, s) -> {
+            if (s == null) {
+                s = new HashSet<>();
+            }
             s.add(endpoint);
             return s;
         });

--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -66,8 +66,7 @@ public class MigrationManager
 
     private static final RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
 
-    @VisibleForTesting
-    static final ConcurrentHashMap<UUID, Set<InetAddress>> scheduledSchemaPulls = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<UUID, Set<InetAddress>> scheduledSchemaPulls = new ConcurrentHashMap<>();
 
     public static final int MIGRATION_DELAY_IN_MS = 60000;
     public static final int MAX_SCHEDULED_SCHEMA_PULL_REQUESTS = 3;

--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -25,11 +25,16 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.*;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ConcurrentHashMultiset;
 import com.palantir.tracing.CloseableTracer;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 
+import org.cliffc.high_scale_lib.ConcurrentAutoTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,9 +67,10 @@ public class MigrationManager
 
     private static final RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
 
-    public static final Set<UUID> scheduledSchemaPulls = new ConcurrentSkipListSet<>();
+    public static final ConcurrentHashMap<UUID, Set<InetAddress>> scheduledSchemaPulls = new ConcurrentHashMap<>();
 
     public static final int MIGRATION_DELAY_IN_MS = 60000;
+    public static final int MAX_SCHEDULED_SCHEMA_PULL_REQUESTS = 3;
 
     private final List<MigrationListener> listeners = new CopyOnWriteArrayList<>();
 
@@ -139,7 +145,14 @@ public class MigrationManager
                     if (epState == null)
                     {
                         logger.debug("epState vanished for {}, not submitting migration task", endpoint);
-                        scheduledSchemaPulls.remove(theirVersion);
+                        scheduledSchemaPulls.computeIfPresent(theirVersion, (v, s) -> {
+                            logger.debug("Removing endpoint from scheduled schema pulls {}: {} ({})", endpoint, theirVersion, s);
+                            s.remove(endpoint);
+                            if (!s.isEmpty()) {
+                                return s;
+                            }
+                            return null;
+                        });
                         return;
                     }
                     VersionedValue value = epState.getApplicationState(ApplicationState.SCHEMA);
@@ -153,14 +166,28 @@ public class MigrationManager
                                 endpoint,
                                 theirVersion,
                                 currentVersion);
-                        scheduledSchemaPulls.remove(theirVersion);
+                        scheduledSchemaPulls.computeIfPresent(theirVersion, (v, s) -> {
+                            logger.debug("Removing endpoint from scheduled schema pulls {}: {} ({})", endpoint, theirVersion, s);
+                            s.remove(endpoint);
+                            if (!s.isEmpty()) {
+                                return s;
+                            }
+                            return null;
+                        });
                         return;
                     }
 
                     if (Schema.instance.getVersion().equals(currentVersion))
                     {
                         logger.debug("not submitting migration task for {} because our versions match", endpoint);
-                        scheduledSchemaPulls.remove(theirVersion);
+                        scheduledSchemaPulls.computeIfPresent(theirVersion, (v, s) -> {
+                            logger.debug("Removing endpoint from scheduled schema pulls {}: {} ({})", endpoint, theirVersion, s);
+                            s.remove(endpoint);
+                            if (!s.isEmpty()) {
+                                return s;
+                            }
+                            return null;
+                        });
                         return;
                     }
                     logger.debug("submitting migration task for endpoint {}, endpoint schema version {}, and our schema version {}",
@@ -170,7 +197,7 @@ public class MigrationManager
                     submitMigrationTask(endpoint, currentVersion);
                 }
             };
-            scheduledSchemaPulls.add(theirVersion);
+            scheduledSchemaPulls.computeIfAbsent(theirVersion, v -> new ConcurrentSkipListSet<>()).add(endpoint);
             ScheduledExecutors.nonPeriodicTasks.schedule(runnable, MIGRATION_DELAY_IN_MS, TimeUnit.MILLISECONDS);
         }
     }
@@ -215,13 +242,14 @@ public class MigrationManager
          * Don't request schema from bootstrapping nodes (?)
          * Don't request schema if we have scheduled a pull request for that schema version
          */
-        boolean isOtherSchemaNonEmpty = !Schema.emptyVersion.equals(theirVersion);
-        boolean noScheduledRequests = !scheduledSchemaPulls.contains(theirVersion);
-        logger.debug("Evaluating schema pull criteria: other schema empty {}, no scheduled requests {}", isOtherSchemaNonEmpty, noScheduledRequests);
+        Set<InetAddress> currentlyScheduledRequests = scheduledSchemaPulls.getOrDefault(theirVersion, Collections.emptySet());
+        boolean noScheduledRequests = currentlyScheduledRequests.size() <= MAX_SCHEDULED_SCHEMA_PULL_REQUESTS
+                                      && !currentlyScheduledRequests.contains(endpoint);
+        logger.debug("Evaluating schema pull criteria: currently scheduled requests for version {}: {}", theirVersion, currentlyScheduledRequests);
         return MessagingService.instance().knowsVersion(endpoint)
                && MessagingService.instance().getRawVersion(endpoint) == MessagingService.current_version
                && !Gossiper.instance.isGossipOnlyMember(endpoint)
-               && isOtherSchemaNonEmpty
+               && !Schema.emptyVersion.equals(theirVersion)
                && noScheduledRequests;
     }
 

--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -26,15 +26,12 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.*;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.ConcurrentHashMultiset;
 import com.palantir.tracing.CloseableTracer;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
+import java.util.function.BiFunction;
 
-import org.cliffc.high_scale_lib.ConcurrentAutoTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -145,14 +142,7 @@ public class MigrationManager
                     if (epState == null)
                     {
                         logger.debug("epState vanished for {}, not submitting migration task", endpoint);
-                        scheduledSchemaPulls.computeIfPresent(theirVersion, (v, s) -> {
-                            logger.debug("Removing endpoint from scheduled schema pulls {}: {} ({})", endpoint, theirVersion, s);
-                            s.remove(endpoint);
-                            if (!s.isEmpty()) {
-                                return s;
-                            }
-                            return null;
-                        });
+                        scheduledSchemaPulls.computeIfPresent(theirVersion, removeEndpointFromSchemaPulls(endpoint));
                         return;
                     }
                     VersionedValue value = epState.getApplicationState(ApplicationState.SCHEMA);
@@ -166,28 +156,14 @@ public class MigrationManager
                                 endpoint,
                                 theirVersion,
                                 currentVersion);
-                        scheduledSchemaPulls.computeIfPresent(theirVersion, (v, s) -> {
-                            logger.debug("Removing endpoint from scheduled schema pulls {}: {} ({})", endpoint, theirVersion, s);
-                            s.remove(endpoint);
-                            if (!s.isEmpty()) {
-                                return s;
-                            }
-                            return null;
-                        });
+                        scheduledSchemaPulls.computeIfPresent(theirVersion, removeEndpointFromSchemaPulls(endpoint));
                         return;
                     }
 
                     if (Schema.instance.getVersion().equals(currentVersion))
                     {
                         logger.debug("not submitting migration task for {} because our versions match", endpoint);
-                        scheduledSchemaPulls.computeIfPresent(theirVersion, (v, s) -> {
-                            logger.debug("Removing endpoint from scheduled schema pulls {}: {} ({})", endpoint, theirVersion, s);
-                            s.remove(endpoint);
-                            if (!s.isEmpty()) {
-                                return s;
-                            }
-                            return null;
-                        });
+                        scheduledSchemaPulls.computeIfPresent(theirVersion, removeEndpointFromSchemaPulls(endpoint));
                         return;
                     }
                     logger.debug("submitting migration task for endpoint {}, endpoint schema version {}, and our schema version {}",
@@ -197,9 +173,20 @@ public class MigrationManager
                     submitMigrationTask(endpoint, currentVersion);
                 }
             };
-            scheduledSchemaPulls.computeIfAbsent(theirVersion, v -> new ConcurrentSkipListSet<>()).add(endpoint);
+            scheduledSchemaPulls.computeIfAbsent(theirVersion, v -> new HashSet<>()).add(endpoint);
             ScheduledExecutors.nonPeriodicTasks.schedule(runnable, MIGRATION_DELAY_IN_MS, TimeUnit.MILLISECONDS);
         }
+    }
+
+    private static BiFunction<UUID, Set<InetAddress>, Set<InetAddress>> removeEndpointFromSchemaPulls(InetAddress endpoint) {
+        return (v, s) -> {
+            logger.debug("Removing endpoint from scheduled schema pulls {}: {} ({})", endpoint, v, s);
+            s.remove(endpoint);
+            if (!s.isEmpty()) {
+                return s;
+            }
+            return null;
+        };
     }
 
     private static Future<?> submitMigrationTask(InetAddress endpoint)

--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -160,7 +160,7 @@ public class MigrationManager
                         logger.debug("not submitting migration task for {} because our versions match", endpoint);
                         return;
                     }
-                    logger.debug("submitting migration task for endpoint {}, endpoint schema version {}, and our schema version",
+                    logger.debug("submitting migration task for endpoint {}, endpoint schema version {}, and our schema version {}",
                             endpoint,
                             currentVersion,
                             Schema.instance.getVersion());
@@ -212,11 +212,14 @@ public class MigrationManager
          * Don't request schema from bootstrapping nodes (?)
          * Don't request schema if we have an outstanding request for that schema version
          */
+        boolean isOtherSchemaNonEmpty = !Schema.emptyVersion.equals(theirVersion);
+        boolean noOutstandingRequests = !outstandingSchemaPulls.contains(theirVersion);
+        logger.debug("Evaluating schema pull criteria: other schema empty {}, no outstanding requests {}", isOtherSchemaNonEmpty, outstandingSchemaPulls);
         return MessagingService.instance().knowsVersion(endpoint)
                && MessagingService.instance().getRawVersion(endpoint) == MessagingService.current_version
                && !Gossiper.instance.isGossipOnlyMember(endpoint)
-               && !Schema.emptyVersion.equals(theirVersion)
-               && !outstandingSchemaPulls.contains(theirVersion);
+               && isOtherSchemaNonEmpty
+               && noOutstandingRequests;
     }
 
     public static boolean isReadyForBootstrap()

--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -62,7 +62,7 @@ public class MigrationManager
 
     private static final RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
 
-    public static final Set<UUID> outstandingSchemaPulls = new ConcurrentSkipListSet<>();
+    public static final Set<UUID> scheduledSchemaPulls = new ConcurrentSkipListSet<>();
 
     public static final int MIGRATION_DELAY_IN_MS = 60000;
 
@@ -139,6 +139,7 @@ public class MigrationManager
                     if (epState == null)
                     {
                         logger.debug("epState vanished for {}, not submitting migration task", endpoint);
+                        scheduledSchemaPulls.remove(theirVersion);
                         return;
                     }
                     VersionedValue value = epState.getApplicationState(ApplicationState.SCHEMA);
@@ -152,12 +153,14 @@ public class MigrationManager
                                 endpoint,
                                 theirVersion,
                                 currentVersion);
+                        scheduledSchemaPulls.remove(theirVersion);
                         return;
                     }
 
                     if (Schema.instance.getVersion().equals(currentVersion))
                     {
                         logger.debug("not submitting migration task for {} because our versions match", endpoint);
+                        scheduledSchemaPulls.remove(theirVersion);
                         return;
                     }
                     logger.debug("submitting migration task for endpoint {}, endpoint schema version {}, and our schema version {}",
@@ -167,6 +170,7 @@ public class MigrationManager
                     submitMigrationTask(endpoint, currentVersion);
                 }
             };
+            scheduledSchemaPulls.add(theirVersion);
             ScheduledExecutors.nonPeriodicTasks.schedule(runnable, MIGRATION_DELAY_IN_MS, TimeUnit.MILLISECONDS);
         }
     }
@@ -189,7 +193,6 @@ public class MigrationManager
          * Do not de-ref the future because that causes distributed deadlock (CASSANDRA-3832) because we are
          * running in the gossip stage.
          */
-        outstandingSchemaPulls.add(theirVersion);
         return StageManager.getStage(Stage.MIGRATION).submit(new MigrationTask(endpoint, theirVersion));
     }
 
@@ -210,16 +213,16 @@ public class MigrationManager
          * Don't request schema from nodes with a differnt or unknonw major version (may have incompatible schema)
          * Don't request schema from fat clients
          * Don't request schema from bootstrapping nodes (?)
-         * Don't request schema if we have an outstanding request for that schema version
+         * Don't request schema if we have scheduled a pull request for that schema version
          */
         boolean isOtherSchemaNonEmpty = !Schema.emptyVersion.equals(theirVersion);
-        boolean noOutstandingRequests = !outstandingSchemaPulls.contains(theirVersion);
-        logger.debug("Evaluating schema pull criteria: other schema empty {}, no outstanding requests {}", isOtherSchemaNonEmpty, outstandingSchemaPulls);
+        boolean noScheduledRequests = !scheduledSchemaPulls.contains(theirVersion);
+        logger.debug("Evaluating schema pull criteria: other schema empty {}, no scheduled requests {}", isOtherSchemaNonEmpty, noScheduledRequests);
         return MessagingService.instance().knowsVersion(endpoint)
                && MessagingService.instance().getRawVersion(endpoint) == MessagingService.current_version
                && !Gossiper.instance.isGossipOnlyMember(endpoint)
                && isOtherSchemaNonEmpty
-               && noOutstandingRequests;
+               && noScheduledRequests;
     }
 
     public static boolean isReadyForBootstrap()

--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -65,7 +65,7 @@ public class MigrationManager
 
     private static final RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
 
-    public static final ConcurrentHashMap<UUID, Set<InetAddress>> scheduledSchemaPulls = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<UUID, Set<InetAddress>> scheduledSchemaPulls = new ConcurrentHashMap<>();
 
     public static final int MIGRATION_DELAY_IN_MS = 60000;
     public static final int MAX_SCHEDULED_SCHEMA_PULL_REQUESTS = 3;
@@ -142,7 +142,7 @@ public class MigrationManager
                     if (epState == null)
                     {
                         logger.debug("epState vanished for {}, not submitting migration task", endpoint);
-                        scheduledSchemaPulls.computeIfPresent(theirVersion, removeEndpointFromSchemaPulls(endpoint));
+                        removeEndpointFromSchemaPullVersion(theirVersion, endpoint);
                         return;
                     }
                     VersionedValue value = epState.getApplicationState(ApplicationState.SCHEMA);
@@ -156,14 +156,14 @@ public class MigrationManager
                                 endpoint,
                                 theirVersion,
                                 currentVersion);
-                        scheduledSchemaPulls.computeIfPresent(theirVersion, removeEndpointFromSchemaPulls(endpoint));
+                        removeEndpointFromSchemaPullVersion(theirVersion, endpoint);
                         return;
                     }
 
                     if (Schema.instance.getVersion().equals(currentVersion))
                     {
                         logger.debug("not submitting migration task for {} because our versions match", endpoint);
-                        scheduledSchemaPulls.computeIfPresent(theirVersion, removeEndpointFromSchemaPulls(endpoint));
+                        removeEndpointFromSchemaPullVersion(theirVersion, endpoint);
                         return;
                     }
                     logger.debug("submitting migration task for endpoint {}, endpoint schema version {}, and our schema version {}",
@@ -178,8 +178,8 @@ public class MigrationManager
         }
     }
 
-    static BiFunction<UUID, Set<InetAddress>, Set<InetAddress>> removeEndpointFromSchemaPulls(InetAddress endpoint) {
-        return (v, s) -> {
+    public static void removeEndpointFromSchemaPullVersion(UUID version, InetAddress endpoint) {
+        scheduledSchemaPulls.computeIfPresent(version, (v, s) -> {
             logger.debug("Removing endpoint from scheduled schema pulls",
                          SafeArg.of("endpoint", endpoint),
                          SafeArg.of("schemaVersion", v),
@@ -189,7 +189,7 @@ public class MigrationManager
                 return s;
             }
             return null;
-        };
+        });
     }
 
     private static Future<?> submitMigrationTask(InetAddress endpoint)
@@ -235,7 +235,6 @@ public class MigrationManager
         Set<InetAddress> currentlyScheduledRequests = scheduledSchemaPulls.getOrDefault(theirVersion, Collections.emptySet());
         boolean noScheduledRequests = currentlyScheduledRequests.size() < MAX_SCHEDULED_SCHEMA_PULL_REQUESTS
                                       && !currentlyScheduledRequests.contains(endpoint);
-        logger.debug("Evaluating schema pull criteria", SafeArg.of("schemaVersion", theirVersion), SafeArg.of("scheduledPulls", currentlyScheduledRequests));
         return MessagingService.instance().knowsVersion(endpoint)
                && MessagingService.instance().getRawVersion(endpoint) == MessagingService.current_version
                && !Gossiper.instance.isGossipOnlyMember(endpoint)

--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -25,7 +25,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.*;
-
 import com.palantir.tracing.CloseableTracer;
 
 import java.lang.management.ManagementFactory;
@@ -70,7 +69,6 @@ public class MigrationManager
     public static final int MAX_SCHEDULED_SCHEMA_PULL_REQUESTS = 3;
 
     private final List<MigrationListener> listeners = new CopyOnWriteArrayList<>();
-
 
     private MigrationManager() {}
 
@@ -178,7 +176,7 @@ public class MigrationManager
         }
     }
 
-    private static BiFunction<UUID, Set<InetAddress>, Set<InetAddress>> removeEndpointFromSchemaPulls(InetAddress endpoint) {
+    static BiFunction<UUID, Set<InetAddress>, Set<InetAddress>> removeEndpointFromSchemaPulls(InetAddress endpoint) {
         return (v, s) -> {
             logger.debug("Removing endpoint from scheduled schema pulls {}: {} ({})", endpoint, v, s);
             s.remove(endpoint);
@@ -230,7 +228,7 @@ public class MigrationManager
          * Don't request schema if we have scheduled a pull request for that schema version
          */
         Set<InetAddress> currentlyScheduledRequests = scheduledSchemaPulls.getOrDefault(theirVersion, Collections.emptySet());
-        boolean noScheduledRequests = currentlyScheduledRequests.size() <= MAX_SCHEDULED_SCHEMA_PULL_REQUESTS
+        boolean noScheduledRequests = currentlyScheduledRequests.size() < MAX_SCHEDULED_SCHEMA_PULL_REQUESTS
                                       && !currentlyScheduledRequests.contains(endpoint);
         logger.debug("Evaluating schema pull criteria: currently scheduled requests for version {}: {}", theirVersion, currentlyScheduledRequests);
         return MessagingService.instance().knowsVersion(endpoint)

--- a/src/java/org/apache/cassandra/service/MigrationTask.java
+++ b/src/java/org/apache/cassandra/service/MigrationTask.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.net.IAsyncCallbackWithFailure;
@@ -83,15 +84,13 @@ class MigrationTask extends WrappedRunnable
             {
                 try
                 {
-                    // TODO: testing always failed merges
-                    //LegacySchemaTables.mergeSchema(message.payload);
+                    logger.debug("Processing response to schema pull from endpoint", SafeArg.of("endpoint", endpoint));
+                    LegacySchemaTables.mergeSchema(message.payload);
                 }
-                /*
                 catch (IOException e)
                 {
                     logger.error("IOException merging remote schema", e);
                 }
-                */
                 catch (ConfigurationException e)
                 {
                     logger.error("Configuration exception merging remote schema", e);
@@ -100,7 +99,9 @@ class MigrationTask extends WrappedRunnable
                 {
                     // always attempt to clean up our outstanding schema pull request if created with a version
                     version.ifPresent(v -> {
-                        logger.debug("Successfully processed response to schema pull, removing endpoint from scheduled schema pulls {}: {}", endpoint, v);
+                        logger.debug("Successfully processed response to schema pull",
+                                     SafeArg.of("endpoint", endpoint),
+                                     SafeArg.of("schemaVersion", v));
                         MigrationManager.scheduledSchemaPulls.computeIfPresent(v, MigrationManager.removeEndpointFromSchemaPulls(endpoint));
                     });
                 }
@@ -111,7 +112,9 @@ class MigrationTask extends WrappedRunnable
             {
                 // always attempt to clean up our outstanding schema pull request if created with a version
                 version.ifPresent(v -> {
-                    logger.debug("Timed out waiting for response to schema pull, removing endpoint from scheduled schema pulls {}: {}", endpoint, v);
+                    logger.debug("Timed out waiting for response to schema pull",
+                                 SafeArg.of("endpoint", endpoint),
+                                 SafeArg.of("schemaVersion", v));
                     MigrationManager.scheduledSchemaPulls.computeIfPresent(v, MigrationManager.removeEndpointFromSchemaPulls(endpoint));
                 });
             }

--- a/src/java/org/apache/cassandra/service/MigrationTask.java
+++ b/src/java/org/apache/cassandra/service/MigrationTask.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.service;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,55 +42,71 @@ class MigrationTask extends WrappedRunnable
     private static final Logger logger = LoggerFactory.getLogger(MigrationTask.class);
 
     private final InetAddress endpoint;
+    private final Optional<UUID> version;
 
     MigrationTask(InetAddress endpoint)
     {
         this.endpoint = endpoint;
+        this.version = Optional.empty();
+    }
+
+    MigrationTask(InetAddress endpoint, UUID version)
+    {
+        this.endpoint = endpoint;
+        this.version = Optional.of(version);
     }
 
     public void runMayThrow() throws Exception
     {
-        if (!FailureDetector.instance.isAlive(endpoint))
+        try
         {
-            logger.warn("Can't send schema pull request: node {} is down.", endpoint);
-            return;
-        }
-
-        // There is a chance that quite some time could have passed between now and the MM#maybeScheduleSchemaPull(),
-        // potentially enough for the endpoint node to restart - which is an issue if it does restart upgraded, with
-        // a higher major.
-        if (!MigrationManager.shouldPullSchemaFrom(endpoint))
-        {
-            logger.info("Skipped sending a migration request: node {} has a higher major version now.", endpoint);
-            return;
-        }
-
-        MessageOut message = new MessageOut<>(MessagingService.Verb.MIGRATION_REQUEST, null, MigrationManager.MigrationsSerializer.instance);
-
-        IAsyncCallback<Collection<Mutation>> cb = new IAsyncCallback<Collection<Mutation>>()
-        {
-            @Override
-            public void response(MessageIn<Collection<Mutation>> message)
+            if (!FailureDetector.instance.isAlive(endpoint))
             {
-                try
-                {
-                    LegacySchemaTables.mergeSchema(message.payload);
-                }
-                catch (IOException e)
-                {
-                    logger.error("IOException merging remote schema", e);
-                }
-                catch (ConfigurationException e)
-                {
-                    logger.error("Configuration exception merging remote schema", e);
-                }
+                logger.warn("Can't send schema pull request: node {} is down.", endpoint);
+                return;
             }
 
-            public boolean isLatencyForSnitch()
+            // There is a chance that quite some time could have passed between now and the MM#maybeScheduleSchemaPull(),
+            // potentially enough for the endpoint node to restart - which is an issue if it does restart upgraded, with
+            // a higher major.
+            if (!MigrationManager.shouldPullSchemaFrom(endpoint))
             {
-                return false;
+                logger.info("Skipped sending a migration request: node {} has a higher major version now.", endpoint);
+                return;
             }
-        };
-        MessagingService.instance().sendRR(message, endpoint, cb);
+
+            MessageOut message = new MessageOut<>(MessagingService.Verb.MIGRATION_REQUEST, null, MigrationManager.MigrationsSerializer.instance);
+
+            IAsyncCallback<Collection<Mutation>> cb = new IAsyncCallback<Collection<Mutation>>()
+            {
+                @Override
+                public void response(MessageIn<Collection<Mutation>> message)
+                {
+                    try
+                    {
+                        LegacySchemaTables.mergeSchema(message.payload);
+                    }
+                    catch (IOException e)
+                    {
+                        logger.error("IOException merging remote schema", e);
+                    }
+                    catch (ConfigurationException e)
+                    {
+                        logger.error("Configuration exception merging remote schema", e);
+                    }
+                }
+
+                public boolean isLatencyForSnitch()
+                {
+                    return false;
+                }
+            };
+            MessagingService.instance().sendRR(message, endpoint, cb);
+        }
+        finally
+        {
+            // always attempt to clean up our outstanding schema pull request if created with a version
+            version.ifPresent(MigrationManager.outstandingSchemaPulls::remove);
+        }
     }
 }

--- a/src/java/org/apache/cassandra/service/MigrationTask.java
+++ b/src/java/org/apache/cassandra/service/MigrationTask.java
@@ -106,7 +106,7 @@ class MigrationTask extends WrappedRunnable
         finally
         {
             // always attempt to clean up our outstanding schema pull request if created with a version
-            version.ifPresent(MigrationManager.outstandingSchemaPulls::remove);
+            version.ifPresent(MigrationManager.scheduledSchemaPulls::remove);
         }
     }
 }

--- a/src/java/org/apache/cassandra/service/MigrationTask.java
+++ b/src/java/org/apache/cassandra/service/MigrationTask.java
@@ -102,7 +102,7 @@ class MigrationTask extends WrappedRunnable
                         logger.debug("Successfully processed response to schema pull",
                                      SafeArg.of("endpoint", endpoint),
                                      SafeArg.of("schemaVersion", v));
-                        MigrationManager.scheduledSchemaPulls.computeIfPresent(v, MigrationManager.removeEndpointFromSchemaPulls(endpoint));
+                        MigrationManager.removeEndpointFromSchemaPullVersion(v, endpoint);
                     });
                 }
             }
@@ -115,7 +115,7 @@ class MigrationTask extends WrappedRunnable
                     logger.debug("Timed out waiting for response to schema pull",
                                  SafeArg.of("endpoint", endpoint),
                                  SafeArg.of("schemaVersion", v));
-                    MigrationManager.scheduledSchemaPulls.computeIfPresent(v, MigrationManager.removeEndpointFromSchemaPulls(endpoint));
+                    MigrationManager.removeEndpointFromSchemaPullVersion(v, endpoint);
                 });
             }
 

--- a/src/java/org/apache/cassandra/service/MigrationTask.java
+++ b/src/java/org/apache/cassandra/service/MigrationTask.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.net.IAsyncCallbackWithFailure;
 import org.apache.cassandra.schema.LegacySchemaTables;
 import org.apache.cassandra.gms.FailureDetector;
 import org.apache.cassandra.net.IAsyncCallback;
@@ -58,55 +59,73 @@ class MigrationTask extends WrappedRunnable
 
     public void runMayThrow() throws Exception
     {
-        try
+        if (!FailureDetector.instance.isAlive(endpoint))
         {
-            if (!FailureDetector.instance.isAlive(endpoint))
+            logger.warn("Can't send schema pull request: node {} is down.", endpoint);
+            return;
+        }
+
+        // There is a chance that quite some time could have passed between now and the MM#maybeScheduleSchemaPull(),
+        // potentially enough for the endpoint node to restart - which is an issue if it does restart upgraded, with
+        // a higher major.
+        if (!MigrationManager.shouldPullSchemaFrom(endpoint))
+        {
+            logger.info("Skipped sending a migration request: node {} has a higher major version now.", endpoint);
+            return;
+        }
+
+        MessageOut message = new MessageOut<>(MessagingService.Verb.MIGRATION_REQUEST, null, MigrationManager.MigrationsSerializer.instance);
+
+        IAsyncCallbackWithFailure<Collection<Mutation>> cb = new IAsyncCallbackWithFailure<Collection<Mutation>>()
+        {
+            @Override
+            public void response(MessageIn<Collection<Mutation>> message)
             {
-                logger.warn("Can't send schema pull request: node {} is down.", endpoint);
-                return;
+                try
+                {
+                    LegacySchemaTables.mergeSchema(message.payload);
+                }
+                catch (IOException e)
+                {
+                    logger.error("IOException merging remote schema", e);
+                }
+                catch (ConfigurationException e)
+                {
+                    logger.error("Configuration exception merging remote schema", e);
+                }
+                finally
+                {
+                    // always attempt to clean up our outstanding schema pull request if created with a version
+                    version.ifPresent(v -> MigrationManager.scheduledSchemaPulls.computeIfPresent(v, (_v, s) -> {
+                        logger.debug("Successfully processed response to schema pull, removing endpoint from scheduled schema pulls {}: {} ({})", endpoint, v, s);
+                        s.remove(endpoint);
+                        if (!s.isEmpty()) {
+                            return s;
+                        }
+                        return null;
+                    }));
+                }
             }
 
-            // There is a chance that quite some time could have passed between now and the MM#maybeScheduleSchemaPull(),
-            // potentially enough for the endpoint node to restart - which is an issue if it does restart upgraded, with
-            // a higher major.
-            if (!MigrationManager.shouldPullSchemaFrom(endpoint))
+            @Override
+            public void onFailure(InetAddress from)
             {
-                logger.info("Skipped sending a migration request: node {} has a higher major version now.", endpoint);
-                return;
+                // always attempt to clean up our outstanding schema pull request if created with a version
+                version.ifPresent(v -> MigrationManager.scheduledSchemaPulls.computeIfPresent(v, (_v, s) -> {
+                    logger.debug("Timed out waiting for response to schema pull, removing endpoint from scheduled schema pulls {}: {} ({})", endpoint, v, s);
+                    s.remove(endpoint);
+                    if (!s.isEmpty()) {
+                        return s;
+                    }
+                    return null;
+                }));
             }
 
-            MessageOut message = new MessageOut<>(MessagingService.Verb.MIGRATION_REQUEST, null, MigrationManager.MigrationsSerializer.instance);
-
-            IAsyncCallback<Collection<Mutation>> cb = new IAsyncCallback<Collection<Mutation>>()
+            public boolean isLatencyForSnitch()
             {
-                @Override
-                public void response(MessageIn<Collection<Mutation>> message)
-                {
-                    try
-                    {
-                        LegacySchemaTables.mergeSchema(message.payload);
-                    }
-                    catch (IOException e)
-                    {
-                        logger.error("IOException merging remote schema", e);
-                    }
-                    catch (ConfigurationException e)
-                    {
-                        logger.error("Configuration exception merging remote schema", e);
-                    }
-                }
-
-                public boolean isLatencyForSnitch()
-                {
-                    return false;
-                }
-            };
-            MessagingService.instance().sendRR(message, endpoint, cb);
-        }
-        finally
-        {
-            // always attempt to clean up our outstanding schema pull request if created with a version
-            version.ifPresent(MigrationManager.scheduledSchemaPulls::remove);
-        }
-    }
+                return false;
+            }
+        };
+       MessagingService.instance().sendRRWithFailure(message, endpoint, cb);
+   }
 }

--- a/src/java/org/apache/cassandra/service/MigrationTask.java
+++ b/src/java/org/apache/cassandra/service/MigrationTask.java
@@ -83,12 +83,15 @@ class MigrationTask extends WrappedRunnable
             {
                 try
                 {
-                    LegacySchemaTables.mergeSchema(message.payload);
+                    // TODO: testing always failed merges
+                    //LegacySchemaTables.mergeSchema(message.payload);
                 }
+                /*
                 catch (IOException e)
                 {
                     logger.error("IOException merging remote schema", e);
                 }
+                */
                 catch (ConfigurationException e)
                 {
                     logger.error("Configuration exception merging remote schema", e);

--- a/src/java/org/apache/cassandra/service/MigrationTask.java
+++ b/src/java/org/apache/cassandra/service/MigrationTask.java
@@ -96,14 +96,10 @@ class MigrationTask extends WrappedRunnable
                 finally
                 {
                     // always attempt to clean up our outstanding schema pull request if created with a version
-                    version.ifPresent(v -> MigrationManager.scheduledSchemaPulls.computeIfPresent(v, (_v, s) -> {
-                        logger.debug("Successfully processed response to schema pull, removing endpoint from scheduled schema pulls {}: {} ({})", endpoint, v, s);
-                        s.remove(endpoint);
-                        if (!s.isEmpty()) {
-                            return s;
-                        }
-                        return null;
-                    }));
+                    version.ifPresent(v -> {
+                        logger.debug("Successfully processed response to schema pull, removing endpoint from scheduled schema pulls {}: {}", endpoint, v);
+                        MigrationManager.scheduledSchemaPulls.computeIfPresent(v, MigrationManager.removeEndpointFromSchemaPulls(endpoint));
+                    });
                 }
             }
 
@@ -111,14 +107,10 @@ class MigrationTask extends WrappedRunnable
             public void onFailure(InetAddress from)
             {
                 // always attempt to clean up our outstanding schema pull request if created with a version
-                version.ifPresent(v -> MigrationManager.scheduledSchemaPulls.computeIfPresent(v, (_v, s) -> {
-                    logger.debug("Timed out waiting for response to schema pull, removing endpoint from scheduled schema pulls {}: {} ({})", endpoint, v, s);
-                    s.remove(endpoint);
-                    if (!s.isEmpty()) {
-                        return s;
-                    }
-                    return null;
-                }));
+                version.ifPresent(v -> {
+                    logger.debug("Timed out waiting for response to schema pull, removing endpoint from scheduled schema pulls {}: {}", endpoint, v);
+                    MigrationManager.scheduledSchemaPulls.computeIfPresent(v, MigrationManager.removeEndpointFromSchemaPulls(endpoint));
+                });
             }
 
             public boolean isLatencyForSnitch()

--- a/test/unit/org/apache/cassandra/service/MigrationManagerTest.java
+++ b/test/unit/org/apache/cassandra/service/MigrationManagerTest.java
@@ -25,7 +25,6 @@ import java.util.UUID;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.restrictions.MultiColumnRestriction;
 import org.apache.cassandra.net.MessagingService;
 
 import static org.junit.Assert.assertFalse;
@@ -33,7 +32,8 @@ import static org.junit.Assert.assertTrue;
 
 public class MigrationManagerTest
 {
-    private static final UUID uuid = UUID.randomUUID();
+    private static final UUID UUID_1 = UUID.randomUUID();
+    private static final UUID UUID_2 = UUID.randomUUID();
 
     private static InetAddress HOST_1;
     private static InetAddress HOST_2;
@@ -56,20 +56,33 @@ public class MigrationManagerTest
     @Test
     public void shouldPullSchemaIfNoOutstandingRequests()
     {
-        assertTrue(MigrationManager.shouldPullSchemaFrom(HOST_1,uuid));
+        assertTrue(MigrationManager.shouldPullSchemaFrom(HOST_1, UUID_1));
     }
 
     @Test
     public void onlyRequestOncePerEndpointVersion() {
-        MigrationManager.addEndointToSchemaPullVersion(uuid, HOST_1);
-        assertFalse(MigrationManager.shouldPullSchemaFrom(HOST_1, uuid));
+        MigrationManager.addEndointToSchemaPullVersion(UUID_1, HOST_1);
+        assertFalse(MigrationManager.shouldPullSchemaFrom(HOST_1, UUID_1));
+    }
+
+    @Test
+    public void removalAllowsForPull() {
+        MigrationManager.addEndointToSchemaPullVersion(UUID_1, HOST_1);
+        MigrationManager.removeEndpointFromSchemaPullVersion(UUID_1, HOST_1);
+        assertTrue(MigrationManager.shouldPullSchemaFrom(HOST_1, UUID_1));
+    }
+
+    @Test
+    public void multipleSchemaVersionsDontInteract() {
+        MigrationManager.addEndointToSchemaPullVersion(UUID_1, HOST_1);
+        assertTrue(MigrationManager.shouldPullSchemaFrom(HOST_1, UUID_2));
     }
 
     @Test
     public void noRequestOverMaxOutstanding() {
-        MigrationManager.addEndointToSchemaPullVersion(uuid, HOST_1);
-        MigrationManager.addEndointToSchemaPullVersion(uuid, HOST_2);
-        MigrationManager.addEndointToSchemaPullVersion(uuid, HOST_3);
-        assertFalse(MigrationManager.shouldPullSchemaFrom(HOST_4, uuid));
+        MigrationManager.addEndointToSchemaPullVersion(UUID_1, HOST_1);
+        MigrationManager.addEndointToSchemaPullVersion(UUID_1, HOST_2);
+        MigrationManager.addEndointToSchemaPullVersion(UUID_1, HOST_3);
+        assertFalse(MigrationManager.shouldPullSchemaFrom(HOST_4, UUID_1));
     }
 }

--- a/test/unit/org/apache/cassandra/service/MigrationManagerTest.java
+++ b/test/unit/org/apache/cassandra/service/MigrationManagerTest.java
@@ -61,28 +61,28 @@ public class MigrationManagerTest
 
     @Test
     public void onlyRequestOncePerEndpointVersion() {
-        MigrationManager.addEndointToSchemaPullVersion(UUID_1, HOST_1);
+        MigrationManager.addEndpointToSchemaPullVersion(UUID_1, HOST_1);
         assertFalse(MigrationManager.shouldPullSchemaFrom(HOST_1, UUID_1));
     }
 
     @Test
     public void removalAllowsForPull() {
-        MigrationManager.addEndointToSchemaPullVersion(UUID_1, HOST_1);
+        MigrationManager.addEndpointToSchemaPullVersion(UUID_1, HOST_1);
         MigrationManager.removeEndpointFromSchemaPullVersion(UUID_1, HOST_1);
         assertTrue(MigrationManager.shouldPullSchemaFrom(HOST_1, UUID_1));
     }
 
     @Test
     public void multipleSchemaVersionsDontInteract() {
-        MigrationManager.addEndointToSchemaPullVersion(UUID_1, HOST_1);
+        MigrationManager.addEndpointToSchemaPullVersion(UUID_1, HOST_1);
         assertTrue(MigrationManager.shouldPullSchemaFrom(HOST_1, UUID_2));
     }
 
     @Test
     public void noRequestOverMaxOutstanding() {
-        MigrationManager.addEndointToSchemaPullVersion(UUID_1, HOST_1);
-        MigrationManager.addEndointToSchemaPullVersion(UUID_1, HOST_2);
-        MigrationManager.addEndointToSchemaPullVersion(UUID_1, HOST_3);
+        MigrationManager.addEndpointToSchemaPullVersion(UUID_1, HOST_1);
+        MigrationManager.addEndpointToSchemaPullVersion(UUID_1, HOST_2);
+        MigrationManager.addEndpointToSchemaPullVersion(UUID_1, HOST_3);
         assertFalse(MigrationManager.shouldPullSchemaFrom(HOST_4, UUID_1));
     }
 }

--- a/test/unit/org/apache/cassandra/service/MigrationManagerTest.java
+++ b/test/unit/org/apache/cassandra/service/MigrationManagerTest.java
@@ -22,32 +22,54 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.UUID;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import org.apache.cassandra.cql3.restrictions.MultiColumnRestriction;
+import org.apache.cassandra.net.MessagingService;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class MigrationManagerTest
 {
-    @Test
-    public void shouldPullSchemaIfNoOutstandingRequests() throws UnknownHostException
+    private static final UUID uuid = UUID.randomUUID();
+
+    private static InetAddress HOST_1;
+    private static InetAddress HOST_2;
+    private static InetAddress HOST_3;
+    private static InetAddress HOST_4;
+
+    @BeforeClass
+    public static void setup() throws UnknownHostException
     {
-        assertTrue(MigrationManager.shouldPullSchemaFrom(InetAddress.getLocalHost(), UUID.randomUUID()));
+        HOST_1 = InetAddress.getByName("10.0.0.1");
+        HOST_2 = InetAddress.getByName("10.0.0.2");
+        HOST_3 = InetAddress.getByName("10.0.0.3");
+        HOST_4 = InetAddress.getByName("10.0.0.4");
+        MessagingService.instance().setVersion(HOST_1, MessagingService.VERSION_22);
+        MessagingService.instance().setVersion(HOST_2, MessagingService.VERSION_22);
+        MessagingService.instance().setVersion(HOST_3, MessagingService.VERSION_22);
+        MessagingService.instance().setVersion(HOST_4, MessagingService.VERSION_22);
     }
 
     @Test
-    public void onlyRequestOncePerEndpointVersion() throws UnknownHostException {
-        UUID uuid = UUID.randomUUID();
-        MigrationManager.addEndointToSchemaPullVersion(uuid, InetAddress.getLocalHost());
-        assertFalse(MigrationManager.shouldPullSchemaFrom(InetAddress.getLocalHost(), uuid));
+    public void shouldPullSchemaIfNoOutstandingRequests()
+    {
+        assertTrue(MigrationManager.shouldPullSchemaFrom(HOST_1,uuid));
     }
 
     @Test
-    public void noRequestOverMaxOutstanding() throws UnknownHostException {
-        UUID uuid = UUID.randomUUID();
-        MigrationManager.addEndointToSchemaPullVersion(uuid, InetAddress.getByName("10.0.0.1"));
-        MigrationManager.addEndointToSchemaPullVersion(uuid, InetAddress.getByName("10.0.0.2"));
-        MigrationManager.addEndointToSchemaPullVersion(uuid, InetAddress.getByName("10.0.0.3"));
-        assertFalse(MigrationManager.shouldPullSchemaFrom(InetAddress.getLocalHost(), uuid));
+    public void onlyRequestOncePerEndpointVersion() {
+        MigrationManager.addEndointToSchemaPullVersion(uuid, HOST_1);
+        assertFalse(MigrationManager.shouldPullSchemaFrom(HOST_1, uuid));
+    }
+
+    @Test
+    public void noRequestOverMaxOutstanding() {
+        MigrationManager.addEndointToSchemaPullVersion(uuid, HOST_1);
+        MigrationManager.addEndointToSchemaPullVersion(uuid, HOST_2);
+        MigrationManager.addEndointToSchemaPullVersion(uuid, HOST_3);
+        assertFalse(MigrationManager.shouldPullSchemaFrom(HOST_4, uuid));
     }
 }

--- a/test/unit/org/apache/cassandra/service/MigrationManagerTest.java
+++ b/test/unit/org/apache/cassandra/service/MigrationManagerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MigrationManagerTest
+{
+    @Test
+    public void shouldPullSchemaIfNoOutstandingRequests() throws UnknownHostException
+    {
+        assertTrue(MigrationManager.shouldPullSchemaFrom(InetAddress.getLocalHost(), UUID.randomUUID()));
+    }
+
+    @Test
+    public void onlyRequestOncePerEndpointVersion() throws UnknownHostException {
+        UUID uuid = UUID.randomUUID();
+        MigrationManager.addEndointToSchemaPullVersion(uuid, InetAddress.getLocalHost());
+        assertFalse(MigrationManager.shouldPullSchemaFrom(InetAddress.getLocalHost(), uuid));
+    }
+
+    @Test
+    public void noRequestOverMaxOutstanding() throws UnknownHostException {
+        UUID uuid = UUID.randomUUID();
+        MigrationManager.addEndointToSchemaPullVersion(uuid, InetAddress.getByName("10.0.0.1"));
+        MigrationManager.addEndointToSchemaPullVersion(uuid, InetAddress.getByName("10.0.0.2"));
+        MigrationManager.addEndointToSchemaPullVersion(uuid, InetAddress.getByName("10.0.0.3"));
+        assertFalse(MigrationManager.shouldPullSchemaFrom(InetAddress.getLocalHost(), uuid));
+    }
+}


### PR DESCRIPTION
Reduce schema pull request volume by only scheduling one request per schema version at a time. The thought is that _any_ successful request for a schema version will return the same set of mutations, so there's no need to flood other nodes with unnecessary requests.