### PR TITLE
Nodetool Drain throws immediately if the server is not initialized

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2638,7 +2638,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             logger.info("Received removenode gossip about myself. Is this node rejoining after an explicit removenode?");
             try
             {
-                drain();
+                drainInternal();
             }
             catch (Exception e)
             {
@@ -4606,7 +4606,19 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
      * - Drain waits for in-progress streaming to complete
      * - Drain flushes *all* columnfamilies (shutdown hook only flushes non-durable CFs)
      */
-    public synchronized void drain() throws IOException, InterruptedException, ExecutionException
+    public void drain() throws IOException, InterruptedException, ExecutionException
+    {
+        if (daemon.setupCompleted())
+        {
+            drainInternal();
+        }
+        else
+        {
+            throw new IllegalStateException("Cannot drain a node that is bootstrapping");
+        }
+    }
+
+    private synchronized void drainInternal() throws IOException, InterruptedException, ExecutionException
     {
         Stopwatch watch = Stopwatch.createStarted();
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4613,7 +4613,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
         else
         {
-            throw new IllegalStateException("Cannot drain a node that is bootstrapping");
+            throw new IllegalStateException("Cannot drain a node that is initializing or bootstrapping");
         }
     }
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4602,8 +4602,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     /**
      * Shuts node off to writes, empties memtables and the commit log.
-     * There are two differences between drain and the normal shutdown hook:
-     * - Drain waits for in-progress streaming to complete
+     * There is one difference between drain and the normal shutdown hook:
      * - Drain flushes *all* columnfamilies (shutdown hook only flushes non-durable CFs)
      */
     public void drain() throws IOException, InterruptedException, ExecutionException


### PR DESCRIPTION
Since the drain method is `synchronized`, calls to `nodetool drain` will hang if the server is not initialized. This includes nodes that are bootstrapping.

This PR makes these calls to `drain()` fail fast, so the behavior is more obvious.