### PR TITLE
Tweak MessagingService Shutdown and Add Internode Connect Timeout

### DIFF
--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -88,6 +88,8 @@ public class Config
 
     public long native_transport_idle_timeout_in_ms = 0L;
 
+    public volatile Long internode_connect_timeout_in_ms = 1000L;
+
     public volatile Long request_timeout_in_ms = 10000L;
 
     public volatile Long read_request_timeout_in_ms = 5000L;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1077,6 +1077,12 @@ public class DatabaseDescriptor
         return conf.rpc_listen_backlog;
     }
 
+
+    public static long getInternodeConnectionTimeout()
+    {
+        return conf.request_timeout_in_ms;
+    }
+
     public static long getRpcTimeout()
     {
         return conf.request_timeout_in_ms;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1080,7 +1080,12 @@ public class DatabaseDescriptor
 
     public static long getInternodeConnectionTimeout()
     {
-        return conf.request_timeout_in_ms;
+        return conf.internode_connect_timeout_in_ms;
+    }
+
+    public static long setInternodeConnectionTimeout(long timeoutInMillis)
+    {
+        return conf.internode_connect_timeout_in_ms = timeoutInMillis;
     }
 
     public static long getRpcTimeout()

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -766,17 +766,14 @@ public final class MessagingService implements MessagingServiceMBean
         // We may need to schedule hints on the mutation stage, so it's erroneous to shut down the mutation stage first
         assert !StageManager.getStage(Stage.MUTATION).isShutdown();
 
-        // the important part
-        if (!callbacks.shutdownBlocking())
-            logger.warn("Failed to wait for messaging service callbacks shutdown");
-
         // attempt to humor tests that try to stop and restart MS
         try
         {
             clearMessageSinks();
-            for (SocketThread th : socketThreads)
+            for (SocketThread th : socketThreads) {
                 try
                 {
+                    // Close incoming connections
                     th.close();
                 }
                 catch (IOException e)
@@ -784,6 +781,11 @@ public final class MessagingService implements MessagingServiceMBean
                     // see https://issues.apache.org/jira/browse/CASSANDRA-10545
                     handleIOException(e);
                 }
+
+            }
+            // Wait to finish callbacks before closing outbound connections
+            if (!callbacks.shutdownBlocking())
+                logger.warn("Failed to wait for messaging service callbacks shutdown");
 
             connectionManagers.values().forEach(OutboundTcpConnectionPool::close);
         }

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -781,7 +781,6 @@ public final class MessagingService implements MessagingServiceMBean
                     // see https://issues.apache.org/jira/browse/CASSANDRA-10545
                     handleIOException(e);
                 }
-
             }
             // Wait to finish callbacks before closing outbound connections
             if (!callbacks.shutdownBlocking())

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
@@ -627,6 +627,7 @@ public class OutboundTcpConnection extends Thread
             if (!qm.isTimedOut())
                 return;
             iter.remove();
+            invokeFailureCallback(qm);
             dropped.incrementAndGet();
         }
     }

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
@@ -34,6 +34,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
 import java.util.zip.Checksum;
 
 import javax.net.ssl.SSLHandshakeException;
@@ -42,6 +43,7 @@ import javax.net.ssl.SSLSocket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
 import net.jpountz.lz4.LZ4BlockOutputStream;
 import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Factory;
@@ -65,6 +67,7 @@ import org.xerial.snappy.SnappyOutputStream;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Uninterruptibles;
 
@@ -216,8 +219,9 @@ public class OutboundTcpConnection extends Thread
             //The timestamp of the first message has already been provided to the coalescing strategy
             //so skip logging it.
             inner:
-            for (QueuedMessage qm : drainedMessages)
+            for (int i = 0; i < drainedMessages.size(); i++)
             {
+                QueuedMessage qm = drainedMessages.get(i);
                 try
                 {
                     MessageOut<?> m = qm.message;
@@ -236,8 +240,10 @@ public class OutboundTcpConnection extends Thread
                     else
                     {
                         // clear out the queue, else gossip messages back up.
-                        drainedMessages.clear();
-                        backlog.clear();
+                        int cleared = clearQueueWithFailureCallback(i, drainedMessages, drainedMessageSize, backlog);
+                        logger.warn("Failed to connect to endpoint. Cleared backlog and invoked failure callbacks",
+                                    SafeArg.of("clearedMessages", cleared),
+                                    SafeArg.of("endpoint", poolReference.endPoint()));
                         currentMsgBufferCount = 0;
                         break inner;
                     }
@@ -253,6 +259,24 @@ public class OutboundTcpConnection extends Thread
             }
             drainedMessages.clear();
         }
+    }
+
+    @VisibleForTesting
+    int clearQueueWithFailureCallback(int currentMessage, List<QueuedMessage> bufferedMessages, int bufferSize, BlockingQueue<QueuedMessage> queue) {
+        bufferedMessages.stream().skip(currentMessage).forEach(this::invokeFailureCallback);
+        int initialCleared = bufferedMessages.size() - currentMessage;
+        bufferedMessages.clear();
+
+        int queueSize = queue.size();
+        int remaining = queueSize;
+        while (remaining > 0) {
+            remaining -= queue.drainTo(bufferedMessages, Math.min(bufferSize, remaining));
+            for (QueuedMessage qm : bufferedMessages) {
+                invokeFailureCallback(qm);
+            }
+            bufferedMessages.clear();
+        }
+        return initialCleared + queueSize;
     }
 
     public int getPendingMessages()
@@ -331,10 +355,7 @@ public class OutboundTcpConnection extends Thread
                         throw new AssertionError(e1);
                     }
                 } else {
-                    CallbackInfo registeredCallbackInfo = MessagingService.instance().getRegisteredCallback(qm.id);
-                    if (registeredCallbackInfo != null && registeredCallbackInfo.isFailureCallback()) {
-                        ((IAsyncCallbackWithFailure) MessagingService.instance().removeRegisteredCallback(qm.id).callback).onFailure(poolReference.endPoint());
-                    }
+                    invokeFailureCallback(qm);
                 }
             }
             else
@@ -342,6 +363,25 @@ public class OutboundTcpConnection extends Thread
                 // Non IO exceptions are likely a programming error so let's not silence them
                 logger.error("error writing to {}", poolReference.endPoint(), e);
             }
+        }
+    }
+
+    @VisibleForTesting
+    void invokeFailureCallback(QueuedMessage qm) {
+        if (qm == null) {
+            return;
+        }
+        CallbackInfo registeredCallbackInfo = MessagingService.instance().getRegisteredCallback(qm.id);
+        if (registeredCallbackInfo != null && registeredCallbackInfo.isFailureCallback()) {
+            Optional.ofNullable(MessagingService.instance().removeRegisteredCallback(qm.id))
+                    .map(info -> info.callback)
+                    .map(callback -> (IAsyncCallbackWithFailure) callback)
+                    .ifPresent(callback -> {
+                        logger.debug("Invoking failure callback for message",
+                                     SafeArg.of("endpoint", poolReference.endPoint()),
+                                     SafeArg.of("messageId", qm.id), SafeArg.of("verb", qm.message.verb));
+                        callback.onFailure(poolReference.endPoint());
+                    });
         }
     }
 
@@ -594,7 +634,7 @@ public class OutboundTcpConnection extends Thread
     }
 
     /** messages that have not been retried yet */
-    private static class QueuedMessage implements Coalescable
+    static class QueuedMessage implements Coalescable
     {
         final MessageOut<?> message;
         final int id;

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
@@ -34,11 +34,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.IntStream;
 import java.util.zip.Checksum;
 
 import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLSocket;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
@@ -330,6 +330,11 @@ public class OutboundTcpConnection extends Thread
                     {
                         throw new AssertionError(e1);
                     }
+                } else {
+                    CallbackInfo registeredCallbackInfo = MessagingService.instance().getRegisteredCallback(qm.id);
+                    if (registeredCallbackInfo != null && registeredCallbackInfo.isFailureCallback()) {
+                        ((IAsyncCallbackWithFailure) MessagingService.instance().removeRegisteredCallback(qm.id).callback).onFailure(poolReference.endPoint());
+                    }
                 }
             }
             else
@@ -397,7 +402,7 @@ public class OutboundTcpConnection extends Thread
             logger.trace("attempting to connect to {}", poolReference.endPoint());
 
         long start = System.nanoTime();
-        long timeout = TimeUnit.MILLISECONDS.toNanos(DatabaseDescriptor.getRpcTimeout());
+        long timeout = TimeUnit.MILLISECONDS.toNanos(DatabaseDescriptor.getInternodeConnectionTimeout());
         while (System.nanoTime() - start < timeout && !isStopped)
         {
             targetVersion = MessagingService.instance().getVersion(poolReference.endPoint());

--- a/src/java/org/apache/cassandra/net/WriteCallbackInfo.java
+++ b/src/java/org/apache/cassandra/net/WriteCallbackInfo.java
@@ -46,7 +46,7 @@ public class WriteCallbackInfo extends CallbackInfo
         this.consistencyLevel = consistencyLevel;
         this.allowHints = allowHints;
         //Local writes shouldn't go through messaging service (https://issues.apache.org/jira/browse/CASSANDRA-10477)
-        //assert (!target.equals(FBUtilities.getBroadcastAddress()));
+        assert (!target.equals(FBUtilities.getBroadcastAddress()));
     }
 
     Mutation mutation()

--- a/src/java/org/apache/cassandra/net/WriteCallbackInfo.java
+++ b/src/java/org/apache/cassandra/net/WriteCallbackInfo.java
@@ -46,7 +46,7 @@ public class WriteCallbackInfo extends CallbackInfo
         this.consistencyLevel = consistencyLevel;
         this.allowHints = allowHints;
         //Local writes shouldn't go through messaging service (https://issues.apache.org/jira/browse/CASSANDRA-10477)
-        assert (!target.equals(FBUtilities.getBroadcastAddress()));
+        //assert (!target.equals(FBUtilities.getBroadcastAddress()));
     }
 
     Mutation mutation()

--- a/test/unit/org/apache/cassandra/net/MessagingServiceTest.java
+++ b/test/unit/org/apache/cassandra/net/MessagingServiceTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.BeforeClass;
@@ -101,114 +102,87 @@ public class MessagingServiceTest
     }
 
     @Test
-    public void shutdown_refusesNewMessagesWhenInProgress() throws InterruptedException
-    {
-
+    public void shutdown_refusesNewMessagesWhenInProgress() throws InterruptedException {
         Keyspace keyspace = Keyspace.open(KEYSPACE1);
-        //ColumnFamilyStore store = keyspace.getColumnFamilyStore(CF_STANDARD1);
         DecoratedKey dk = Util.dk("key1");
 
-        // add data
         Mutation mutation = new Mutation(KEYSPACE1, dk.getKey());
         mutation.add(CF_STANDARD1, Util.cellname("Column1"), ByteBufferUtil.bytes("asdf"), 0);
-        //mutation.applyUnsafe();
-        AtomicBoolean response = new AtomicBoolean(false);
         MessageOut<Mutation> message = mutation.createMessage();
         List<MessagingService.SocketThread> incomingAcceptThreads;
-        try
-        {
+        try {
             messagingService.listen();
             assertTrue(messagingService.isListening());
             assertFalse(MessagingService.instance().isListening());
             incomingAcceptThreads = messagingService.getSocketThreads();
             assertTrue(incomingAcceptThreads.size() > 0);
 
-            TestHandler handler = new TestHandler(ImmutableList.of(FBUtilities.getLocalAddress()), ImmutableList.of(), ConsistencyLevel.ANY, keyspace, () -> response.set(true), WriteType.SIMPLE);
+            TestHandler handler = createHandler(keyspace);
             MessagingService.instance().sendRR(message, FBUtilities.getLocalAddress(), handler, false);
-            // Wait for response
             handler.get();
-            assertTrue(response.get());
-            response.set(false);
-            //MessagingService.instance().receive();
-//            while (true)
-//            {
-//                try
-//                {
-//                    Thread.sleep(500);
-//                }
-//                catch (InterruptedException ignored)
-//                {
-//                    break;
-//                }
-//            }
-        }finally
-        {
+            assertEquals(1, handler.success);
+        } finally {
             messagingService.shutdown();
         }
-
         incomingAcceptThreads.forEach(thread -> assertFalse(thread.isAlive()));
-        // throws IOException b/c broken pipe MessagingService.instance().getConnectionPool(FBUtilities.getLocalAddress()).smallMessages.out.flush();
-        TestHandler handler2 = new TestHandler(ImmutableList.of(FBUtilities.getLocalAddress()), ImmutableList.of(), ConsistencyLevel.ANY, keyspace, () -> response.set(true), WriteType.SIMPLE);
+        DatabaseDescriptor.setWriteRpcTimeout(Duration.ofSeconds(1).toMillis());
+        DatabaseDescriptor.setInternodeConnectionTimeout(Duration.ofMillis(50).toMillis());
+
+        Instant start = Instant.now();
+        TestHandler handler2 = createHandler(keyspace);
         MessagingService.instance().sendRR(message, FBUtilities.getLocalAddress(), handler2, false);
-        TestHandler handler3 = new TestHandler(ImmutableList.of(FBUtilities.getLocalAddress()), ImmutableList.of(), ConsistencyLevel.ANY, keyspace, () -> response.set(true), WriteType.SIMPLE);
+        handler2.get();
+        Duration handler2Time = Duration.between(start, Instant.now());
+        start = Instant.now();
+        TestHandler handler3 = createHandler(keyspace);
         MessagingService.instance().sendRR(message, FBUtilities.getLocalAddress(), handler3, false);
-        TestHandler handler4 = new TestHandler(ImmutableList.of(FBUtilities.getLocalAddress()), ImmutableList.of(), ConsistencyLevel.ANY, keyspace, () -> response.set(true), WriteType.SIMPLE);
+        handler3.get();
+        Duration handler3Time = Duration.between(start, Instant.now());
+        TestHandler handler4 = createHandler(keyspace);
         MessagingService.instance().sendRR(message, FBUtilities.getLocalAddress(), handler4, false);
-        // Wait for response
-        int timeouts = 0;
-        int failures = 0;
-        try {
-            handler2.get();
-        } catch (WriteTimeoutException e) {
-            timeouts++;
-        } catch (WriteFailureException e)
-        {
-            failures++;
-        }
-        try {
-            handler3.get();
-        } catch (WriteTimeoutException e) {
-            timeouts++;
-        } catch (WriteFailureException e)
-        {
-            failures++;
-        }
-        try {
-            handler4.get();
-        } catch (WriteTimeoutException e) {
-            timeouts++;
-        } catch (WriteFailureException e)
-        {
-            failures++;
-        }
-        System.out.println(failures);
-        System.out.println(timeouts);
+        handler4.get();
+        Duration handler4Time = Duration.between(start, Instant.now());
 
-        // Comfortable buffer to assert we're not timing out when we know we will fail
-        assertTrue(failures > 0);
+        // handler2 may or may not fail vs timeout. Likely due to OS level buffering, flushing the socket that has now
+        // been closed on the receiving end may or may not throw an IOException
+        int failures = handler2.failures + handler3.failures + handler4.failures;
+        assertTrue(failures >= 2);
 
-//        MessagingService.instance().sendRR(message, FBUtilities.getLocalAddress(), handler, false);
-//        Thread.sleep(1000);
-//        assertTrue(response.get());
-
-        // Create incoming tcp connection
-        // call shutdown
-        // send something over the connection before shutdown completes
-        // assert that socket was closed when we are reordered
-
+        // Failures should fail in less time than the write timeout, as they hit connect timeout instead
+        assertTrue(handler3Time.minus(Duration.ofMillis(800)).isNegative());
+        assertTrue(handler4Time.minus(Duration.ofMillis(800)).isNegative());
     }
 
-        static class TestHandler<T> extends WriteResponseHandler<T> {
+    private TestHandler createHandler(Keyspace ks) {
+        return new TestHandler(ImmutableList.of(FBUtilities.getLocalAddress()), ImmutableList.of(), ConsistencyLevel.ANY, ks, () -> {}, WriteType.SIMPLE);
+    }
 
-            public TestHandler(Collection<InetAddress> writeEndpoints, Collection<InetAddress> pendingEndpoints, ConsistencyLevel consistencyLevel, Keyspace keyspace, Runnable callback, WriteType writeType)
-            {
-                super(writeEndpoints, pendingEndpoints, consistencyLevel, keyspace, callback, writeType);
-            }
+    static class TestHandler<T> extends WriteResponseHandler<T> {
+        public int success = 0;
+        public int failures = 0;
+        public int timeouts = 0;
 
-            @Override
-            protected int totalBlockFor() {
-                return 1;
-            }
+
+        public TestHandler(Collection<InetAddress> writeEndpoints, Collection<InetAddress> pendingEndpoints, ConsistencyLevel consistencyLevel, Keyspace keyspace, Runnable callback, WriteType writeType)
+        {
+            super(writeEndpoints, pendingEndpoints, consistencyLevel, keyspace, callback, writeType);
         }
 
+        @Override
+        protected int totalBlockFor() {
+            return 1;
+        }
+
+        @Override
+        public void get() {
+            try {
+                super.get();
+                success++;
+            } catch (WriteTimeoutException e) {
+                timeouts++;
+            } catch (WriteFailureException e) {
+                failures++;
+            }
+        }
+    }
 }

--- a/test/unit/org/apache/cassandra/net/MessagingServiceTest.java
+++ b/test/unit/org/apache/cassandra/net/MessagingServiceTest.java
@@ -25,10 +25,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.BeforeClass;
@@ -38,28 +34,24 @@ import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.KSMetaData;
-import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.Mutation;
-import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.WriteType;
-import org.apache.cassandra.db.marshal.UUIDType;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.WriteFailureException;
 import org.apache.cassandra.exceptions.WriteTimeoutException;
 import org.apache.cassandra.locator.SimpleStrategy;
-import org.apache.cassandra.service.AbstractWriteResponseHandler;
-import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.service.WriteResponseHandler;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 public class MessagingServiceTest
 {
@@ -110,12 +102,18 @@ public class MessagingServiceTest
         mutation.add(CF_STANDARD1, Util.cellname("Column1"), ByteBufferUtil.bytes("asdf"), 0);
         MessageOut<Mutation> message = mutation.createMessage();
         List<MessagingService.SocketThread> incomingAcceptThreads;
+        InetAddress oldBroadcast = FBUtilities.getBroadcastAddress();
         try {
             messagingService.listen();
             assertTrue(messagingService.isListening());
             assertFalse(MessagingService.instance().isListening());
             incomingAcceptThreads = messagingService.getSocketThreads();
             assertTrue(incomingAcceptThreads.size() > 0);
+
+            // Spoof broadcast address to avoid WriteCallbackInfo assertion
+            InetAddress mockBroadcast = mock(InetAddress.class);
+            doReturn(oldBroadcast.getAddress()).when(mockBroadcast).getAddress();
+            FBUtilities.setBroadcastInetAddress(mockBroadcast);
 
             TestHandler handler = createHandler(keyspace);
             MessagingService.instance().sendRR(message, FBUtilities.getLocalAddress(), handler, false);
@@ -151,6 +149,8 @@ public class MessagingServiceTest
         // Failures should fail in less time than the write timeout, as they hit connect timeout instead
         assertTrue(handler3Time.minus(Duration.ofMillis(800)).isNegative());
         assertTrue(handler4Time.minus(Duration.ofMillis(800)).isNegative());
+
+        FBUtilities.setBroadcastInetAddress(oldBroadcast);
     }
 
     private TestHandler createHandler(Keyspace ks) {

--- a/test/unit/org/apache/cassandra/net/MessagingServiceTest.java
+++ b/test/unit/org/apache/cassandra/net/MessagingServiceTest.java
@@ -20,15 +20,61 @@
  */
 package org.apache.cassandra.net;
 
+import java.net.InetAddress;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google.common.collect.ImmutableList;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.Util;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.KSMetaData;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.SystemKeyspace;
+import org.apache.cassandra.db.WriteType;
+import org.apache.cassandra.db.marshal.UUIDType;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.exceptions.WriteFailureException;
+import org.apache.cassandra.exceptions.WriteTimeoutException;
+import org.apache.cassandra.locator.SimpleStrategy;
+import org.apache.cassandra.service.AbstractWriteResponseHandler;
+import org.apache.cassandra.service.StorageProxy;
+import org.apache.cassandra.service.WriteResponseHandler;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class MessagingServiceTest
 {
+    private static final String KEYSPACE1 = "MessagingServiceKeyspace";
+    private static final String CF_STANDARD1 = "columnfamily";
     private final MessagingService messagingService = MessagingService.test();
+
+    @BeforeClass
+    public static void defineSchema() throws ConfigurationException
+    {
+        SchemaLoader.prepareServer();
+        SchemaLoader.createKeyspace(KEYSPACE1,
+                                    SimpleStrategy.class,
+                                    KSMetaData.optsWithRF(1),
+                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD1));
+    }
 
     @Test
     public void testDroppedMessages()
@@ -53,4 +99,116 @@ public class MessagingServiceTest
         assertEquals("READ messages were dropped in last 5000 ms: 1250 for internal timeout and 1250 for cross node timeout", logs.get(0));
         assertEquals(7500, (int)messagingService.getDroppedMessages().get(verb.toString()));
     }
+
+    @Test
+    public void shutdown_refusesNewMessagesWhenInProgress() throws InterruptedException
+    {
+
+        Keyspace keyspace = Keyspace.open(KEYSPACE1);
+        //ColumnFamilyStore store = keyspace.getColumnFamilyStore(CF_STANDARD1);
+        DecoratedKey dk = Util.dk("key1");
+
+        // add data
+        Mutation mutation = new Mutation(KEYSPACE1, dk.getKey());
+        mutation.add(CF_STANDARD1, Util.cellname("Column1"), ByteBufferUtil.bytes("asdf"), 0);
+        //mutation.applyUnsafe();
+        AtomicBoolean response = new AtomicBoolean(false);
+        MessageOut<Mutation> message = mutation.createMessage();
+        List<MessagingService.SocketThread> incomingAcceptThreads;
+        try
+        {
+            messagingService.listen();
+            assertTrue(messagingService.isListening());
+            assertFalse(MessagingService.instance().isListening());
+            incomingAcceptThreads = messagingService.getSocketThreads();
+            assertTrue(incomingAcceptThreads.size() > 0);
+
+            TestHandler handler = new TestHandler(ImmutableList.of(FBUtilities.getLocalAddress()), ImmutableList.of(), ConsistencyLevel.ANY, keyspace, () -> response.set(true), WriteType.SIMPLE);
+            MessagingService.instance().sendRR(message, FBUtilities.getLocalAddress(), handler, false);
+            // Wait for response
+            handler.get();
+            assertTrue(response.get());
+            response.set(false);
+            //MessagingService.instance().receive();
+//            while (true)
+//            {
+//                try
+//                {
+//                    Thread.sleep(500);
+//                }
+//                catch (InterruptedException ignored)
+//                {
+//                    break;
+//                }
+//            }
+        }finally
+        {
+            messagingService.shutdown();
+        }
+
+        incomingAcceptThreads.forEach(thread -> assertFalse(thread.isAlive()));
+        // throws IOException b/c broken pipe MessagingService.instance().getConnectionPool(FBUtilities.getLocalAddress()).smallMessages.out.flush();
+        TestHandler handler2 = new TestHandler(ImmutableList.of(FBUtilities.getLocalAddress()), ImmutableList.of(), ConsistencyLevel.ANY, keyspace, () -> response.set(true), WriteType.SIMPLE);
+        MessagingService.instance().sendRR(message, FBUtilities.getLocalAddress(), handler2, false);
+        TestHandler handler3 = new TestHandler(ImmutableList.of(FBUtilities.getLocalAddress()), ImmutableList.of(), ConsistencyLevel.ANY, keyspace, () -> response.set(true), WriteType.SIMPLE);
+        MessagingService.instance().sendRR(message, FBUtilities.getLocalAddress(), handler3, false);
+        TestHandler handler4 = new TestHandler(ImmutableList.of(FBUtilities.getLocalAddress()), ImmutableList.of(), ConsistencyLevel.ANY, keyspace, () -> response.set(true), WriteType.SIMPLE);
+        MessagingService.instance().sendRR(message, FBUtilities.getLocalAddress(), handler4, false);
+        // Wait for response
+        int timeouts = 0;
+        int failures = 0;
+        try {
+            handler2.get();
+        } catch (WriteTimeoutException e) {
+            timeouts++;
+        } catch (WriteFailureException e)
+        {
+            failures++;
+        }
+        try {
+            handler3.get();
+        } catch (WriteTimeoutException e) {
+            timeouts++;
+        } catch (WriteFailureException e)
+        {
+            failures++;
+        }
+        try {
+            handler4.get();
+        } catch (WriteTimeoutException e) {
+            timeouts++;
+        } catch (WriteFailureException e)
+        {
+            failures++;
+        }
+        System.out.println(failures);
+        System.out.println(timeouts);
+
+        // Comfortable buffer to assert we're not timing out when we know we will fail
+        assertTrue(failures > 0);
+
+//        MessagingService.instance().sendRR(message, FBUtilities.getLocalAddress(), handler, false);
+//        Thread.sleep(1000);
+//        assertTrue(response.get());
+
+        // Create incoming tcp connection
+        // call shutdown
+        // send something over the connection before shutdown completes
+        // assert that socket was closed when we are reordered
+
+    }
+
+        static class TestHandler<T> extends WriteResponseHandler<T> {
+
+            public TestHandler(Collection<InetAddress> writeEndpoints, Collection<InetAddress> pendingEndpoints, ConsistencyLevel consistencyLevel, Keyspace keyspace, Runnable callback, WriteType writeType)
+            {
+                super(writeEndpoints, pendingEndpoints, consistencyLevel, keyspace, callback, writeType);
+            }
+
+            @Override
+            protected int totalBlockFor() {
+                return 1;
+            }
+        }
+
 }

--- a/test/unit/org/apache/cassandra/net/OutboundTcpConnectionTest.java
+++ b/test/unit/org/apache/cassandra/net/OutboundTcpConnectionTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.net;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.io.IVersionedSerializer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class OutboundTcpConnectionTest
+{
+    private OutboundTcpConnection connection;
+    private static OutboundTcpConnectionPool pool;
+    private static final InetAddress TARGET = mock(InetAddress.class);
+    private static final OutboundTcpConnection.QueuedMessage QM1 = new OutboundTcpConnection.QueuedMessage(new MessageOut<>(MessagingService.Verb.MUTATION), 1);
+    private static final OutboundTcpConnection.QueuedMessage QM2 = new OutboundTcpConnection.QueuedMessage(new MessageOut<>(MessagingService.Verb.MUTATION), 2);
+    private static final OutboundTcpConnection.QueuedMessage QM3 = new OutboundTcpConnection.QueuedMessage(new MessageOut<>(MessagingService.Verb.MUTATION), 3);
+
+    @BeforeClass
+    public static void beforeClass() throws UnknownHostException
+    {
+        pool = mock(OutboundTcpConnectionPool.class);
+        doReturn(InetAddress.getLocalHost()).when(pool).endPoint();
+    }
+
+    @Before
+    public void before() {
+        connection = spy(new OutboundTcpConnection(pool, "test"));
+        MessagingService.instance().clearCallbacksUnsafe();
+    }
+
+    @Test
+    public void invokeFailureCallback_ignoresNonFailureCallbacks() {
+        TestCallback cb = new TestCallback();
+        CallbackInfo nonFailureCallback = new CallbackInfo(TARGET, cb, mock(IVersionedSerializer.class), false);
+        MessagingService.instance().setCallbackForTests(QM1.id, nonFailureCallback);
+        connection.invokeFailureCallback(QM1);
+        assertEquals(0, cb.responses.get());
+    }
+
+    @Test
+    public void invokeFailureCallback_handlesExpiredCallback() {
+        assertNull(MessagingService.instance().getRegisteredCallback(QM1.id));
+        connection.invokeFailureCallback(QM1);
+    }
+
+    @Test
+    public void invokeFailureCallback_runsCallback() {
+        TestFailureCallback cb = registerFailureCallback(QM1);
+        connection.invokeFailureCallback(QM1);
+        assertEquals(0, cb.responses.get());
+        assertEquals(1, cb.failures.get());
+        assertNull(MessagingService.instance().getRegisteredCallback(QM1.id));
+    }
+
+    @Test
+    public void clearQueueWithFailureCallback_handlesInProgressDrainedList() throws InterruptedException
+    {
+        List<OutboundTcpConnection.QueuedMessage> drained = new ArrayList<>(2);
+        drained.add(QM1);
+        drained.add(QM2);
+        BlockingQueue<OutboundTcpConnection.QueuedMessage> backlog = new LinkedBlockingQueue<>();
+        backlog.put(QM3);
+
+        TestFailureCallback cb1 = registerFailureCallback(QM1);
+        TestFailureCallback cb2 = registerFailureCallback(QM2);
+        TestFailureCallback cb3 = registerFailureCallback(QM3);
+
+        connection.clearQueueWithFailureCallback(1, drained, 2, backlog);
+
+        assertEquals(0, cb1.failures.get());
+        assertEquals(1, cb2.failures.get());
+        assertEquals(1, cb3.failures.get());
+
+        assertTrue(drained.isEmpty());
+        assertTrue(backlog.isEmpty());
+    }
+
+    @Test
+    public void clearQueueWithFailureCallback_clearsLargeBacklog() throws InterruptedException
+    {
+        List<OutboundTcpConnection.QueuedMessage> drained = new ArrayList<>(2);
+        BlockingQueue<OutboundTcpConnection.QueuedMessage> backlog = spy(new LinkedBlockingQueue<>());
+        backlog.put(QM1);
+        backlog.put(QM2);
+        backlog.put(QM3);
+        backlog.put(QM3);
+        backlog.put(QM3);
+
+        TestFailureCallback cb1 = registerFailureCallback(QM1);
+        TestFailureCallback cb2 = registerFailureCallback(QM2);
+        TestFailureCallback cb3 = registerFailureCallback(QM3);
+
+        connection.clearQueueWithFailureCallback(0, drained, 2, backlog);
+        // With enough elements remaining, drain the buffer size
+        verify(backlog, times(2)).drainTo(anyCollection(), eq(2));
+        // Last call, don't take more off the backlog than needed from when we first called clearQueueWithFailureCallback
+        verify(backlog, times(1)).drainTo(anyCollection(), eq(1));
+
+        assertEquals(1, cb1.failures.get());
+        assertEquals(1, cb2.failures.get());
+        assertEquals(1, cb3.failures.get());
+
+        assertTrue(drained.isEmpty());
+        assertTrue(backlog.isEmpty());
+    }
+
+    static class TestCallback<T> implements IAsyncCallback<T>
+    {
+        public final AtomicInteger responses = new AtomicInteger(0);
+
+        public void response(MessageIn<T> _msg)
+        {
+            responses.incrementAndGet();
+
+        }
+
+        public boolean isLatencyForSnitch()
+        {
+            return false;
+        }
+    }
+
+    static class TestFailureCallback<T> extends TestCallback<T> implements IAsyncCallbackWithFailure<T> {
+        public final AtomicInteger failures = new AtomicInteger(0);
+
+        public void onFailure(InetAddress from)
+        {
+            failures.incrementAndGet();
+        }
+    }
+
+    private TestFailureCallback registerFailureCallback(OutboundTcpConnection.QueuedMessage qm) {
+        TestFailureCallback cb = new TestFailureCallback();
+        MessagingService.instance().setCallbackForTests(qm.id, new CallbackInfo(TARGET, cb, mock(IVersionedSerializer.class), true));
+        return cb;
+    }
+}


### PR DESCRIPTION
A couple different, but sort of related changes in this PR:

* On MessagingService shutdown we now close the incoming socket before shutting down the callback expiring map. Although in the previous ordering the callback map won't allow new callbacks to be registered, I think other C* nodes may continue successfully sending messages since at the networking layer they're still accepted. This might help a little bit, in conjunction with the next change, to avoid waiting until timeouts for requests we know will fail -- but probably not a ton.
* If one C* node sees another as up, but cannot connect for whatever reason, it will loop trying to reconnect in OutboundTcpConnection for `minRpcTimeout`, which can be the same as read/write timeouts in practice. Once this is exceeded, all the messages on the backlog are cleared. If these were needed to satisfy a read/write, this node as the coordinator just waits until the failure callback is invoked via read/write timeout (which can be a long time).
  * If we make this separately configurable and assume recoverable network problems are short-lived, and non-recoverable ones take substantially longer than read/write timeouts, we can make this connectivity timeout small and invoke the failure callbacks much faster than the write timeout, which might improve the client experience.
  * Normally you'd hope this node sees the other as unreachable in this scenario as then it will not attempt to send a request. However, we've seen this not be the case relatively frequently.
  * Also generally, whenever messages got cleared from the backlog we were not invoking any failure callbacks. We can just do that too instead of waiting for them to timeout