### PR TITLE
Move CoalescingSupplier to com.palantir.cassandra

### DIFF
--- a/src/java/com/palantir/cassandra/concurrent/CoalescingSupplier.java
+++ b/src/java/com/palantir/cassandra/concurrent/CoalescingSupplier.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -26,11 +24,9 @@ import java.util.function.Supplier;
 import com.google.common.base.Throwables;
 
 /**
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * A supplier that coalesces computation requests, such that only one computation is ever running at a time, and
+ * concurrent requests will result in a single computation. Computations are guaranteed to execute after being
+ * requested; requests will not receive results for computations that started prior to the request.
  * 
  * Copied directly from:
  * https://github.com/palantir/atlasdb/blob/0.138.0/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java

--- a/src/java/com/palantir/cassandra/concurrent/CoalescingSupplier.java
+++ b/src/java/com/palantir/cassandra/concurrent/CoalescingSupplier.java
@@ -1,9 +1,11 @@
 /*
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.common.concurrent;
+package com.palantir.cassandra.concurrent;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;

--- a/src/java/com/palantir/cassandra/concurrent/CoalescingSupplier.java
+++ b/src/java/com/palantir/cassandra/concurrent/CoalescingSupplier.java
@@ -26,9 +26,11 @@ import java.util.function.Supplier;
 import com.google.common.base.Throwables;
 
 /**
- * A supplier that coalesces computation requests, such that only one computation is ever running at a time, and
- * concurrent requests will result in a single computation. Computations are guaranteed to execute after being
- * requested; requests will not receive results for computations that started prior to the request.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  * 
  * Copied directly from:
  * https://github.com/palantir/atlasdb/blob/0.138.0/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java

--- a/src/java/com/palantir/cassandra/db/CompactionsInProgressFlusher.java
+++ b/src/java/com/palantir/cassandra/db/CompactionsInProgressFlusher.java
@@ -23,7 +23,7 @@ import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.commitlog.ReplayPosition;
 import org.apache.cassandra.utils.FBUtilities;
 
-import com.palantir.common.concurrent.CoalescingSupplier;
+import com.palantir.cassandra.concurrent.CoalescingSupplier;
 
 /**
  * Executing a single compaction task requires two flushes of the system.compactions_in_progress table: at start and


### PR DESCRIPTION
Move CoalescingSupplier to com.palantir.cassandra.

This deconflicts the class name with https://github.com/palantir/atlasdb/blob/0.138.0/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java, which allows [PCQL](https://github.palantir.build/foundry/sls-cassandra/pull/4809) to take both as dependencies without classname conflicts