### PR TITLE
migrate to SafeLogging in `org.apache.cassandra.streaming`

### DIFF
--- a/src/java/org/apache/cassandra/streaming/ConnectionHandler.java
+++ b/src/java/org/apache/cassandra/streaming/ConnectionHandler.java
@@ -37,6 +37,8 @@ import com.google.common.util.concurrent.SettableFuture;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.io.util.DataOutputStreamPlus;
 import org.apache.cassandra.io.util.BufferedDataOutputStreamPlus;
 import org.apache.cassandra.io.util.WrappedDataOutputStreamPlus;
@@ -80,11 +82,13 @@ public class ConnectionHandler
     @SuppressWarnings("resource")
     public void initiate() throws Exception
     {
-        logger.debug("[Stream #{}] Sending stream init for incoming stream", session.planId());
+        if (logger.isDebugEnabled())
+            logger.debug("[Stream #{}] Sending stream init for incoming stream", SafeArg.of("planId", session.planId()));
         Socket incomingSocket = session.createConnection();
         incoming.start(incomingSocket, StreamMessage.CURRENT_VERSION, true);
 
-        logger.debug("[Stream #{}] Sending stream init for outgoing stream", session.planId());
+        if (logger.isDebugEnabled())
+            logger.debug("[Stream #{}] Sending stream init for outgoing stream", SafeArg.of("planId", session.planId()));
         Socket outgoingSocket = session.createConnection();
         outgoing.start(outgoingSocket, StreamMessage.CURRENT_VERSION, true);
     }
@@ -106,7 +110,10 @@ public class ConnectionHandler
 
     public ListenableFuture<?> close()
     {
-        logger.debug("[Stream #{}] Closing stream connection handler on {}", session.planId(), session.peer);
+        if (logger.isDebugEnabled())
+            logger.debug("[Stream #{}] Closing stream connection handler on {}",
+                         SafeArg.of("planId", session.planId()),
+                         SafeArg.of("peer", session.peer));
 
         ListenableFuture<?> inClosed = closeIncoming();
         ListenableFuture<?> outClosed = closeOutgoing();
@@ -290,7 +297,10 @@ public class ConnectionHandler
                 {
                     // receive message
                     StreamMessage message = StreamMessage.deserialize(in, protocolVersion, session);
-                    logger.debug("[Stream #{}] Received {}", session.planId(), message);
+                    if (logger.isDebugEnabled())
+                        logger.debug("[Stream #{}] Received {}",
+                                     SafeArg.of("planId", session.planId()),
+                                     SafeArg.of("message", message));
                     // Might be null if there is an error during streaming (see FileMessage.deserialize). It's ok
                     // to ignore here since we'll have asked for a retry.
                     if (message != null)
@@ -357,7 +367,10 @@ public class ConnectionHandler
                 {
                     if ((next = messageQueue.poll(1, TimeUnit.SECONDS)) != null)
                     {
-                        logger.debug("[Stream #{}] Sending {}", session.planId(), next);
+                        if (logger.isDebugEnabled())
+                            logger.debug("[Stream #{}] Sending {}",
+                                         SafeArg.of("planId", session.planId()),
+                                         SafeArg.of("message", next));
                         sendMessage(out, next);
                         if (next.type == StreamMessage.Type.SESSION_FAILED)
                             close();

--- a/src/java/org/apache/cassandra/streaming/DefaultConnectionFactory.java
+++ b/src/java/org/apache/cassandra/streaming/DefaultConnectionFactory.java
@@ -24,6 +24,7 @@ import java.net.Socket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.net.OutboundTcpConnectionPool;
 
@@ -60,7 +61,10 @@ public class DefaultConnectionFactory implements StreamConnectionFactory
                     throw e;
 
                 long waitms = DatabaseDescriptor.getRpcTimeout() * (long)Math.pow(2, attempts);
-                logger.warn("Failed attempt {} to connect to {}. Retrying in {} ms. ({})", attempts, peer, waitms, e);
+                logger.warn("Failed attempt {} to connect to {}. Retrying in {} ms.",
+                            SafeArg.of("attempts", attempts),
+                            SafeArg.of("peer", peer),
+                            SafeArg.of("waitms", waitms), e);
                 try
                 {
                     Thread.sleep(waitms);

--- a/src/java/org/apache/cassandra/streaming/StreamCoordinator.java
+++ b/src/java/org/apache/cassandra/streaming/StreamCoordinator.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.concurrent.DebuggableThreadPoolExecutor;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
@@ -216,7 +217,10 @@ public class StreamCoordinator
         public void run()
         {
             session.start();
-            logger.info("[Stream #{}, ID#{}] Beginning stream session with {}", session.planId(), session.sessionIndex(), session.peer);
+            logger.info("[Stream #{}, ID#{}] Beginning stream session with {}",
+                        SafeArg.of("planId", session.planId()),
+                        SafeArg.of("sessionIndex", session.sessionIndex()),
+                        SafeArg.of("peer", session.peer));
         }
     }
 

--- a/src/java/org/apache/cassandra/streaming/StreamLockfile.java
+++ b/src/java/org/apache/cassandra/streaming/StreamLockfile.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.UUID;
 
 import com.google.common.base.Charsets;
+
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.io.sstable.format.SSTableWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,7 +87,7 @@ public class StreamLockfile
         }
         catch (IOException e)
         {
-            logger.warn(String.format("Could not create lockfile %s for stream session, nothing to worry too much about", lockfile), e);
+            logger.warn("Could not create lockfile {} for stream session, nothing to worry too much about", SafeArg.of("lockfile", lockfile.toString()), e);
         }
     }
 
@@ -107,7 +109,7 @@ public class StreamLockfile
             catch (Exception e)
             {
                 JVMStabilityInspector.inspectThrowable(e);
-                logger.warn("failed to delete a potentially stale sstable {}", file);
+                logger.warn("failed to delete a potentially stale sstable {}", SafeArg.of("file", file));
             }
         }
     }

--- a/src/java/org/apache/cassandra/streaming/StreamLockfile.java
+++ b/src/java/org/apache/cassandra/streaming/StreamLockfile.java
@@ -88,7 +88,7 @@ public class StreamLockfile
         }
         catch (IOException e)
         {
-            logger.warn("Could not create lockfile {} for stream session, nothing to worry too much about", SafeArg.of("lockfile", lockfile.toString()), e);
+            logger.warn("Could not create lockfile {} for stream session, nothing to worry too much about", UnsafeArg.of("lockfile", lockfile.toString()), e);
         }
     }
 

--- a/src/java/org/apache/cassandra/streaming/StreamLockfile.java
+++ b/src/java/org/apache/cassandra/streaming/StreamLockfile.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import com.google.common.base.Charsets;
 
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import org.apache.cassandra.io.sstable.format.SSTableWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,7 +110,7 @@ public class StreamLockfile
             catch (Exception e)
             {
                 JVMStabilityInspector.inspectThrowable(e);
-                logger.warn("failed to delete a potentially stale sstable {}", SafeArg.of("file", file));
+                logger.warn("failed to delete a potentially stale sstable {}", UnsafeArg.of("file", file));
             }
         }
     }

--- a/src/java/org/apache/cassandra/streaming/StreamReader.java
+++ b/src/java/org/apache/cassandra/streaming/StreamReader.java
@@ -24,6 +24,9 @@ import java.util.Collection;
 import java.util.UUID;
 
 import com.google.common.base.Throwables;
+
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.io.sstable.format.SSTableWriter;
 import org.apache.cassandra.io.sstable.format.Version;
@@ -99,9 +102,15 @@ public class StreamReader
             throw new IOException("CF " + cfId + " was dropped during streaming");
         }
 
-        logger.debug("[Stream #{}] Start receiving file #{} from {}, repairedAt = {}, size = {}, ks = '{}', table = '{}'.",
-                     session.planId(), fileSeqNum, session.peer, repairedAt, totalSize, cfs.keyspace.getName(),
-                     cfs.getColumnFamilyName());
+        if (logger.isDebugEnabled())
+            logger.debug("[Stream #{}] Start receiving file #{} from {}, repairedAt = {}, size = {}, ks = '{}', table = '{}'.",
+                         SafeArg.of("planId", session.planId()),
+                         SafeArg.of("fileSeqNum", fileSeqNum),
+                         SafeArg.of("peer", session.peer),
+                         SafeArg.of("repairedAt", repairedAt),
+                         SafeArg.of("size", totalSize),
+                         SafeArg.of("keyspace", cfs.keyspace.getName()),
+                         SafeArg.of("table", cfs.getColumnFamilyName()));
 
         DataInputStream dis = new DataInputStream(new LZFInputStream(Channels.newInputStream(channel)));
         BytesReadTracker in = new BytesReadTracker(dis);
@@ -118,14 +127,22 @@ public class StreamReader
                 // TODO move this to BytesReadTracker
                 session.progress(desc, ProgressInfo.Direction.IN, in.getBytesRead(), totalSize);
             }
-            logger.debug("[Stream #{}] Finished receiving file #{} from {} readBytes = {}, totalSize = {}",
-                         session.planId(), fileSeqNum, session.peer, in.getBytesRead(), totalSize);
+            if (logger.isDebugEnabled())
+                logger.debug("[Stream #{}] Finished receiving file #{} from {} readBytes = {}, totalSize = {}",
+                             SafeArg.of("planId", session.planId()),
+                             SafeArg.of("fileSeqNum", fileSeqNum),
+                             SafeArg.of("peer", session.peer),
+                             SafeArg.of("readBytes", in.getBytesRead()),
+                             SafeArg.of("totalSize", totalSize));
             return writer;
         } catch (Throwable e)
         {
             if (key != null)
                 logger.warn("[Stream {}] Error while reading partition {} from stream on ks='{}' and table='{}'.",
-                            session.planId(), key, cfs.keyspace.getName(), cfs.getColumnFamilyName());
+                            SafeArg.of("planId", session.planId()),
+                            UnsafeArg.of("key", key),
+                            SafeArg.of("keyspace", cfs.keyspace.getName()),
+                            SafeArg.of("columnFamily", cfs.getColumnFamilyName()));
             if (writer != null)
             {
                 try

--- a/src/java/org/apache/cassandra/streaming/StreamReceiveTask.java
+++ b/src/java/org/apache/cassandra/streaming/StreamReceiveTask.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.concurrent.NamedThreadFactory;
 import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -151,18 +152,26 @@ public class StreamReceiveTask extends StreamTask
                         {
                             int invalidatedKeys = cfs.invalidateRowCache(nonOverlappingBounds);
                             if (invalidatedKeys > 0)
-                                logger.debug("[Stream #{}] Invalidated {} row cache entries on table {}.{} after stream " +
-                                             "receive task completed.", task.session.planId(), invalidatedKeys,
-                                             cfs.keyspace.getName(), cfs.getColumnFamilyName());
+                                if (logger.isDebugEnabled())
+                                    logger.debug("[Stream #{}] Invalidated {} row cache entries on table {}.{} after stream " +
+                                                 "receive task completed.",
+                                                 SafeArg.of("planId", task.session.planId()),
+                                                 SafeArg.of("invalidatedKeys", invalidatedKeys),
+                                                 SafeArg.of("keyspace", cfs.keyspace.getName()),
+                                                 SafeArg.of("table", cfs.getColumnFamilyName()));
                         }
 
                         if (cfs.metadata.isCounter())
                         {
                             int invalidatedKeys = cfs.invalidateCounterCache(nonOverlappingBounds);
                             if (invalidatedKeys > 0)
-                                logger.debug("[Stream #{}] Invalidated {} counter cache entries on table {}.{} after stream " +
-                                             "receive task completed.", task.session.planId(), invalidatedKeys,
-                                             cfs.keyspace.getName(), cfs.getColumnFamilyName());
+                                if (logger.isDebugEnabled())
+                                    logger.debug("[Stream #{}] Invalidated {} counter cache entries on table {}.{} after stream " +
+                                                 "receive task completed.",
+                                                 SafeArg.of("planId", task.session.planId()),
+                                                 SafeArg.of("invalidatedKeys", invalidatedKeys),
+                                                 SafeArg.of("keyspace", cfs.keyspace.getName()),
+                                                 SafeArg.of("table", cfs.getColumnFamilyName()));
                         }
                     }
                 }

--- a/src/java/org/apache/cassandra/streaming/StreamResultFuture.java
+++ b/src/java/org/apache/cassandra/streaming/StreamResultFuture.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.net.IncomingStreamingConnection;
 
 /**
@@ -85,7 +86,7 @@ public final class StreamResultFuture extends AbstractFuture<StreamState>
                 future.addEventListener(listener);
         }
 
-        logger.info("[Stream #{}] Executing streaming plan for {}", planId, description);
+        logger.info("[Stream #{}] Executing streaming plan for {}", SafeArg.of("planId", planId), SafeArg.of("description", description));
 
         // Initialize and start all sessions
         for (final StreamSession session : coordinator.getAllStreamSessions())
@@ -110,14 +111,20 @@ public final class StreamResultFuture extends AbstractFuture<StreamState>
         StreamResultFuture future = StreamManager.instance.getReceivingStream(planId);
         if (future == null)
         {
-            logger.info("[Stream #{} ID#{}] Creating new streaming plan for {}", planId, sessionIndex, description);
+            logger.info("[Stream #{} ID#{}] Creating new streaming plan for {}",
+                        SafeArg.of("planId", planId),
+                        SafeArg.of("sessionIndex", sessionIndex),
+                        SafeArg.of("description", description));
 
             // The main reason we create a StreamResultFuture on the receiving side is for JMX exposure.
             future = new StreamResultFuture(planId, description, keepSSTableLevel, isIncremental);
             StreamManager.instance.registerReceiving(future);
         }
         future.attachConnection(from, sessionIndex, connection, isForOutgoing, version);
-        logger.info("[Stream #{}, ID#{}] Received streaming plan for {}", planId, sessionIndex, description);
+        logger.info("[Stream #{}, ID#{}] Received streaming plan for {}",
+                    SafeArg.of("planId", planId),
+                    SafeArg.of("sessionIndex", sessionIndex),
+                    SafeArg.of("description", description));
         return future;
     }
 
@@ -168,12 +175,12 @@ public final class StreamResultFuture extends AbstractFuture<StreamState>
     {
         SessionInfo sessionInfo = session.getSessionInfo();
         logger.info("[Stream #{} ID#{}] Prepare completed. Receiving {} files({} bytes), sending {} files({} bytes)",
-                    session.planId(),
-                    session.sessionIndex(),
-                    sessionInfo.getTotalFilesToReceive(),
-                    sessionInfo.getTotalSizeToReceive(),
-                    sessionInfo.getTotalFilesToSend(),
-                    sessionInfo.getTotalSizeToSend());
+                    SafeArg.of("planId", session.planId()),
+                    SafeArg.of("sessionIndex", session.sessionIndex()),
+                    SafeArg.of("totalFilesToReceive", sessionInfo.getTotalFilesToReceive()),
+                    SafeArg.of("totalSizeToReceive", sessionInfo.getTotalSizeToReceive()),
+                    SafeArg.of("totalFilesToSend", sessionInfo.getTotalFilesToSend()),
+                    SafeArg.of("totalSizeToSend", sessionInfo.getTotalSizeToSend()));
         StreamEvent.SessionPreparedEvent event = new StreamEvent.SessionPreparedEvent(planId, sessionInfo);
         coordinator.addSessionInfo(sessionInfo);
         fireStreamEvent(event);
@@ -181,7 +188,9 @@ public final class StreamResultFuture extends AbstractFuture<StreamState>
 
     void handleSessionComplete(StreamSession session)
     {
-        logger.info("[Stream #{}] Session with {} is complete", session.planId(), session.peer);
+        logger.info("[Stream #{}] Session with {} is complete",
+                    SafeArg.of("planId", session.planId()),
+                    SafeArg.of("peer", session.peer));
         fireStreamEvent(new StreamEvent.SessionCompleteEvent(session));
         SessionInfo sessionInfo = session.getSessionInfo();
         coordinator.addSessionInfo(sessionInfo);
@@ -208,12 +217,12 @@ public final class StreamResultFuture extends AbstractFuture<StreamState>
             StreamState finalState = getCurrentState();
             if (finalState.hasFailedSession())
             {
-                logger.warn("[Stream #{}] Stream failed", planId);
+                logger.warn("[Stream #{}] Stream failed", SafeArg.of("planId", planId));
                 setException(new StreamException(finalState, "Stream failed"));
             }
             else
             {
-                logger.info("[Stream #{}] All sessions completed", planId);
+                logger.info("[Stream #{}] All sessions completed", SafeArg.of("planId", planId));
                 set(finalState);
             }
         }

--- a/src/java/org/apache/cassandra/streaming/StreamSession.java
+++ b/src/java/org/apache/cassandra/streaming/StreamSession.java
@@ -29,6 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.*;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.db.lifecycle.SSTableIntervalTree;
 import org.apache.cassandra.db.lifecycle.View;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -224,16 +225,17 @@ public class StreamSession implements IEndpointStateChangeSubscriber
     {
         if (requests.isEmpty() && transfers.isEmpty())
         {
-            logger.info("[Stream #{}] Session does not have any tasks.", planId());
+            logger.info("[Stream #{}] Session does not have any tasks.", SafeArg.of("planId", planId()));
             closeSession(State.COMPLETE);
             return;
         }
 
         try
         {
-            logger.info("[Stream #{}] Starting streaming to {}{}", planId(),
-                                                                   peer,
-                                                                   peer.equals(connecting) ? "" : " through " + connecting);
+            logger.info("[Stream #{}] Starting streaming to {}{}", SafeArg.of("planId", planId()),
+                        SafeArg.of("peer", peer),
+                        SafeArg.of("through", peer.equals(connecting) ? "" : " through " + connecting)
+            );
             handler.initiate();
             onInitializationComplete();
         }
@@ -340,7 +342,8 @@ public class StreamSession implements IEndpointStateChangeSubscriber
                             }
                         }
 
-                        logger.debug("ViewFilter for {}/{} sstables", sstables.size(), view.sstables.size());
+                        if (logger.isDebugEnabled())
+                            logger.debug("ViewFilter for {}/{} sstables", SafeArg.of("size", sstables.size()), SafeArg.of("viewSize", view.sstables.size()));
                         return ImmutableList.copyOf(sstables);
                     }
                 }).refs);
@@ -517,11 +520,13 @@ public class StreamSession implements IEndpointStateChangeSubscriber
             logger.error("[Stream #{}] Streaming socket timed out. This means the session peer stopped responding or " +
                          "is still processing received data. If there is no sign of failure in the other end or a very " +
                          "dense table is being transferred you may want to increase streaming_socket_timeout_in_ms " +
-                         "property. Current value is {}ms.", planId(), DatabaseDescriptor.getStreamingSocketTimeout(), e);
+                         "property. Current value is {}ms.",
+                         SafeArg.of("planId", planId()),
+                         SafeArg.of("streamingSockeTimeout", DatabaseDescriptor.getStreamingSocketTimeout()), e);
         }
         else
         {
-            logger.error("[Stream #{}] Streaming error occurred", planId(), e);
+            logger.error("[Stream #{}] Streaming error occurred", SafeArg.of("planId", planId()), e);
         }
         // send session failure message
         if (handler.isOutgoingConnected())
@@ -626,7 +631,7 @@ public class StreamSession implements IEndpointStateChangeSubscriber
      */
     public synchronized void sessionFailed()
     {
-        logger.error("[Stream #{}] Remote peer {} failed stream session.", planId(), peer.getHostAddress());
+        logger.error("[Stream #{}] Remote peer {} failed stream session.", SafeArg.of("planId", planId()), SafeArg.of("peer", peer.getHostAddress()));
         closeSession(State.FAILED);
     }
 
@@ -664,13 +669,13 @@ public class StreamSession implements IEndpointStateChangeSubscriber
 
     public void onRemove(InetAddress endpoint)
     {
-        logger.error("[Stream #{}] Session failed because remote peer {} has left.", planId(), peer.getHostAddress());
+        logger.error("[Stream #{}] Session failed because remote peer {} has left.", SafeArg.of("planId", planId()), SafeArg.of("peer", peer.getHostAddress()));
         closeSession(State.FAILED);
     }
 
     public void onRestart(InetAddress endpoint, EndpointState epState)
     {
-        logger.error("[Stream #{}] Session failed because remote peer {} was restarted.", planId(), peer.getHostAddress());
+        logger.error("[Stream #{}] Session failed because remote peer {} was restarted.", SafeArg.of("planId", planId()), SafeArg.of("peer", peer.getHostAddress()));
         closeSession(State.FAILED);
     }
 

--- a/src/java/org/apache/cassandra/streaming/StreamWriter.java
+++ b/src/java/org/apache/cassandra/streaming/StreamWriter.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import com.ning.compress.lzf.LZFOutputStream;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.DataIntegrityMetadata;
@@ -75,8 +76,13 @@ public class StreamWriter
     public void write(DataOutputStreamPlus output) throws IOException
     {
         long totalSize = totalSize();
-        logger.debug("[Stream #{}] Start streaming file {} to {}, repairedAt = {}, totalSize = {}", session.planId(),
-                     sstable.getFilename(), session.peer, sstable.getSSTableMetadata().repairedAt, totalSize);
+        if (logger.isDebugEnabled())
+            logger.debug("[Stream #{}] Start streaming file {} to {}, repairedAt = {}, totalSize = {}",
+                         SafeArg.of("planId", session.planId()),
+                         SafeArg.of("file", sstable.getFilename()),
+                         SafeArg.of("peer", session.peer),
+                         SafeArg.of("repairedAt", sstable.getSSTableMetadata().repairedAt),
+                         SafeArg.of("totalSize", totalSize));
 
         try(RandomAccessReader file = sstable.openDataReader();
             ChecksumValidator validator = new File(sstable.descriptor.filenameFor(Component.CRC)).exists()
@@ -115,8 +121,13 @@ public class StreamWriter
                 // make sure that current section is sent
                 compressedOutput.flush();
             }
-            logger.debug("[Stream #{}] Finished streaming file {} to {}, bytesTransferred = {}, totalSize = {}",
-                         session.planId(), sstable.getFilename(), session.peer, progress, totalSize);
+            if (logger.isDebugEnabled())
+                logger.debug("[Stream #{}] Finished streaming file {} to {}, bytesTransferred = {}, totalSize = {}",
+                             SafeArg.of("planId", session.planId()),
+                             SafeArg.of("file", sstable.getFilename()),
+                             SafeArg.of("peer", session.peer),
+                             SafeArg.of("bytesTransferred", progress),
+                             SafeArg.of("totalSize", totalSize));
         }
     }
 

--- a/src/java/org/apache/cassandra/streaming/StreamWriter.java
+++ b/src/java/org/apache/cassandra/streaming/StreamWriter.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import com.ning.compress.lzf.LZFOutputStream;
 
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.DataIntegrityMetadata;
@@ -79,7 +80,7 @@ public class StreamWriter
         if (logger.isDebugEnabled())
             logger.debug("[Stream #{}] Start streaming file {} to {}, repairedAt = {}, totalSize = {}",
                          SafeArg.of("planId", session.planId()),
-                         SafeArg.of("file", sstable.getFilename()),
+                         UnsafeArg.of("file", sstable.getFilename()),
                          SafeArg.of("peer", session.peer),
                          SafeArg.of("repairedAt", sstable.getSSTableMetadata().repairedAt),
                          SafeArg.of("totalSize", totalSize));
@@ -124,7 +125,7 @@ public class StreamWriter
             if (logger.isDebugEnabled())
                 logger.debug("[Stream #{}] Finished streaming file {} to {}, bytesTransferred = {}, totalSize = {}",
                              SafeArg.of("planId", session.planId()),
-                             SafeArg.of("file", sstable.getFilename()),
+                             UnsafeArg.of("file", sstable.getFilename()),
                              SafeArg.of("peer", session.peer),
                              SafeArg.of("bytesTransferred", progress),
                              SafeArg.of("totalSize", totalSize));

--- a/src/java/org/apache/cassandra/streaming/compress/CompressedStreamReader.java
+++ b/src/java/org/apache/cassandra/streaming/compress/CompressedStreamReader.java
@@ -25,6 +25,8 @@ import java.nio.channels.ReadableByteChannel;
 
 import com.google.common.base.Throwables;
 
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.io.sstable.format.SSTableWriter;
 
@@ -82,9 +84,15 @@ public class CompressedStreamReader extends StreamReader
             throw new IOException("CF " + cfId + " was dropped during streaming");
         }
 
-        logger.debug("[Stream #{}] Start receiving file #{} from {}, repairedAt = {}, size = {}, ks = '{}', table = '{}'.",
-                     session.planId(), fileSeqNum, session.peer, repairedAt, totalSize, cfs.keyspace.getName(),
-                     cfs.getColumnFamilyName());
+        if (logger.isDebugEnabled())
+            logger.debug("[Stream #{}] Start receiving file #{} from {}, repairedAt = {}, size = {}, ks = '{}', table = '{}'.",
+                         SafeArg.of("planId", session.planId()),
+                         SafeArg.of("fileSeqNum", fileSeqNum),
+                         SafeArg.of("peer", session.peer),
+                         SafeArg.of("repairedAt", repairedAt),
+                         SafeArg.of("size", totalSize),
+                         SafeArg.of("keyspace", cfs.keyspace.getName()),
+                         SafeArg.of("table", cfs.getColumnFamilyName()));
 
         CompressedInputStream cis = new CompressedInputStream(Channels.newInputStream(channel), compressionInfo);
         BytesReadTracker in = new BytesReadTracker(new DataInputStream(cis));
@@ -113,15 +121,23 @@ public class CompressedStreamReader extends StreamReader
                     session.progress(desc, ProgressInfo.Direction.IN, cis.getTotalCompressedBytesRead(), totalSize);
                 }
             }
-            logger.debug("[Stream #{}] Finished receiving file #{} from {} readBytes = {}, totalSize = {}", session.planId(), fileSeqNum,
-                         session.peer, cis.getTotalCompressedBytesRead(), totalSize);
+            if (logger.isDebugEnabled())
+                logger.debug("[Stream #{}] Finished receiving file #{} from {} readBytes = {}, totalSize = {}",
+                             SafeArg.of("planId", session.planId()),
+                             SafeArg.of("fileSeqNum", fileSeqNum),
+                             SafeArg.of("peer", session.peer),
+                             SafeArg.of("readBytes", cis.getTotalCompressedBytesRead()),
+                             SafeArg.of("totalSize", totalSize));
             return writer;
         }
         catch (Throwable e)
         {
             if (key != null)
                 logger.warn("[Stream {}] Error while reading partition {} from stream on ks='{}' and table='{}'.",
-                            session.planId(), key, cfs.keyspace.getName(), cfs.getColumnFamilyName());
+                            SafeArg.of("planId", session.planId()),
+                            UnsafeArg.of("key", key),
+                            SafeArg.of("keyspace", cfs.keyspace.getName()),
+                            SafeArg.of("columnFamily", cfs.getColumnFamilyName()));
             if (writer != null)
             {
                 try

--- a/src/java/org/apache/cassandra/streaming/compress/CompressedStreamWriter.java
+++ b/src/java/org/apache/cassandra/streaming/compress/CompressedStreamWriter.java
@@ -28,6 +28,7 @@ import com.google.common.base.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.io.compress.CompressionMetadata;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.ChannelProxy;
@@ -59,8 +60,13 @@ public class CompressedStreamWriter extends StreamWriter
     public void write(DataOutputStreamPlus out) throws IOException
     {
         long totalSize = totalSize();
-        logger.debug("[Stream #{}] Start streaming file {} to {}, repairedAt = {}, totalSize = {}", session.planId(),
-                     sstable.getFilename(), session.peer, sstable.getSSTableMetadata().repairedAt, totalSize);
+        if (logger.isDebugEnabled())
+            logger.debug("[Stream #{}] Start streaming file {} to {}, repairedAt = {}, totalSize = {}",
+                         SafeArg.of("planId", session.planId()),
+                         SafeArg.of("file", sstable.getFilename()),
+                         SafeArg.of("peer", session.peer),
+                         SafeArg.of("repairedAt", sstable.getSSTableMetadata().repairedAt),
+                         SafeArg.of("totalSize", totalSize));
         try (RandomAccessReader file = sstable.openDataReader(); final ChannelProxy fc = file.getChannel())
         {
             long progress = 0L;
@@ -96,8 +102,13 @@ public class CompressedStreamWriter extends StreamWriter
                     session.progress(sstable.descriptor, ProgressInfo.Direction.OUT, progress, totalSize);
                 }
             }
-            logger.debug("[Stream #{}] Finished streaming file {} to {}, bytesTransferred = {}, totalSize = {}",
-                         session.planId(), sstable.getFilename(), session.peer, progress, totalSize);
+            if (logger.isDebugEnabled())
+                logger.debug("[Stream #{}] Finished streaming file {} to {}, bytesTransferred = {}, totalSize = {}",
+                             SafeArg.of("planId", session.planId()),
+                             SafeArg.of("file", sstable.getFilename()),
+                             SafeArg.of("peer", session.peer),
+                             SafeArg.of("bytesTransferred", progress),
+                             SafeArg.of("totalSize", totalSize));
         }
     }
 

--- a/src/java/org/apache/cassandra/streaming/compress/CompressedStreamWriter.java
+++ b/src/java/org/apache/cassandra/streaming/compress/CompressedStreamWriter.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import org.apache.cassandra.io.compress.CompressionMetadata;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.ChannelProxy;
@@ -63,7 +64,7 @@ public class CompressedStreamWriter extends StreamWriter
         if (logger.isDebugEnabled())
             logger.debug("[Stream #{}] Start streaming file {} to {}, repairedAt = {}, totalSize = {}",
                          SafeArg.of("planId", session.planId()),
-                         SafeArg.of("file", sstable.getFilename()),
+                         UnsafeArg.of("file", sstable.getFilename()),
                          SafeArg.of("peer", session.peer),
                          SafeArg.of("repairedAt", sstable.getSSTableMetadata().repairedAt),
                          SafeArg.of("totalSize", totalSize));
@@ -105,7 +106,7 @@ public class CompressedStreamWriter extends StreamWriter
             if (logger.isDebugEnabled())
                 logger.debug("[Stream #{}] Finished streaming file {} to {}, bytesTransferred = {}, totalSize = {}",
                              SafeArg.of("planId", session.planId()),
-                             SafeArg.of("file", sstable.getFilename()),
+                             UnsafeArg.of("file", sstable.getFilename()),
                              SafeArg.of("peer", session.peer),
                              SafeArg.of("bytesTransferred", progress),
                              SafeArg.of("totalSize", totalSize));


### PR DESCRIPTION
Mark logging arguments as Safe or Unsafe in `org.apache.cassandra.streaming`.

This PR also wraps all calls to `logger.debug()` in an `if (logger.isDebugEnabled())` check.

For reviewers, please confirm that you agree with my choices for SafeArgs.

Everything appears to be safe except
- `partitionKey` in `StreamReader`

Interesting is the `message` variable in `ConnectionHandler`. I validated that these are safe by checking the `toString` methods of all subclasses of `StreamMessage`, but would appreciate a second look at this.
