### PR TITLE
migrate to SafeLogging in `org.apache.cassandra.gms`

### DIFF
--- a/src/java/org/apache/cassandra/gms/FailureDetector.java
+++ b/src/java/org/apache/cassandra/gms/FailureDetector.java
@@ -35,6 +35,7 @@ import com.codahale.metrics.UniformSnapshot;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.cassandra.db.BootstrappingSafetyException;
 import com.palantir.cassandra.metrics.FailureDetectorMetrics;
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.util.FileUtils;
@@ -68,7 +69,7 @@ public class FailureDetector implements IFailureDetector, FailureDetectorMBean
         if (System.getProperty("cassandra.max_local_pause_in_ms") != null)
         {
             long pause = Long.parseLong(System.getProperty("cassandra.max_local_pause_in_ms"));
-            logger.warn("Overriding max local pause time to {} ms", pause);
+            logger.warn("Overriding max local pause time to {} ms", SafeArg.of("timeInMs", pause));
             return pause * 1000000L;
         }
         else
@@ -80,7 +81,7 @@ public class FailureDetector implements IFailureDetector, FailureDetectorMBean
         if (System.getProperty("palantir_cassandra.bootstrap_safeguard_pause_in_ms") != null)
         {
             long pause = Long.parseLong(System.getProperty("palantir_cassandra.bootstrap_safeguard_pause_in_ms"));
-            logger.warn("Overriding max bootstrapping node pause time to {} ms", pause);
+            logger.warn("Overriding max bootstrapping node pause time to {} ms", SafeArg.of("timeInMs", pause));
             return pause * 1000000L;
         }
         else
@@ -113,7 +114,7 @@ public class FailureDetector implements IFailureDetector, FailureDetectorMBean
         }
         else
         {
-            logger.info("Overriding FD INITIAL_VALUE to {}ms", newvalue);
+            logger.info("Overriding FD INITIAL_VALUE to {}ms", SafeArg.of("valueInMs", newvalue));
             return Integer.parseInt(newvalue);
         }
     }
@@ -258,7 +259,7 @@ public class FailureDetector implements IFailureDetector, FailureDetectorMBean
         // it's worth being defensive here so minor bugs don't cause disproportionate
         // badness.  (See CASSANDRA-1463 for an example).
         if (epState == null)
-            logger.error("unknown endpoint {}", ep);
+            logger.error("unknown endpoint {}", SafeArg.of("endpoint", ep));
         return epState != null && epState.isAlive();
     }
 
@@ -286,7 +287,7 @@ public class FailureDetector implements IFailureDetector, FailureDetectorMBean
         }
 
         if (logger.isTraceEnabled())
-            logger.trace("Average for {} is {}", ep, heartbeatWindow.mean());
+            logger.trace("Average for {} is {}", SafeArg.of("endpoint", ep), SafeArg.of("mean", heartbeatWindow.mean()));
     }
 
     private void safeguardBootstrapTimeout()
@@ -295,7 +296,7 @@ public class FailureDetector implements IFailureDetector, FailureDetectorMBean
         {
             StorageService.instance.unsafeDisableNode();
             logger.error("Detected local pause longer than Gossiper failed bootstrap timeout (nanos) {}"
-                   + "whilst node was bootstrapping", MAX_BOOTSTRAPPING_NODE_PAUSE_IN_NANOS);
+                         + "whilst node was bootstrapping", SafeArg.of("timeout", MAX_BOOTSTRAPPING_NODE_PAUSE_IN_NANOS));
             StorageService.instance.recordNonTransientError(StorageServiceMBean.NonTransientError.BOOTSTRAP_ERROR,
                                                             ImmutableMap.of("timeoutDuringBootstrap", "true"));
             throw new BootstrappingSafetyException("Bootstrap failed due to gossip timeout");
@@ -318,7 +319,9 @@ public class FailureDetector implements IFailureDetector, FailureDetectorMBean
         }
         if (diff > MAX_LOCAL_PAUSE_IN_NANOS)
         {
-            logger.warn("Not marking nodes down due to local pause of {} > {}", diff, MAX_LOCAL_PAUSE_IN_NANOS);
+            logger.warn("Not marking nodes down due to local pause of {} > {}",
+                        SafeArg.of("localPause", diff),
+                        SafeArg.of("maxLocalPause", MAX_LOCAL_PAUSE_IN_NANOS));
             lastPause = now;
             return;
         }
@@ -329,12 +332,17 @@ public class FailureDetector implements IFailureDetector, FailureDetectorMBean
         }
         double phi = hbWnd.phi(now);
         if (logger.isTraceEnabled())
-            logger.trace("PHI for {} : {}", ep, phi);
+            logger.trace("PHI for {} : {}", SafeArg.of("endpoint", ep), SafeArg.of("phi", phi));
 
         if (PHI_FACTOR * phi > getPhiConvictThreshold())
         {
             if (logger.isTraceEnabled())
-                logger.trace("Node {} phi {} > {}; intervals: {} mean: {}", new Object[]{ep, PHI_FACTOR * phi, getPhiConvictThreshold(), hbWnd, hbWnd.mean()});
+                logger.trace("Node {} phi {} > {}; intervals: {} mean: {}",
+                             SafeArg.of("endpoint", ep),
+                             SafeArg.of("adjustedPhi", PHI_FACTOR * phi),
+                             SafeArg.of("phiConvictThreshold", getPhiConvictThreshold()),
+                             SafeArg.of("intervals", hbWnd),
+                             SafeArg.of("mean", hbWnd.mean()));
             for (IFailureDetectionEventListener listener : fdEvntListeners)
             {
                 listener.convict(ep, phi);
@@ -342,18 +350,19 @@ public class FailureDetector implements IFailureDetector, FailureDetectorMBean
         }
         else if (logger.isDebugEnabled() && (PHI_FACTOR * phi * DEBUG_PERCENTAGE / 100.0 > getPhiConvictThreshold()))
         {
-            logger.debug("PHI for {} : {}", ep, phi);
+            logger.debug("PHI for {} : {}", SafeArg.of("endpoint", ep), SafeArg.of("phi", phi));
         }
         else if (logger.isTraceEnabled())
         {
-            logger.trace("PHI for {} : {}", ep, phi);
-            logger.trace("mean for {} : {}", ep, hbWnd.mean());
+            logger.trace("PHI for {} : {}", SafeArg.of("endpoint", ep), SafeArg.of("phi", phi));
+            logger.trace("mean for {} : {}", SafeArg.of("endpoint", ep), SafeArg.of("mean", hbWnd.mean()));
         }
     }
 
     public void forceConviction(InetAddress ep)
     {
-        logger.debug("Forcing conviction of {}", ep);
+        if (logger.isDebugEnabled())
+            logger.debug("Forcing conviction of {}", SafeArg.of("endpoint", ep));
         for (IFailureDetectionEventListener listener : fdEvntListeners)
         {
             listener.convict(ep, getPhiConvictThreshold());
@@ -474,7 +483,7 @@ class ArrivalWindow
         }
         else
         {
-            logger.info("Overriding FD MAX_INTERVAL to {}ms", newvalue);
+            logger.info("Overriding FD MAX_INTERVAL to {}ms", SafeArg.of("valueInMs", newvalue));
             return TimeUnit.NANOSECONDS.convert(Integer.parseInt(newvalue), TimeUnit.MILLISECONDS);
         }
     }
@@ -488,11 +497,13 @@ class ArrivalWindow
             if (interArrivalTime <= MAX_INTERVAL_IN_NANO)
             {
                 arrivalIntervals.add(interArrivalTime);
-                logger.trace("Reporting interval time of {} for {}", interArrivalTime, ep);
+                if (logger.isTraceEnabled())
+                    logger.trace("Reporting interval time of {} for {}", SafeArg.of("interval", interArrivalTime), SafeArg.of("endpoint", ep));
             }
             else
             {
-                logger.debug("Ignoring interval time of {} for {}", interArrivalTime, ep);
+                if (logger.isDebugEnabled())
+                    logger.debug("Ignoring interval time of {} for {}", SafeArg.of("interval", interArrivalTime), SafeArg.of("endpoint", ep));
             }
         }
         else

--- a/src/java/org/apache/cassandra/gms/GossipDigestAck2VerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestAck2VerbHandler.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.MessageIn;
 
@@ -35,7 +36,7 @@ public class GossipDigestAck2VerbHandler implements IVerbHandler<GossipDigestAck
         if (logger.isTraceEnabled())
         {
             InetAddress from = message.from;
-            logger.trace("Received a GossipDigestAck2Message from {}", from);
+            logger.trace("Received a GossipDigestAck2Message from {}", SafeArg.of("endpoint", from));
         }
         if (!Gossiper.instance.isEnabled())
         {

--- a/src/java/org/apache/cassandra/gms/GossipDigestAckVerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestAckVerbHandler.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.MessageIn;
 import org.apache.cassandra.net.MessageOut;
@@ -38,7 +39,7 @@ public class GossipDigestAckVerbHandler implements IVerbHandler<GossipDigestAck>
     {
         InetAddress from = message.from;
         if (logger.isTraceEnabled())
-            logger.trace("Received a GossipDigestAckMessage from {}", from);
+            logger.trace("Received a GossipDigestAckMessage from {}", SafeArg.of("endpoint", from));
         if (!Gossiper.instance.isEnabled() && !Gossiper.instance.isInShadowRound())
         {
             if (logger.isTraceEnabled())
@@ -49,12 +50,12 @@ public class GossipDigestAckVerbHandler implements IVerbHandler<GossipDigestAck>
         GossipDigestAck gDigestAckMessage = message.payload;
         List<GossipDigest> gDigestList = gDigestAckMessage.getGossipDigestList();
         Map<InetAddress, EndpointState> epStateMap = gDigestAckMessage.getEndpointStateMap();
-        logger.trace("Received ack with {} digests and {} states", gDigestList.size(), epStateMap.size());
+        logger.trace("Received ack with {} digests and {} states", SafeArg.of("digestSize", gDigestList.size()), SafeArg.of("epStateSize", epStateMap.size()));
 
         if (Gossiper.instance.isInShadowRound())
         {
             if (logger.isDebugEnabled())
-                logger.debug("Finishing shadow round with {}", from);
+                logger.debug("Finishing shadow round with {}", SafeArg.of("endpoint", from));
             Gossiper.instance.finishShadowRound(epStateMap);
             return; // don't bother doing anything else, we have what we came for
         }
@@ -67,7 +68,7 @@ public class GossipDigestAckVerbHandler implements IVerbHandler<GossipDigestAck>
             if ((System.nanoTime() - Gossiper.instance.firstSynSendAt) < 0 || Gossiper.instance.firstSynSendAt == 0)
             {
                 if (logger.isTraceEnabled())
-                    logger.trace("Ignoring unrequested GossipDigestAck from {}", from);
+                    logger.trace("Ignoring unrequested GossipDigestAck from {}", SafeArg.of("endpoint", from));
                 return;
             }
 
@@ -90,7 +91,7 @@ public class GossipDigestAckVerbHandler implements IVerbHandler<GossipDigestAck>
                                                                                            new GossipDigestAck2(deltaEpStateMap),
                                                                                            GossipDigestAck2.serializer);
         if (logger.isTraceEnabled())
-            logger.trace("Sending a GossipDigestAck2Message to {}", from);
+            logger.trace("Sending a GossipDigestAck2Message to {}", SafeArg.of("endpoint", from));
         MessagingService.instance().sendOneWay(gDigestAck2Message, from);
     }
 }

--- a/src/java/org/apache/cassandra/gms/GossipDigestSynVerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestSynVerbHandler.java
@@ -23,6 +23,7 @@ import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.MessageIn;
@@ -37,7 +38,7 @@ public class GossipDigestSynVerbHandler implements IVerbHandler<GossipDigestSyn>
     {
         InetAddress from = message.from;
         if (logger.isTraceEnabled())
-            logger.trace("Received a GossipDigestSynMessage from {}", from);
+            logger.trace("Received a GossipDigestSynMessage from {}", SafeArg.of("endpoint", from));
         if (!Gossiper.instance.isEnabled())
         {
             if (logger.isTraceEnabled())
@@ -49,13 +50,19 @@ public class GossipDigestSynVerbHandler implements IVerbHandler<GossipDigestSyn>
         /* If the message is from a different cluster throw it away. */
         if (!gDigestMessage.clusterId.equals(DatabaseDescriptor.getClusterName()))
         {
-            logger.warn("ClusterName mismatch from {} {}!={}", from, gDigestMessage.clusterId, DatabaseDescriptor.getClusterName());
+            logger.warn("ClusterName mismatch from {} {}!={}",
+                        SafeArg.of("remoteEndpoint", from),
+                        SafeArg.of("remoteCluster", gDigestMessage.clusterId),
+                        SafeArg.of("localCluster", DatabaseDescriptor.getClusterName()));
             return;
         }
 
         if (gDigestMessage.partioner != null && !gDigestMessage.partioner.equals(DatabaseDescriptor.getPartitionerName()))
         {
-            logger.warn("Partitioner mismatch from {} {}!={}", from, gDigestMessage.partioner, DatabaseDescriptor.getPartitionerName());
+            logger.warn("Partitioner mismatch from {} {}!={}",
+                        SafeArg.of("remoteEndpoint", from),
+                        SafeArg.of("remotePartitioner", gDigestMessage.partioner),
+                        SafeArg.of("localPartitioner", DatabaseDescriptor.getPartitionerName()));
             return;
         }
 
@@ -68,7 +75,7 @@ public class GossipDigestSynVerbHandler implements IVerbHandler<GossipDigestSyn>
                 sb.append(gDigest);
                 sb.append(" ");
             }
-            logger.trace("Gossip syn digests are : {}", sb);
+            logger.trace("Gossip syn digests are : {}", SafeArg.of("digests", sb));
         }
 
         doSort(gDigestList);
@@ -76,12 +83,12 @@ public class GossipDigestSynVerbHandler implements IVerbHandler<GossipDigestSyn>
         List<GossipDigest> deltaGossipDigestList = new ArrayList<GossipDigest>();
         Map<InetAddress, EndpointState> deltaEpStateMap = new HashMap<InetAddress, EndpointState>();
         Gossiper.instance.examineGossiper(gDigestList, deltaGossipDigestList, deltaEpStateMap);
-        logger.trace("sending {} digests and {} deltas", deltaGossipDigestList.size(), deltaEpStateMap.size());
+        logger.trace("sending {} digests and {} deltas", SafeArg.of("digests", deltaGossipDigestList.size()), SafeArg.of("deltas", deltaEpStateMap.size()));
         MessageOut<GossipDigestAck> gDigestAckMessage = new MessageOut<GossipDigestAck>(MessagingService.Verb.GOSSIP_DIGEST_ACK,
                                                                                         new GossipDigestAck(deltaGossipDigestList, deltaEpStateMap),
                                                                                         GossipDigestAck.serializer);
         if (logger.isTraceEnabled())
-            logger.trace("Sending a GossipDigestAckMessage to {}", from);
+            logger.trace("Sending a GossipDigestAckMessage to {}", SafeArg.of("endpoint", from));
         MessagingService.instance().sendOneWay(gDigestAckMessage, from);
     }
 

--- a/src/java/org/apache/cassandra/gms/GossipShutdownVerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipShutdownVerbHandler.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.gms;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.MessageIn;
 
@@ -31,7 +32,8 @@ public class GossipShutdownVerbHandler implements IVerbHandler
     {
         if (!Gossiper.instance.isEnabled())
         {
-            logger.debug("Ignoring shutdown message from {} because gossip is disabled", message.from);
+            if (logger.isDebugEnabled())
+                logger.debug("Ignoring shutdown message from {} because gossip is disabled", SafeArg.of("endpoint", message.from));
             return;
         }
         Gossiper.instance.markAsShutdown(message.from);

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 
 import com.palantir.cassandra.cvim.CrossVpcIpMappingHandshaker;
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.MBeanWrapper;
 import org.apache.cassandra.utils.Pair;
@@ -153,7 +154,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                 /* Update the local heartbeat counter. */
                 endpointStateMap.get(FBUtilities.getBroadcastAddress()).getHeartBeatState().updateHeartBeat();
                 if (logger.isTraceEnabled())
-                    logger.trace("My heartbeat is now {}", endpointStateMap.get(FBUtilities.getBroadcastAddress()).getHeartBeatState().getHeartBeatVersion());
+                    logger.trace("My heartbeat is now {}", SafeArg.of("heartbeat", endpointStateMap.get(FBUtilities.getBroadcastAddress()).getHeartBeatState().getHeartBeatVersion()));
                 final List<GossipDigest> gDigests = new ArrayList<GossipDigest>();
                 Gossiper.instance.makeRandomGossipDigest(gDigests);
 
@@ -215,7 +216,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             {
                 longValue = Long.MAX_VALUE;
             }
-            logger.info("Overriding FAILED_BOOTSTRAP_TIMEOUT to {}ms", longValue);
+            logger.info("Overriding FAILED_BOOTSTRAP_TIMEOUT to {}ms", SafeArg.of("valueInMs", longValue));
             return longValue;
         }
         else
@@ -240,7 +241,8 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
 
     public boolean seenAnySeed()
     {
-        logger.debug("Checking if seenAnySeed with seeds {} and endpointStateMap {}", seeds, endpointStateMap);
+        if (logger.isDebugEnabled())
+            logger.debug("Checking if seenAnySeed with seeds {} and endpointStateMap {}", SafeArg.of("seeds", seeds), SafeArg.of("endpointStateMap", endpointStateMap));
         for (Map.Entry<InetAddress, EndpointState> entry : endpointStateMap.entrySet())
         {
             if (seeds.contains(entry.getKey()))
@@ -248,7 +250,8 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             try
             {
                 VersionedValue internalIp = entry.getValue().getApplicationState(ApplicationState.INTERNAL_IP);
-                logger.debug("Converting endpoint entry {} to internalIP {} and comparing it to seeds", entry.getValue(), internalIp);
+                if (logger.isDebugEnabled())
+                    logger.debug("Converting endpoint entry {} to internalIP {} and comparing it to seeds", SafeArg.of("entry", entry.getValue()), SafeArg.of("internalIp", internalIp));
                 if (internalIp != null && seeds.contains(InetAddress.getByName(internalIp.value)))
                     return true;
             }
@@ -360,7 +363,11 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         if (!epState.isAlive())
             return;
 
-        logger.debug("Convicting {} with status {} - alive {}", endpoint, getGossipStatus(epState), epState.isAlive());
+        if (logger.isDebugEnabled())
+            logger.debug("Convicting {} with status {} - alive {}",
+                         SafeArg.of("endpoint", endpoint),
+                         SafeArg.of("status", getGossipStatus(epState)),
+                         SafeArg.of("isAlive", epState.isAlive()));
 
 
         if (isShutdown(endpoint))
@@ -415,7 +422,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         FailureDetector.instance.remove(endpoint);
         quarantineEndpoint(endpoint);
         if (logger.isDebugEnabled())
-            logger.debug("evicting {} from gossip", endpoint);
+            logger.debug("evicting {} from gossip", SafeArg.of("endpoint", endpoint));
     }
 
     /**
@@ -440,7 +447,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         quarantineEndpoint(endpoint);
         MessagingService.instance().destroyConnectionPool(endpoint);
         if (logger.isDebugEnabled())
-            logger.debug("removing endpoint {}", endpoint);
+            logger.debug("removing endpoint {}", SafeArg.of("endpoint", endpoint));
     }
 
     /**
@@ -521,7 +528,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                 sb.append(gDigest);
                 sb.append(" ");
             }
-            logger.trace("Gossip Digests are : {}", sb);
+            logger.trace("Gossip Digests are : {}", SafeArg.of("digests", sb));
         }
     }
 
@@ -539,14 +546,14 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         // remember this node's generation
         int generation = epState.getHeartBeatState().getGeneration();
         logger.info("Removing host: {}", hostId);
-        logger.info("Sleeping for {}ms to ensure {} does not change", StorageService.RING_DELAY, endpoint);
+        logger.info("Sleeping for {}ms to ensure {} does not change", SafeArg.of("ringDelay", StorageService.RING_DELAY), SafeArg.of("endpoint", endpoint));
         Uninterruptibles.sleepUninterruptibly(StorageService.RING_DELAY, TimeUnit.MILLISECONDS);
         // make sure it did not change
         epState = endpointStateMap.get(endpoint);
         if (epState.getHeartBeatState().getGeneration() != generation)
             throw new RuntimeException("Endpoint " + endpoint + " generation changed while trying to remove it");
         // update the other node's generation to mimic it as if it had changed it itself
-        logger.info("Advertising removal for {}", endpoint);
+        logger.info("Advertising removal for {}", SafeArg.of("endpoint", endpoint));
         epState.updateTimestamp(); // make sure we don't evict it too soon
         epState.getHeartBeatState().forceNewerGenerationUnsafe();
         Map<ApplicationState, VersionedValue> states = new EnumMap<>(ApplicationState.class);
@@ -570,7 +577,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         epState.getHeartBeatState().forceNewerGenerationUnsafe();
         long expireTime = computeExpireTime();
         epState.addApplicationState(ApplicationState.STATUS, StorageService.instance.valueFactory.removedNonlocal(hostId, expireTime));
-        logger.info("Completing removal of {}", endpoint);
+        logger.info("Completing removal of {}", SafeArg.of("endpoint", endpoint));
         addExpireTimeForEndpoint(endpoint, expireTime);
         endpointStateMap.put(endpoint, epState);
         // ensure at least one gossip round occurs before returning
@@ -596,7 +603,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         InetAddress endpoint = InetAddress.getByName(address);
         EndpointState epState = endpointStateMap.get(endpoint);
         Collection<Token> tokens = null;
-        logger.warn("Assassinating {} via gossip", endpoint);
+        logger.warn("Assassinating {} via gossip", SafeArg.of("endpoint", endpoint));
 
         if (epState == null)
         {
@@ -612,17 +619,19 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             {
                 JVMStabilityInspector.inspectThrowable(th);
                 // TODO this is broken
-                logger.warn("Unable to calculate tokens for {}.  Will use a random one", address);
+                logger.warn("Unable to calculate tokens for {}.  Will use a random one", SafeArg.of("address", address));
                 tokens = Collections.singletonList(StorageService.getPartitioner().getRandomToken());
             }
             int generation = epState.getHeartBeatState().getGeneration();
             int heartbeat = epState.getHeartBeatState().getHeartBeatVersion();
-            logger.info("Sleeping for {}ms to ensure {} does not change", StorageService.RING_DELAY, endpoint);
+            logger.info("Sleeping for {}ms to ensure {} does not change",
+                        SafeArg.of("delayInMs", StorageService.RING_DELAY),
+                        SafeArg.of("endpoint", endpoint));
             Uninterruptibles.sleepUninterruptibly(StorageService.RING_DELAY, TimeUnit.MILLISECONDS);
             // make sure it did not change
             EndpointState newState = endpointStateMap.get(endpoint);
             if (newState == null)
-                logger.warn("Endpoint {} disappeared while trying to assassinate, continuing anyway", endpoint);
+                logger.warn("Endpoint {} disappeared while trying to assassinate, continuing anyway", SafeArg.of("endpoint", endpoint));
             else if (newState.getHeartBeatState().getGeneration() != generation)
                 throw new RuntimeException("Endpoint still alive: " + endpoint + " generation changed while trying to assassinate it");
             else if (newState.getHeartBeatState().getHeartBeatVersion() != heartbeat)
@@ -635,7 +644,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         epState.addApplicationState(ApplicationState.STATUS, StorageService.instance.valueFactory.left(tokens, computeExpireTime()));
         handleMajorStateChange(endpoint, epState);
         Uninterruptibles.sleepUninterruptibly(intervalInMillis * 4, TimeUnit.MILLISECONDS);
-        logger.warn("Finished assassinating {}", endpoint);
+        logger.warn("Finished assassinating {}", SafeArg.of("endpoint", endpoint));
     }
 
     public boolean isKnownEndpoint(InetAddress endpoint)
@@ -666,7 +675,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         int index = (size == 1) ? 0 : random.nextInt(size);
         InetAddress to = liveEndpoints.get(index);
         if (logger.isTraceEnabled())
-            logger.trace("Sending a GossipDigestSyn to {} ...", to);
+            logger.trace("Sending a GossipDigestSyn to {} ...", SafeArg.of("endpoint", to));
         if (firstSynSendAt == 0)
             firstSynSendAt = System.nanoTime();
         MessagingService.instance().sendOneWay(message, to);
@@ -778,7 +787,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             // still behind?  something's broke
             if (lastProcessedMessageAt < now - 1000)
             {
-                logger.warn("Gossip stage has {} pending tasks; skipping status check (no nodes will be marked down)", pending);
+                logger.warn("Gossip stage has {} pending tasks; skipping status check (no nodes will be marked down)", SafeArg.of("pendingTasks", pending));
                 return;
             }
         }
@@ -800,7 +809,9 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                     && !justRemovedEndpoints.containsKey(endpoint)
                     && TimeUnit.NANOSECONDS.toMillis(nowNano - epState.getUpdateTimestamp()) > fatClientTimeout)
                 {
-                    logger.info("FatClient {} has been silent for {}ms, removing from gossip", endpoint, fatClientTimeout);
+                    logger.info("FatClient {} has been silent for {}ms, removing from gossip",
+                                SafeArg.of("endpoint", endpoint),
+                                SafeArg.of("fatClientTimeout", fatClientTimeout));
                     removeEndpoint(endpoint); // will put it in justRemovedEndpoints to respect quarantine delay
                     evictFromMembership(endpoint); // can get rid of the state immediately
                 }
@@ -812,7 +823,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                 {
                     if (logger.isDebugEnabled())
                     {
-                        logger.debug("time is expiring for endpoint : {} ({})", endpoint, expireTime);
+                        logger.debug("time is expiring for endpoint : {} ({})", SafeArg.of("endpoint", endpoint), SafeArg.of("expireTime", expireTime));
                     }
                     evictFromMembership(endpoint);
                 }
@@ -826,7 +837,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                 if ((now - entry.getValue()) > QUARANTINE_DELAY)
                 {
                     if (logger.isDebugEnabled())
-                        logger.debug("{} elapsed, {} gossip quarantine over", QUARANTINE_DELAY, entry.getKey());
+                        logger.debug("{} elapsed, {} gossip quarantine over", SafeArg.of("delay", QUARANTINE_DELAY), SafeArg.of("endpoint", entry.getKey()));
                     justRemovedEndpoints.remove(entry.getKey());
                 }
             }
@@ -900,7 +911,10 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             {
                 reqdEndpointState = new EndpointState(new HeartBeatState(localHbGeneration, localHbVersion));
                 if (logger.isTraceEnabled())
-                    logger.trace("local heartbeat version {} greater than {} for {}", localHbVersion, version, forEndpoint);
+                    logger.trace("local heartbeat version {} greater than {} for {}",
+                                 SafeArg.of("localHbVersion", localHbVersion),
+                                 SafeArg.of("version", version),
+                                 SafeArg.of("endpoint", forEndpoint));
             }
             /* Accumulate all application states whose versions are greater than "version" variable */
             Map<ApplicationState, VersionedValue> states = new EnumMap<>(ApplicationState.class);
@@ -915,7 +929,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                     }
                     final ApplicationState key = entry.getKey();
                     if (logger.isTraceEnabled())
-                        logger.trace("Adding state {}: {}" , key, value.value);
+                        logger.trace("Adding state {}: {}", SafeArg.of("key", key), SafeArg.of("value", value.value));
 
                     states.put(key, value);
                 }
@@ -964,7 +978,8 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                 // we will clean the fd intervals for it and relearn them
                 if (!localEndpointState.isAlive())
                 {
-                    logger.debug("Clearing interval times for {} due to generation change", endpoint);
+                    if (logger.isDebugEnabled())
+                        logger.debug("Clearing interval times for {} due to generation change", SafeArg.of("endpoint", endpoint));
                     fd.remove(endpoint);
                 }
                 fd.report(endpoint);
@@ -991,7 +1006,10 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         int version = MessagingService.instance().getVersion(addr);
         if (version < MessagingService.VERSION_20)
         {
-            logger.trace("Marking as alive b/c version {} < {}. {}", version, MessagingService.VERSION_20, addr);
+            logger.trace("Marking as alive b/c version {} < {}. {}",
+                         SafeArg.of("version", version),
+                         SafeArg.of("maxVersion", MessagingService.VERSION_20),
+                         SafeArg.of("endpoint", addr));
             realMarkAlive(addr, localState);
             return;
         }
@@ -999,7 +1017,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         localState.markDead();
 
         MessageOut<EchoMessage> echoMessage = new MessageOut<EchoMessage>(MessagingService.Verb.ECHO, EchoMessage.instance, EchoMessage.serializer);
-        logger.trace("Sending a EchoMessage to {}", addr);
+        logger.trace("Sending a EchoMessage to {}", SafeArg.of("endpoint", addr));
         IAsyncCallback echoHandler = new IAsyncCallback()
         {
             public boolean isLatencyForSnitch()
@@ -1009,7 +1027,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
 
             public void response(MessageIn msg)
             {
-                logger.trace("marking alive via echo handler {}", addr);
+                logger.trace("marking alive via echo handler {}", SafeArg.of("endpoint", addr));
                 realMarkAlive(addr, localState);
             }
         };
@@ -1021,14 +1039,15 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
     public void realMarkAlive(final InetAddress addr, final EndpointState localState)
     {
         if (logger.isTraceEnabled())
-            logger.trace("marking as alive {}", addr);
+            logger.trace("marking as alive {}", SafeArg.of("endpoint", addr));
         localState.markAlive();
         localState.updateTimestamp(); // prevents doStatusCheck from racing us and evicting if it was down > aVeryLongTime
         liveEndpoints.add(addr);
         unreachableEndpoints.remove(addr);
         expireTimeEndpointMap.remove(addr);
-        logger.debug("removing expire time for endpoint : {}", addr);
-        logger.info("InetAddress {} is now UP", addr);
+        if (logger.isDebugEnabled())
+            logger.debug("removing expire time for endpoint : {}", SafeArg.of("endpoint", addr));
+        logger.info("InetAddress {} is now UP", SafeArg.of("endpoint", addr));
         for (IEndpointStateChangeSubscriber subscriber : subscribers)
             subscriber.onAlive(addr, localState);
         if (logger.isTraceEnabled())
@@ -1039,11 +1058,11 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
     public void markDead(InetAddress addr, EndpointState localState)
     {
         if (logger.isTraceEnabled())
-            logger.trace("marking as down {}", addr);
+            logger.trace("marking as down {}", SafeArg.of("endpoint", addr));
         localState.markDead();
         liveEndpoints.remove(addr);
         unreachableEndpoints.put(addr, System.nanoTime());
-        logger.info("InetAddress {} is now DOWN", addr);
+        logger.info("InetAddress {} is now DOWN", SafeArg.of("endpoint", addr));
         for (IEndpointStateChangeSubscriber subscriber : subscribers)
             subscriber.onDead(addr, localState);
         if (logger.isTraceEnabled())
@@ -1062,12 +1081,12 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         if (!isDeadState(epState))
         {
             if (localEpState != null)
-                logger.info("Node {} has restarted, now UP", ep);
+                logger.info("Node {} has restarted, now UP", SafeArg.of("endpoint", ep));
             else
-                logger.info("Node {} is now part of the cluster", ep);
+                logger.info("Node {} is now part of the cluster", SafeArg.of("endpoint", ep));
         }
         if (logger.isTraceEnabled())
-            logger.trace("Adding endpoint state for {}", ep);
+            logger.trace("Adding endpoint state for {}", SafeArg.of("endpoint", ep));
         endpointStateMap.put(ep, epState);
 
         if (localEpState != null)
@@ -1080,7 +1099,8 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             markAlive(ep, epState);
         else
         {
-            logger.debug("Not marking {} alive due to dead state", ep);
+            if (logger.isDebugEnabled())
+                logger.debug("Not marking {} alive due to dead state", SafeArg.of("endpoint", ep));
             markDead(ep, epState);
         }
         for (IEndpointStateChangeSubscriber subscriber : subscribers)
@@ -1137,7 +1157,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             if (justRemovedEndpoints.containsKey(ep))
             {
                 if (logger.isTraceEnabled())
-                    logger.trace("Ignoring gossip for {} because it is quarantined", ep);
+                    logger.trace("Ignoring gossip for {} because it is quarantined", SafeArg.of("endpoint", ep));
                 continue;
             }
 
@@ -1154,18 +1174,27 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                 int remoteGeneration = remoteState.getHeartBeatState().getGeneration();
                 long localTime = System.currentTimeMillis()/1000;
                 if (logger.isTraceEnabled())
-                    logger.trace("{} local generation {}, remote generation {}", ep, localGeneration, remoteGeneration);
+                    logger.trace("{} local generation {}, remote generation {}",
+                                 SafeArg.of("endpoint", ep),
+                                 SafeArg.of("localGeneration", localGeneration),
+                                 SafeArg.of("remoteGeneration", remoteGeneration));
 
                 // We measure generation drift against local time, based on the fact that generation is initialized by time
                 if (remoteGeneration > localTime + MAX_GENERATION_DIFFERENCE)
                 {
                     // assume some peer has corrupted memory and is broadcasting an unbelievable generation about another peer (or itself)
-                    logger.warn("received an invalid gossip generation for peer {}; local time = {}, received generation = {}", ep, localTime, remoteGeneration);
+                    logger.warn("received an invalid gossip generation for peer {}; local time = {}, received generation = {}",
+                                SafeArg.of("peer", ep),
+                                SafeArg.of("localTime", localTime),
+                                SafeArg.of("remoteGeneration", remoteGeneration));
                 }
                 else if (remoteGeneration > localGeneration)
                 {
                     if (logger.isTraceEnabled())
-                        logger.trace("Updating heartbeat state generation to {} from {} for {}", remoteGeneration, localGeneration, ep);
+                        logger.trace("Updating heartbeat state generation to {} from {} for {}",
+                                     SafeArg.of("remoteGeneration", remoteGeneration),
+                                     SafeArg.of("localGeneration", localGeneration),
+                                     SafeArg.of("endpoint", ep));
                     // major state change will handle the update by inserting the remote state directly
                     handleMajorStateChange(ep, remoteState);
                 }
@@ -1180,7 +1209,10 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                         applyNewStates(ep, localEpStatePtr, remoteState);
                     }
                     else if (logger.isTraceEnabled())
-                            logger.trace("Ignoring remote version {} <= {} for {}", remoteMaxVersion, localMaxVersion, ep);
+                        logger.trace("Ignoring remote version {} <= {} for {}",
+                                     SafeArg.of("remoteMaxVersion", remoteMaxVersion),
+                                     SafeArg.of("localMaxBVersion", localMaxVersion),
+                                     SafeArg.of("endpoint", ep));
 
                     if (!localEpStatePtr.isAlive() && !isDeadState(localEpStatePtr)) // unless of course, it was dead
                         markAlive(ep, localEpStatePtr);
@@ -1188,7 +1220,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                 else
                 {
                     if (logger.isTraceEnabled())
-                        logger.trace("Ignoring remote generation {} < {}", remoteGeneration, localGeneration);
+                        logger.trace("Ignoring remote generation {} < {}", SafeArg.of("remoteGeneration", remoteGeneration), SafeArg.of("localGeneration", localGeneration));
                 }
             }
             else
@@ -1207,7 +1239,10 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
 
         localState.setHeartBeatState(remoteState.getHeartBeatState());
         if (logger.isTraceEnabled())
-            logger.trace("Updating heartbeat state version to {} from {} for {} ...", localState.getHeartBeatState().getHeartBeatVersion(), oldVersion, addr);
+            logger.trace("Updating heartbeat state version to {} from {} for {} ...",
+                         SafeArg.of("version", localState.getHeartBeatState().getHeartBeatVersion()),
+                         SafeArg.of("oldVersion", oldVersion),
+                         SafeArg.of("endpoint", addr));
 
         Set<Entry<ApplicationState, VersionedValue>> remoteStates = remoteState.states();
         assert remoteState.getHeartBeatState().getGeneration() == localState.getHeartBeatState().getGeneration();
@@ -1241,7 +1276,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         /* We are here since we have no data for this endpoint locally so request everthing. */
         deltaGossipDigestList.add(new GossipDigest(gDigest.getEndpoint(), remoteGeneration, 0));
         if (logger.isTraceEnabled())
-            logger.trace("requestAll for {}", gDigest.getEndpoint());
+            logger.trace("requestAll for {}", SafeArg.of("endpoint", gDigest.getEndpoint()));
     }
 
     /* Send all the data with version greater than maxRemoteVersion */
@@ -1349,7 +1384,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         //notify snitches that Gossiper is about to start
         DatabaseDescriptor.getEndpointSnitch().gossiperStarting();
         if (logger.isTraceEnabled())
-            logger.trace("gossip started with generation {}", localState.getHeartBeatState().getGeneration());
+            logger.trace("gossip started with generation {}", SafeArg.of("generation", localState.getHeartBeatState().getGeneration()));
 
         scheduledGossipTask = executor.scheduleWithFixedDelay(new GossipTask(),
                                                               Gossiper.intervalInMillis,
@@ -1402,7 +1437,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             {
                 if (slept % 5000 == 0)
                 { // CASSANDRA-8072, retry at the beginning and every 5 seconds
-                    logger.trace("Sending shadow round GOSSIP DIGEST SYN to seeds {}", seeds);
+                    logger.trace("Sending shadow round GOSSIP DIGEST SYN to seeds {}", SafeArg.of("seeds", seeds));
                     for (InetAddress seed : seeds)
                         MessagingService.instance().sendOneWay(message, seed);
                 }
@@ -1471,7 +1506,8 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         EndpointState epState = endpointStateMap.get(ep);
         if (epState != null)
         {
-            logger.debug("not replacing a previous epState for {}, but reusing it: {}", ep, epState);
+            if (logger.isDebugEnabled())
+                logger.debug("not replacing a previous epState for {}, but reusing it: {}", SafeArg.of("endpoint", ep), SafeArg.of("endpointState", epState));
             epState.setHeartBeatState(new HeartBeatState(0));
         }
         else
@@ -1483,7 +1519,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         endpointStateMap.put(ep, epState);
         unreachableEndpoints.put(ep, System.nanoTime());
         if (logger.isTraceEnabled())
-            logger.trace("Adding saved endpoint {} {}", ep, epState.getHeartBeatState().getGeneration());
+            logger.trace("Adding saved endpoint {} {}", SafeArg.of("endpoint", ep), SafeArg.of("generation", epState.getHeartBeatState().getGeneration()));
     }
 
     private void addLocalApplicationStateInternal(ApplicationState state, VersionedValue value)
@@ -1600,7 +1636,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
     {
         if (logger.isDebugEnabled())
         {
-            logger.debug("adding expire time for endpoint : {} ({})", endpoint, expireTime);
+            logger.debug("adding expire time for endpoint : {} ({})", SafeArg.of("endpoint", endpoint), SafeArg.of("expireTime", expireTime));
         }
         expireTimeEndpointMap.put(endpoint, expireTime);
     }

--- a/src/java/org/apache/cassandra/gms/TokenSerializer.java
+++ b/src/java/org/apache/cassandra/gms/TokenSerializer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.gms;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token;
 
@@ -52,7 +53,7 @@ public class TokenSerializer
             int size = in.readInt();
             if (size < 1)
                 break;
-            logger.trace("Reading token of {} bytes", size);
+            logger.trace("Reading token of {} bytes", SafeArg.of("bytes", size));
             byte[] bintoken = new byte[size];
             in.readFully(bintoken);
             tokens.add(partitioner.getTokenFactory().fromByteArray(ByteBuffer.wrap(bintoken)));


### PR DESCRIPTION
Mark logging arguments as Safe or Unsafe in org.apache.cassandra.gms.

This PR also wraps all calls to logger.debug() in an if (logger.isDebugEnabled()) check.

For reviewers, please confirm that you agree with my choices for SafeArgs.