### PR TITLE
add JVM option `bootstrap_safety_check_grace_period_minutes`

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -111,6 +111,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     private static final boolean DISABLE_WAIT_TO_BOOTSTRAP = Boolean.getBoolean("palantir_cassandra.disable_wait_to_bootstrap");
     private static final boolean DISABLE_WAIT_TO_FINISH_BOOTSTRAP = Boolean.getBoolean("palantir_cassandra.disable_wait_to_finish_bootstrap");
     private static final Integer BOOTSTRAP_DISK_USAGE_THRESHOLD = Integer.getInteger("palantir_cassandra.bootstrap_disk_usage_threshold_percentage");
+    private static final Integer BOOTSTRAP_SAFETY_CHECK_GRACE_PERIOD_MINUTES = Integer.getInteger("palantir_cassandra.bootstrap_safety_check_grace_period_minutes", 30);
 
     public static final int RING_DELAY = getRingDelay(); // delay after which we assume ring has stablized
 
@@ -1053,7 +1054,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             try
             {
                 setMode(Mode.WAITING_TO_FINISH_BOOTSTRAP, "Awaiting finish bootstrap call", true);
-                boolean timeoutExceeded = !finishBootstrapCondition.await(30, MINUTES);
+                boolean timeoutExceeded = !finishBootstrapCondition.await(BOOTSTRAP_SAFETY_CHECK_GRACE_PERIOD_MINUTES, MINUTES);
                 if (timeoutExceeded)
                 {
                     recordNonTransientError(NonTransientError.BOOTSTRAP_ERROR, ImmutableMap.of("bootstrapSafetyCheckFailed", "true"));


### PR DESCRIPTION
In #473, we required that `SS#finishBootstrap` be called within 30 minutes. The assumption was for this endpoint to always be called via automation, so waiting longer than a few minutes was not necessary.

In some circumstances, our automation does not work as expected and the bootstrap must be completed manually. The 30 minute deadline presents an unnecessary operational burden for certain remote environments.

This PR introduces a JVM option `palantir_cassandra.bootstrap_safety_check_grace_period_minutes`, to give us more flexibility in these situations.