### PR TITLE
Add guard to setMode for NTEs

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1616,9 +1616,9 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                     logger.info("Stopped waiting for bootstrap streaming to complete because detected a bootstrap error.", SafeArg.of("nonTransientErrors", getNonTransientErrors()));
                     break;
                 }
-                bootstrapStream.cancel(true);
                 Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
             }
+            bootstrapStream.cancel(true);
             isBootstrapMode = false;
             return !StorageService.instance.hasNonTransientError(StorageServiceMBean.NonTransientError.BOOTSTRAP_ERROR);
         }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1615,6 +1615,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                     if (hasNonTransientError(NonTransientError.BOOTSTRAP_ERROR))
                     {
                         logger.info("Aborting waiting for bootstrap streaming to complete because detected a bootstrap error.", SafeArg.of("nonTransientErrors", getNonTransientErrors()));
+                        bootstrapStream.cancel(true);
                         break;
                     }
                 }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1544,11 +1544,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     void setMode(Mode m, @Safe String msg, boolean log)
     {
         if (operationMode == Mode.NON_TRANSIENT_ERROR && m != Mode.NON_TRANSIENT_ERROR) {
-            if (log)
-                logger.warn("Attempted to change mode from NTE to non-NTE", SafeArg.of("attemptedSetMode", m), SafeArg.of("msg", msg));
-            else
-                logger.debug("Attempted to change mode from NTE to non-NTE", SafeArg.of("attemptedSetMode", m), SafeArg.of("msg", msg));
-            return;
+            logger.warn("Attempted to change mode from NTE to non-NTE", SafeArg.of("attemptedSetMode", m), SafeArg.of("msg", msg));
         }
         operationMode = m;
         if (log)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1606,9 +1606,19 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         ListenableFuture<StreamState> bootstrapStream = bootstrapper.bootstrap(streamStateStore, !replacing && useStrictConsistency); // handles token update
         try
         {
-            bootstrapStream.get();
+            while (true) {
+                if (bootstrapStream.isDone()) {
+                    bootstrapStream.get();
+                    logger.info("Bootstrap streaming completed for tokens {}", tokens);
+                    break;
+                }
+                if (hasNonTransientError(NonTransientError.BOOTSTRAP_ERROR)) {
+                    logger.info("Stopped waiting for bootstrap streaming to complete because detected a bootstrap error.", SafeArg.of("nonTransientErrors", getNonTransientErrors()));
+                    break;
+                }
+                Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+            }
             isBootstrapMode = false;
-            logger.info("Bootstrap streaming completed for tokens {}", tokens);
             return !StorageService.instance.hasNonTransientError(StorageServiceMBean.NonTransientError.BOOTSTRAP_ERROR);
         }
         catch (Throwable e)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1543,7 +1543,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     @VisibleForTesting
     void setMode(Mode m, @Safe String msg, boolean log)
     {
-        if (operationMode == Mode.NON_TRANSIENT_ERROR && m != Mode.NON_TRANSIENT_ERROR) {
+        if (operationMode == Mode.NON_TRANSIENT_ERROR && m != Mode.NON_TRANSIENT_ERROR)
+        {
             logger.warn("Attempted to change mode from NTE to non-NTE", SafeArg.of("attemptedSetMode", m), SafeArg.of("msg", msg));
         }
         operationMode = m;
@@ -1602,13 +1603,16 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         ListenableFuture<StreamState> bootstrapStream = bootstrapper.bootstrap(streamStateStore, !replacing && useStrictConsistency); // handles token update
         try
         {
-            while (true) {
-                if (bootstrapStream.isDone()) {
+            while (true)
+            {
+                if (bootstrapStream.isDone())
+                {
                     bootstrapStream.get();
                     logger.info("Bootstrap streaming completed for tokens {}", tokens);
                     break;
                 }
-                if (hasNonTransientError(NonTransientError.BOOTSTRAP_ERROR)) {
+                if (hasNonTransientError(NonTransientError.BOOTSTRAP_ERROR))
+                {
                     logger.info("Stopped waiting for bootstrap streaming to complete because detected a bootstrap error.", SafeArg.of("nonTransientErrors", getNonTransientErrors()));
                     break;
                 }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1620,7 +1620,6 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                     }
                 }
             }
-            bootstrapStream.cancel(true);
             isBootstrapMode = false;
             return !StorageService.instance.hasNonTransientError(StorageServiceMBean.NonTransientError.BOOTSTRAP_ERROR);
         }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1616,6 +1616,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                     logger.info("Stopped waiting for bootstrap streaming to complete because detected a bootstrap error.", SafeArg.of("nonTransientErrors", getNonTransientErrors()));
                     break;
                 }
+                bootstrapStream.cancel(true);
                 Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
             }
             isBootstrapMode = false;

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1608,7 +1608,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             {
                 try {
                     bootstrapStream.get(5, MINUTES);
-                    logger.info("Bootstrap streaming completed for tokens {}", tokens);
+                    logger.info("Bootstrap streaming completed for tokens {}", SafeArg.of("tokens", tokens));
                     break;
                 }
                 catch (TimeoutException e) {

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1546,6 +1546,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         if (operationMode == Mode.NON_TRANSIENT_ERROR && m != Mode.NON_TRANSIENT_ERROR)
         {
             logger.warn("Attempted to change mode from NTE to non-NTE", SafeArg.of("attemptedSetMode", m), SafeArg.of("msg", msg));
+            return;
         }
         operationMode = m;
         if (log)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1543,6 +1543,13 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     @VisibleForTesting
     void setMode(Mode m, @Safe String msg, boolean log)
     {
+        if (operationMode == Mode.NON_TRANSIENT_ERROR && m != Mode.NON_TRANSIENT_ERROR) {
+            if (log)
+                logger.warn("Attempted to change mode from NTE to non-NTE", SafeArg.of("attemptedSetMode", m), SafeArg.of("msg", msg));
+            else
+                logger.debug("Attempted to change mode from NTE to non-NTE", SafeArg.of("attemptedSetMode", m), SafeArg.of("msg", msg));
+            return;
+        }
         operationMode = m;
         if (log)
             logger.info(m.toString(), SafeArg.of("msg", msg));

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1605,18 +1605,18 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         {
             while (true)
             {
-                if (bootstrapStream.isDone())
-                {
-                    bootstrapStream.get();
+                try {
+                    bootstrapStream.get(5, MINUTES);
                     logger.info("Bootstrap streaming completed for tokens {}", tokens);
                     break;
                 }
-                if (hasNonTransientError(NonTransientError.BOOTSTRAP_ERROR))
-                {
-                    logger.info("Stopped waiting for bootstrap streaming to complete because detected a bootstrap error.", SafeArg.of("nonTransientErrors", getNonTransientErrors()));
-                    break;
+                catch (TimeoutException e) {
+                    if (hasNonTransientError(NonTransientError.BOOTSTRAP_ERROR))
+                    {
+                        logger.info("Aborting waiting for bootstrap streaming to complete because detected a bootstrap error.", SafeArg.of("nonTransientErrors", getNonTransientErrors()));
+                        break;
+                    }
                 }
-                Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
             }
             bootstrapStream.cancel(true);
             isBootstrapMode = false;


### PR DESCRIPTION
When a node enters non-transient error, it should never regain a normal operation mode (hence non-transient). This PR adds a guard for this and additionally short-circuits the bootstrap when the node enters NTE. This addition is necessary because the bootstrap NTE can occur from different threads than the one calling `bootstrapStream.get()`.