### PR TITLE
[WIP] pass token ring view with mutations/reads, and verify

### DIFF
--- a/src/java/com/palantir/cassandra/db/TokenOwnershipSnapshot.java
+++ b/src/java/com/palantir/cassandra/db/TokenOwnershipSnapshot.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.db;
+
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import com.google.common.net.InetAddresses;
+import org.apache.commons.lang3.StringUtils;
+
+public final class TokenOwnershipSnapshot
+{
+
+    public static byte[] serialize(Iterable<InetAddress> owners)
+    {
+        return StringUtils.join(owners, ',').getBytes(StandardCharsets.UTF_8);
+    }
+
+    public static Set<InetAddress> deserialize(@Nullable byte[] serialized)
+    {
+        if (serialized == null)
+        {
+            return null;
+        }
+        Set<InetAddress> owners = new HashSet<>();
+        for (String inetAddress : StringUtils.split(new String(serialized, StandardCharsets.UTF_8), ','))
+        {
+            owners.add(InetAddresses.forString(inetAddress));
+        }
+        return owners;
+    }
+
+    private TokenOwnershipSnapshot() {}
+}

--- a/src/java/com/palantir/cassandra/utils/OwnershipVerificationUtils.java
+++ b/src/java/com/palantir/cassandra/utils/OwnershipVerificationUtils.java
@@ -23,18 +23,26 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.cassandra.db.TokenOwnershipSnapshot;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.RangeSliceCommand;
+import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.locator.NetworkTopologyStrategy;
+import org.apache.cassandra.net.MessageIn;
+import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Hex;
@@ -51,25 +59,31 @@ public class OwnershipVerificationUtils
     {
     }
 
-    public static void verifyRead(Keyspace keyspace, ByteBuffer key)
+    public static void verifyRead(Keyspace keyspace, MessageIn<ReadCommand> message)
     {
         if (!VERIFY_KEYS_ON_READ)
         {
             return;
         }
-        verifyOperation(keyspace, key, ReadVerificationHandler.INSTANCE);
+        Set<InetAddress> reportedOwners = TokenOwnershipSnapshot.deserialize(message.parameters.get(MessagingService.TOKEN_OWNERS_PARAM));
+
+        ByteBuffer key = message.payload.key;
+        verifyOperation(keyspace, key, reportedOwners, ReadVerificationHandler.INSTANCE);
     }
 
-    public static void verifyMutation(Mutation mutation)
+    public static void verifyMutation(MessageIn<Mutation> message)
     {
         if (!VERIFY_KEYS_ON_WRITE)
         {
             return;
         }
-        verifyOperation(Keyspace.open(mutation.getKeyspaceName()), mutation.key(), MutationVerificationHandler.INSTANCE);
+        Set<InetAddress> reportedOwners = TokenOwnershipSnapshot.deserialize(message.parameters.get(MessagingService.TOKEN_OWNERS_PARAM));
+
+        Mutation mutation = message.payload;
+        verifyOperation(Keyspace.open(mutation.getKeyspaceName()), mutation.key(), reportedOwners, MutationVerificationHandler.INSTANCE);
     }
 
-    private static void verifyOperation(Keyspace keyspace, ByteBuffer key, OwnershipVerificationHandler handler)
+    private static void verifyOperation(Keyspace keyspace, ByteBuffer key, Set<InetAddress> reportedOwners, OwnershipVerificationHandler handler)
     {
         if (!(keyspace.getReplicationStrategy() instanceof NetworkTopologyStrategy))
         {
@@ -81,7 +95,10 @@ public class OwnershipVerificationUtils
         List<InetAddress> cachedNaturalEndpoints = StorageService.instance.getNaturalEndpoints(keyspaceName, tk);
         Collection<InetAddress> pendingEndpoints = StorageService.instance.getTokenMetadata().pendingEndpointsFor(tk, keyspaceName);
 
-        if (operationIsInvalid(cachedNaturalEndpoints, pendingEndpoints))
+        HashSet<InetAddress> localOwners = new HashSet<>(cachedNaturalEndpoints);
+        localOwners.addAll(pendingEndpoints);
+
+        if (operationIsInvalid(localOwners, reportedOwners))
         {
             if (cacheWasRecentlyRefreshed())
             {
@@ -92,8 +109,11 @@ public class OwnershipVerificationUtils
             refreshCache();
 
             List<InetAddress> refreshedNaturalEndpoints = StorageService.instance.getNaturalEndpoints(keyspaceName, tk);
+            localOwners.clear();
+            localOwners.addAll(refreshedNaturalEndpoints);
+            localOwners.addAll(pendingEndpoints);
 
-            if (operationIsInvalid(refreshedNaturalEndpoints, pendingEndpoints))
+            if (operationIsInvalid(localOwners, reportedOwners))
             {
                 handler.onViolation(keyspace, key, refreshedNaturalEndpoints, pendingEndpoints);
                 return;
@@ -123,9 +143,9 @@ public class OwnershipVerificationUtils
         return Duration.between(lastTokenRingCacheUpdate, Instant.now()).compareTo(Duration.ofMinutes(10)) < 0;
     }
 
-    private static boolean operationIsInvalid(List<InetAddress> naturalEndpoints, Collection<InetAddress> pendingEndpoints)
+    private static boolean operationIsInvalid(Set<InetAddress> localOwners, Set<InetAddress> reportedOwners)
     {
-        return !naturalEndpoints.contains(FBUtilities.getBroadcastAddress()) && !pendingEndpoints.contains(FBUtilities.getBroadcastAddress());
+        return !localOwners.contains(FBUtilities.getBroadcastAddress()) || !localOwners.equals(reportedOwners);
     }
 
     @VisibleForTesting

--- a/src/java/org/apache/cassandra/db/Mutation.java
+++ b/src/java/org/apache/cassandra/db/Mutation.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.db;
 
 import java.io.DataInput;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.*;
 

--- a/src/java/org/apache/cassandra/db/MutationVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/MutationVerbHandler.java
@@ -47,8 +47,7 @@ public class MutationVerbHandler implements IVerbHandler<Mutation>
                 replyTo = InetAddress.getByAddress(from);
             }
 
-            OwnershipVerificationUtils.verifyMutation(message.payload);
-
+            OwnershipVerificationUtils.verifyMutation(message);
             message.payload.apply();
             WriteResponse response = new WriteResponse();
             Tracing.trace("Enqueuing response to {}", replyTo);

--- a/src/java/org/apache/cassandra/db/ReadRepairVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/ReadRepairVerbHandler.java
@@ -26,7 +26,7 @@ public class ReadRepairVerbHandler implements IVerbHandler<Mutation>
 {
     public void doVerb(MessageIn<Mutation> message, int id)
     {
-        OwnershipVerificationUtils.verifyMutation(message.payload);
+        OwnershipVerificationUtils.verifyMutation(message);
         message.payload.apply();
         WriteResponse response = new WriteResponse();
         MessagingService.instance().sendReply(response.createMessage(), id, message.from);

--- a/src/java/org/apache/cassandra/db/ReadVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/ReadVerbHandler.java
@@ -45,13 +45,13 @@ public class ReadVerbHandler implements IVerbHandler<ReadCommand>
         Keyspace keyspace = Keyspace.open(command.ksName);
         Row row = command.getRow(keyspace);
 
+        OwnershipVerificationUtils.verifyRead(keyspace, message);
+
         MessageOut<ReadResponse> reply = new MessageOut<ReadResponse>(MessagingService.Verb.REQUEST_RESPONSE,
                                                                       getResponse(command, row),
                                                                       ReadResponse.serializer);
         Tracing.trace("Enqueuing response to {}", message.from);
         MessagingService.instance().sendReply(reply, id, message.from);
-
-        OwnershipVerificationUtils.verifyRead(keyspace, command.key);
     }
 
     public static ReadResponse getResponse(ReadCommand command, Row row)

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -88,6 +88,7 @@ public final class MessagingService implements MessagingServiceMBean
     public static final String FAILURE_CALLBACK_PARAM = "CAL_BAC";
     public static final byte[] ONE_BYTE = new byte[1];
     public static final String FAILURE_RESPONSE_PARAM = "FAIL";
+    public static final String TOKEN_OWNERS_PARAM = "OWN";
 
     /**
      * we preface every message with this number so the recipient can validate the sender is sane

--- a/src/java/org/apache/cassandra/service/AbstractReadExecutor.java
+++ b/src/java/org/apache/cassandra/service/AbstractReadExecutor.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.cassandra.db.TokenOwnershipSnapshot;
 import org.apache.cassandra.concurrent.KeyspaceAwareSepQueue;
 import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.concurrent.StageManager;
@@ -41,6 +42,7 @@ import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.ReadResponse;
 import org.apache.cassandra.db.Row;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.ReadFailureException;
 import org.apache.cassandra.exceptions.ReadTimeoutException;
 import org.apache.cassandra.exceptions.UnavailableException;
@@ -72,8 +74,9 @@ public abstract class AbstractReadExecutor
     protected final TraceState traceState;
     protected final ColumnFamilyStore cfs;
     protected final ConcurrentLinkedQueue<Long> latencies;
+    protected final Iterable<InetAddress> allOwners;
 
-    AbstractReadExecutor(ReadCommand command, ConsistencyLevel consistencyLevel, List<InetAddress> targetReplicas, ColumnFamilyStore cfs)
+    AbstractReadExecutor(ReadCommand command, ConsistencyLevel consistencyLevel, List<InetAddress> targetReplicas, ColumnFamilyStore cfs, Iterable<InetAddress> allOwners)
     {
         this.command = command;
         this.targetReplicas = targetReplicas;
@@ -82,6 +85,7 @@ public abstract class AbstractReadExecutor
         traceState = Tracing.instance.get();
         this.latencies = new ConcurrentLinkedQueue<>();
         handler = new ReadCallback<>(resolver, consistencyLevel, command, targetReplicas, Optional.of(latencies));
+        this.allOwners = allOwners;
     }
 
     @VisibleForTesting
@@ -116,7 +120,10 @@ public abstract class AbstractReadExecutor
                 traceState.trace("reading {} from {}", readCommand.isDigestQuery() ? "digest" : "data", endpoint);
             logger.trace("reading {} from {}", readCommand.isDigestQuery() ? "digest" : "data", endpoint);
             if (message == null)
+            {
                 message = readCommand.createMessage();
+                message.withParameter(MessagingService.TOKEN_OWNERS_PARAM, TokenOwnershipSnapshot.serialize(allOwners));
+            }
             // Handler adds remote requests latencies to list
             MessagingService.instance().sendRRWithFailure(message, endpoint, handler);
         }
@@ -191,6 +198,11 @@ public abstract class AbstractReadExecutor
         ReadRepairDecision repairDecision = Schema.instance.getCFMetaData(command.ksName, command.cfName).newReadRepairDecision();
         List<InetAddress> targetReplicas = consistencyLevel.filterForQuery(keyspace, allReplicas, repairDecision);
 
+        Token tk = StorageService.getPartitioner().getToken(command.key);
+        Collection<InetAddress> naturalEndpoints = keyspace.getReplicationStrategy().getNaturalEndpoints(tk);
+        Collection<InetAddress> pendingEndpoints = StorageService.instance.getTokenMetadata().pendingEndpointsFor(tk, command.ksName);
+        Iterable<InetAddress> allOwners = Iterables.concat(naturalEndpoints, pendingEndpoints);
+
         // Throw UAE early if we don't have enough replicas.
         consistencyLevel.assureSufficientLiveNodes(keyspace, targetReplicas);
 
@@ -206,14 +218,14 @@ public abstract class AbstractReadExecutor
 
         // Speculative retry is disabled *OR* there are simply no extra replicas to speculate.
         if (retryType == RetryType.NONE || consistencyLevel.blockFor(keyspace) == allReplicas.size())
-            return new NeverSpeculatingReadExecutor(command, consistencyLevel, targetReplicas, cfs);
+            return new NeverSpeculatingReadExecutor(command, consistencyLevel, targetReplicas, cfs, allOwners);
 
         if (targetReplicas.size() == allReplicas.size())
         {
             // CL.ALL, RRD.GLOBAL or RRD.DC_LOCAL and a single-DC.
             // We are going to contact every node anyway, so ask for 2 full data requests instead of 1, for redundancy
             // (same amount of requests in total, but we turn 1 digest request into a full blown data request).
-            return new AlwaysSpeculatingReadExecutor(cfs, command, consistencyLevel, targetReplicas);
+            return new AlwaysSpeculatingReadExecutor(cfs, command, consistencyLevel, targetReplicas, allOwners);
         }
 
         // RRD.NONE or RRD.DC_LOCAL w/ multiple DCs.
@@ -234,9 +246,9 @@ public abstract class AbstractReadExecutor
         targetReplicas.add(extraReplica);
 
         if (retryType == RetryType.ALWAYS)
-            return new AlwaysSpeculatingReadExecutor(cfs, command, consistencyLevel, targetReplicas);
+            return new AlwaysSpeculatingReadExecutor(cfs, command, consistencyLevel, targetReplicas, allOwners);
         else // PERCENTILE or CUSTOM.
-            return new SpeculatingReadExecutor(cfs, command, consistencyLevel, targetReplicas);
+            return new SpeculatingReadExecutor(cfs, command, consistencyLevel, targetReplicas, allOwners);
     }
 
     @VisibleForTesting
@@ -245,9 +257,13 @@ public abstract class AbstractReadExecutor
         protected static final List<PredictedSpeculativeRetryPerformanceMetrics> specRetryPerformanceMetrics =
                 PredictedSpeculativeRetryPerformanceMetrics.createMetricsByThresholds(NeverSpeculatingReadExecutor.class);
 
-        public NeverSpeculatingReadExecutor(ReadCommand command, ConsistencyLevel consistencyLevel, List<InetAddress> targetReplicas, ColumnFamilyStore cfs)
+        public NeverSpeculatingReadExecutor(ReadCommand command,
+                                            ConsistencyLevel consistencyLevel,
+                                            List<InetAddress> targetReplicas,
+                                            ColumnFamilyStore cfs,
+                                            Iterable<InetAddress> allOwners)
         {
-            super(command, consistencyLevel, targetReplicas, cfs);
+            super(command, consistencyLevel, targetReplicas, cfs, allOwners);
         }
 
         public void executeAsync()
@@ -283,9 +299,10 @@ public abstract class AbstractReadExecutor
         public SpeculatingReadExecutor(ColumnFamilyStore cfs,
                                        ReadCommand command,
                                        ConsistencyLevel consistencyLevel,
-                                       List<InetAddress> targetReplicas)
+                                       List<InetAddress> targetReplicas,
+                                       Iterable<InetAddress> allOwners)
         {
-            super(command, consistencyLevel, targetReplicas, cfs);
+            super(command, consistencyLevel, targetReplicas, cfs, allOwners);
         }
 
         public void executeAsync()
@@ -358,9 +375,10 @@ public abstract class AbstractReadExecutor
         public AlwaysSpeculatingReadExecutor(ColumnFamilyStore cfs,
                                              ReadCommand command,
                                              ConsistencyLevel consistencyLevel,
-                                             List<InetAddress> targetReplicas)
+                                             List<InetAddress> targetReplicas,
+                                             Iterable<InetAddress> allOwners)
         {
-            super(command, consistencyLevel, targetReplicas, cfs);
+            super(command, consistencyLevel, targetReplicas, cfs, allOwners);
         }
 
         public void maybeTryAdditionalReplicas()

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -33,6 +33,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.cassandra.concurrent.LocalReadRunnableTimeoutWatcher;
 import com.palantir.cassandra.db.RowCountOverwhelmingException;
 
+import com.palantir.cassandra.db.TokenOwnershipSnapshot;
 import com.palantir.cassandra.settings.LocalQuorumReadForSerialCasSetting;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -945,7 +946,10 @@ public class StorageProxy implements StorageProxyMBean
                 {
                     // belongs on a different server
                     if (message == null)
+                    {
                         message = mutation.createMessage();
+                        message.withParameter(MessagingService.TOKEN_OWNERS_PARAM, TokenOwnershipSnapshot.serialize(targets));
+                    }
                     String dc = DatabaseDescriptor.getEndpointSnitch().getDatacenter(destination);
                     // direct writes to local DC or old Cassandra versions
                     // (1.1 knows how to forward old-style String message IDs; updated to int in 2.0)

--- a/test/unit/com/palantir/cassandra/utils/OwnershipVerificationUtilsTest.java
+++ b/test/unit/com/palantir/cassandra/utils/OwnershipVerificationUtilsTest.java
@@ -27,6 +27,8 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.InvalidMutationException;
 import org.apache.cassandra.locator.NetworkTopologyStrategy;
 import org.apache.cassandra.locator.TokenMetadata;
+import org.apache.cassandra.net.MessageIn;
+import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
@@ -89,7 +91,8 @@ public class OwnershipVerificationUtilsTest
     {
         ByteBuffer key = ByteBufferUtil.bytes("a");
         Mutation mutation = new Mutation(KEYSPACE5, key);
-        OwnershipVerificationUtils.verifyMutation(mutation);
+        MessageIn<Mutation> message = MessageIn.create(REMOTE, mutation, ImmutableMap.of(), MessagingService.Verb.MUTATION, MessagingService.current_version);
+        OwnershipVerificationUtils.verifyMutation(message);
     }
 
     @Test
@@ -97,7 +100,8 @@ public class OwnershipVerificationUtilsTest
     {
         ByteBuffer key = ByteBufferUtil.bytes("b");
         Mutation mutation = new Mutation(KEYSPACE5, key);
-        assertThatThrownBy(() -> OwnershipVerificationUtils.verifyMutation(mutation)).isInstanceOf(InvalidMutationException.class);
+        MessageIn<Mutation> message = MessageIn.create(REMOTE, mutation, ImmutableMap.of(), MessagingService.Verb.MUTATION, MessagingService.current_version);
+        assertThatThrownBy(() -> OwnershipVerificationUtils.verifyMutation(message)).isInstanceOf(InvalidMutationException.class);
     }
 
     @Test
@@ -105,9 +109,10 @@ public class OwnershipVerificationUtilsTest
     {
         ByteBuffer key = ByteBufferUtil.bytes("a");
         Mutation mutation = new Mutation(KEYSPACE5, key);
+        MessageIn<Mutation> message = MessageIn.create(REMOTE, mutation, ImmutableMap.of(), MessagingService.Verb.MUTATION, MessagingService.current_version);
 
         long initialRingVersion = StorageService.instance.getTokenMetadata().getRingVersion();
-        OwnershipVerificationUtils.verifyMutation(mutation);
+        OwnershipVerificationUtils.verifyMutation(message);
         long finalRingVersion = StorageService.instance.getTokenMetadata().getRingVersion();
         assertThat(initialRingVersion).isEqualTo(finalRingVersion);
     }
@@ -117,9 +122,10 @@ public class OwnershipVerificationUtilsTest
     {
         ByteBuffer key = ByteBufferUtil.bytes("b");
         Mutation mutation = new Mutation(KEYSPACE5, key);
+        MessageIn<Mutation> message = MessageIn.create(REMOTE, mutation, ImmutableMap.of(), MessagingService.Verb.MUTATION, MessagingService.current_version);
 
         long initialRingVersion = StorageService.instance.getTokenMetadata().getRingVersion();
-        assertThatThrownBy(() -> OwnershipVerificationUtils.verifyMutation(mutation)).isInstanceOf(InvalidMutationException.class);
+        assertThatThrownBy(() -> OwnershipVerificationUtils.verifyMutation(message)).isInstanceOf(InvalidMutationException.class);
         long finalRingVersion = StorageService.instance.getTokenMetadata().getRingVersion();
         assertThat(initialRingVersion).isNotEqualTo(finalRingVersion);
     }

--- a/test/unit/org/apache/cassandra/service/ReadExecutorTest.java
+++ b/test/unit/org/apache/cassandra/service/ReadExecutorTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.service;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;
@@ -126,12 +127,12 @@ public class ReadExecutorTest {
     public static AbstractReadExecutor getTestNeverSpeculatingReadExecutor(String keyspace, String cf, List<InetAddress> replicas) {
         ColumnFamilyStore cfs = spy(MockSchema.newCFS());
         return spy(new AbstractReadExecutor.NeverSpeculatingReadExecutor(
-                                    getReadCommand(keyspace, cf), ConsistencyLevel.ANY, replicas, cfs));
+                                    getReadCommand(keyspace, cf), ConsistencyLevel.ANY, replicas, cfs, new ArrayList<>()));
     }
 
     public static AbstractReadExecutor getTestSpeculatingReadExecutor(String keyspace, String cf, List<InetAddress> replicas) {
         ColumnFamilyStore cfs = spy(MockSchema.newCFS());
-        return spy(new AbstractReadExecutor.SpeculatingReadExecutor(cfs, getReadCommand(keyspace, cf), ConsistencyLevel.ANY, replicas));
+        return spy(new AbstractReadExecutor.SpeculatingReadExecutor(cfs, getReadCommand(keyspace, cf), ConsistencyLevel.ANY, replicas, new ArrayList<>()));
     }
 
     public static ReadCommand getReadCommand(String keyspace, String cf) {


### PR DESCRIPTION
It is possible for nodes to have inconsistent views of the token ring, and still accept reads/writes.

Previously, we introduced `InvalidMutations`, where a node would check if it owned a token before applying the mutation. However, that implementation fails when the receiving node itself has an incorrect view of the ring.

This PR attempts to address these cases by including the coordinator's view of the ring in Mutation and Read Messages. When handling these verbs, nodes now validate that they have the same view of the ring as the coordinator.