### PR TITLE
Fix effective ownership in Nodetool Status and Ring

### DIFF
--- a/src/java/com/palantir/cassandra/db/SystemPalantir.java
+++ b/src/java/com/palantir/cassandra/db/SystemPalantir.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.db;
+
+final public class SystemPalantir
+{
+    public static final String NAME = "system_palantir";
+
+    private SystemPalantir()
+    {
+    }
+}

--- a/src/java/org/apache/cassandra/config/Schema.java
+++ b/src/java/org/apache/cassandra/config/Schema.java
@@ -21,7 +21,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
-import com.palantir.logsafe.SafeArg;
+import com.palantir.cassandra.db.SystemPalantir;
 import com.palantir.tracing.CloseableTracer;
 
 import com.google.common.base.Splitter;
@@ -60,7 +60,7 @@ public class Schema
                         Splitter.on(",").splitToList(System.getProperty("palantir_cassandra.additional_system_keyspaces", "")));
     public static final Set<String> SYSTEM_KEYSPACES = ImmutableSet.<String>builder()
             .add(SystemKeyspace.NAME, SystemDistributedKeyspace.NAME, TraceKeyspace.NAME, AuthKeyspace.NAME)
-            .add("system_palantir")
+            .add(SystemPalantir.NAME)
             .addAll(additionalSystemKeyspaces)
             .build();
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -41,6 +41,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.*;
 import com.google.common.util.concurrent.*;
 import com.palantir.cassandra.db.BootstrappingSafetyException;
+import com.palantir.cassandra.db.SystemPalantir;
 import com.palantir.cassandra.settings.LocalQuorumReadForSerialCasSetting;
 import com.palantir.cassandra.utils.SchemaAgreementCheck;
 import com.palantir.logsafe.Safe;
@@ -4900,8 +4901,11 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         else
         {
             List<String> userKeyspaces = Schema.instance.getUserKeyspaces();
-
-            if (userKeyspaces.size() > 0)
+            if (Schema.instance.getKeyspaceInstance(SystemPalantir.NAME) != null)
+            {
+                keyspace = SystemPalantir.NAME;
+            }
+            else if (userKeyspaces.size() > 0)
             {
                 keyspace = userKeyspaces.iterator().next();
                 AbstractReplicationStrategy replicationStrategy = Schema.instance.getKeyspaceInstance(keyspace).getReplicationStrategy();


### PR DESCRIPTION
Nodetool Status and Ring can display effective ownership information if a keyspace is provided, or if the non-system keyspaces all use the same replication strategy.

In our case, we can assume that the `system_palantir` keyspace is always present, and use its replication strategy by default, if present.