### PR TITLE
Do not apply no-op schema updates

### DIFF
--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -465,11 +465,7 @@ public class MigrationManager
         CFMetaData oldCfm = Schema.instance.getCFMetaData(cfm.ksName, cfm.cfName);
         if (oldCfm == null)
             throw new ConfigurationException(String.format("Cannot update non existing table '%s' in keyspace '%s'.", cfm.cfName, cfm.ksName));
-        KSMetaData ksm = Schema.instance.getKSMetaData(cfm.ksName);
-
-        oldCfm.validateCompatility(cfm);
-
-
+        
         if (cfm.equals(oldCfm))
         {
             logger.warn("CFMetaData for {}/{} unchanged. Ignoring update. {}",
@@ -478,6 +474,10 @@ public class MigrationManager
                         SafeArg.of("cfm", cfm));
             return;
         }
+
+        KSMetaData ksm = Schema.instance.getKSMetaData(cfm.ksName);
+
+        oldCfm.validateCompatility(cfm);
 
         logger.info("Update table {}/{} from {} to {}",
                                   SafeArg.of("keyspace", cfm.ksName),

--- a/src/java/org/apache/cassandra/service/MigrationManager.java
+++ b/src/java/org/apache/cassandra/service/MigrationManager.java
@@ -469,6 +469,16 @@ public class MigrationManager
 
         oldCfm.validateCompatility(cfm);
 
+
+        if (cfm.equals(oldCfm))
+        {
+            logger.warn("CFMetaData for {}/{} unchanged. Ignoring update. {}",
+                        SafeArg.of("keyspace", cfm.ksName),
+                        SafeArg.of("table", cfm.cfName),
+                        SafeArg.of("cfm", cfm));
+            return;
+        }
+
         logger.info("Update table {}/{} from {} to {}",
                                   SafeArg.of("keyspace", cfm.ksName),
                                   SafeArg.of("table",  cfm.cfName),


### PR DESCRIPTION
If a client submits a schema update via `system_update_column_family`, changes that are actually no-ops will still be announced to the cluster.

This PR skips this expensive schema update process if there is no difference in CFMetaData.