### PR TITLE
Safe logging apache.cassandra.repair

### DIFF
--- a/src/java/org/apache/cassandra/repair/AnticompactionTask.java
+++ b/src/java/org/apache/cassandra/repair/AnticompactionTask.java
@@ -26,6 +26,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.util.concurrent.AbstractFuture;
 
+import com.palantir.logsafe.SafeArg;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,7 +169,7 @@ public class AnticompactionTask extends AbstractFuture<InetAddress> implements R
         if (maybeSetException(exception))
         {
             // Though unlikely, it is possible to arrive here multiple time and we want to avoid print an error message twice
-            logger.error("[repair #{}] Endpoint {} died during anti-compaction", endpoint, parentSession, exception);
+            logger.error("[repair #{}] Endpoint {} died during anti-compaction", SafeArg.of("endpoint", endpoint), SafeArg.of("parentSession", parentSession), exception);
         }
     }
 }

--- a/src/java/org/apache/cassandra/repair/LocalSyncTask.java
+++ b/src/java/org/apache/cassandra/repair/LocalSyncTask.java
@@ -112,6 +112,7 @@ public class LocalSyncTask extends SyncTask implements StreamEventHandler
 
     public void onSuccess(StreamState result)
     {
+        String message = String.format("Sync complete using session %s between %s and %s on %s", desc.sessionId, r1.endpoint, r2.endpoint, desc.columnFamily);
         logger.info(
                 "[repair #{}] Sync complete using session {} between {} and {} on {}",
                 SafeArg.of("sessionId", desc.sessionId),

--- a/src/java/org/apache/cassandra/repair/LocalSyncTask.java
+++ b/src/java/org/apache/cassandra/repair/LocalSyncTask.java
@@ -17,6 +17,8 @@
  */
 package org.apache.cassandra.repair;
 
+import com.palantir.logsafe.SafeArg;
+
 import java.net.InetAddress;
 import java.util.List;
 
@@ -110,8 +112,15 @@ public class LocalSyncTask extends SyncTask implements StreamEventHandler
 
     public void onSuccess(StreamState result)
     {
-        String message = String.format("Sync complete using session %s between %s and %s on %s", desc.sessionId, r1.endpoint, r2.endpoint, desc.columnFamily);
-        logger.info("[repair #{}] {}", desc.sessionId, message);
+        logger.info(
+                "[repair #{}] Sync complete using session {} between {} and {} on {}",
+                SafeArg.of("sessionId", desc.sessionId),
+                SafeArg.of("sessionId", desc.sessionId),
+                SafeArg.of("endpoint1", r1.endpoint),
+                SafeArg.of("endpoint2", r2.endpoint),
+                SafeArg.of("columnFamily", desc.columnFamily)
+        );
+
         Tracing.traceRepair(message);
         set(stat);
     }

--- a/src/java/org/apache/cassandra/repair/RemoteSyncTask.java
+++ b/src/java/org/apache/cassandra/repair/RemoteSyncTask.java
@@ -17,6 +17,8 @@
  */
 package org.apache.cassandra.repair;
 
+import com.palantir.logsafe.SafeArg;
+
 import java.net.InetAddress;
 import java.util.List;
 
@@ -50,8 +52,13 @@ public class RemoteSyncTask extends SyncTask
     {
         InetAddress local = FBUtilities.getBroadcastAddress();
         SyncRequest request = new SyncRequest(desc, local, r1.endpoint, r2.endpoint, differences);
-        String message = String.format("Forwarding streaming repair of %d ranges to %s (to be streamed with %s)", request.ranges.size(), request.src, request.dst);
-        logger.info("[repair #{}] {}", desc.sessionId, message);
+        logger.info(
+                "[repair #{}] Forwarding streaming repair of {} ranges to {} (to be streamed with {})",
+                SafeArg.of("sessionId", desc.sessionId),
+                SafeArg.of("rangeCount", request.ranges.size()),
+                SafeArg.of("syncSource", request.src),
+                SafeArg.of("syncDestination", request.dst)
+        );
         Tracing.traceRepair(message);
         MessagingService.instance().sendOneWay(request.createMessage(), request.src);
     }

--- a/src/java/org/apache/cassandra/repair/RemoteSyncTask.java
+++ b/src/java/org/apache/cassandra/repair/RemoteSyncTask.java
@@ -59,6 +59,7 @@ public class RemoteSyncTask extends SyncTask
                 SafeArg.of("syncSource", request.src),
                 SafeArg.of("syncDestination", request.dst)
         );
+        String message = String.format("Forwarding streaming repair of %d ranges to %s (to be streamed with %s)", request.ranges.size(), request.src, request.dst);
         Tracing.traceRepair(message);
         MessagingService.instance().sendOneWay(request.createMessage(), request.src);
     }

--- a/src/java/org/apache/cassandra/repair/RepairJob.java
+++ b/src/java/org/apache/cassandra/repair/RepairJob.java
@@ -149,7 +149,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
         {
             public void onSuccess(List<SyncStat> stats)
             {
-                logger.info(String.format("[repair #%s] %s is fully synced", SafeArg.of("sessionId", session.getId()), SafeArg.of("columnFamily", desc.columnFamily)));
+                logger.info(String.format("[repair #{}] {} is fully synced", SafeArg.of("sessionId", session.getId()), SafeArg.of("columnFamily", desc.columnFamily)));
                 SystemDistributedKeyspace.successfulRepairJob(session.getId(), desc.keyspace, desc.columnFamily);
                 set(new RepairResult(desc, stats));
             }
@@ -159,7 +159,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
              */
             public void onFailure(Throwable t)
             {
-                logger.warn(String.format("[repair #%s] %s sync failed", SafeArg.of("sessionId", session.getId()), SafeArg.of("columnFamily", desc.columnFamily)));
+                logger.warn(String.format("[repair #{}] {} sync failed", SafeArg.of("sessionId", session.getId()), SafeArg.of("columnFamily", desc.columnFamily)));
                 SystemDistributedKeyspace.failedRepairJob(session.getId(), desc.keyspace, desc.columnFamily, t);
                 setException(t);
             }

--- a/src/java/org/apache/cassandra/repair/RepairJob.java
+++ b/src/java/org/apache/cassandra/repair/RepairJob.java
@@ -147,7 +147,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
         {
             public void onSuccess(List<SyncStat> stats)
             {
-                logger.info(String.format("[repair #%s] %s is fully synced", session.getId(), desc.columnFamily));
+                logger.info(String.format("[repair #%s] %s is fully synced", SafeArg.of("sessionId", session.getId()), SafeArg.of("columnFamily", desc.columnFamily)));
                 SystemDistributedKeyspace.successfulRepairJob(session.getId(), desc.keyspace, desc.columnFamily);
                 set(new RepairResult(desc, stats));
             }
@@ -157,7 +157,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
              */
             public void onFailure(Throwable t)
             {
-                logger.warn(String.format("[repair #%s] %s sync failed", session.getId(), desc.columnFamily));
+                logger.warn(String.format("[repair #%s] %s sync failed", SafeArg.of("sessionId", session.getId()), SafeArg.of("columnFamily", desc.columnFamily)));
                 SystemDistributedKeyspace.failedRepairJob(session.getId(), desc.keyspace, desc.columnFamily, t);
                 setException(t);
             }
@@ -175,8 +175,12 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
      */
     private ListenableFuture<List<TreeResponse>> sendValidationRequest(Collection<InetAddress> endpoints)
     {
-        String message = String.format("Requesting merkle trees for %s (to %s)", desc.columnFamily, endpoints);
-        logger.info("[repair #{}] {}", desc.sessionId, message);
+        logger.info(
+                "[repair #{}] Requesting merkle trees for {} (to {})",
+                SafeArg.of("sessionId", desc.sessionId),
+                SafeArg.of("columnFamily", desc.columnFamily),
+                SafeArg.of("endpoints", endpoints)
+        );
         Tracing.traceRepair(message);
         int gcBefore = Keyspace.open(desc.keyspace).getColumnFamilyStore(desc.columnFamily).gcBefore(System.currentTimeMillis());
         List<ListenableFuture<TreeResponse>> tasks = new ArrayList<>(endpoints.size());
@@ -195,8 +199,12 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
      */
     private ListenableFuture<List<TreeResponse>> sendSequentialValidationRequest(Collection<InetAddress> endpoints)
     {
-        String message = String.format("Requesting merkle trees for %s (to %s)", desc.columnFamily, endpoints);
-        logger.info("[repair #{}] {}", desc.sessionId, message);
+        logger.info(
+                "[repair #{}] Requesting merkle trees for {} (to {})",
+                SafeArg.of("sessionId", desc.sessionId),
+                SafeArg.of("columnFamily", desc.columnFamily),
+                SafeArg.of("endpoints", endpoints)
+        );
         Tracing.traceRepair(message);
         int gcBefore = Keyspace.open(desc.keyspace).getColumnFamilyStore(desc.columnFamily).gcBefore(System.currentTimeMillis());
         List<ListenableFuture<TreeResponse>> tasks = new ArrayList<>(endpoints.size());
@@ -204,7 +212,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
         Queue<InetAddress> requests = new LinkedList<>(endpoints);
         InetAddress address = requests.poll();
         ValidationTask firstTask = new ValidationTask(desc, address, gcBefore);
-        logger.info("Validating {}", address);
+        logger.info("Validating {}", SafeArg.of("endpoint", address));
         session.waitForValidation(Pair.create(desc, address), firstTask);
         tasks.add(firstTask);
         ValidationTask currentTask = firstTask;
@@ -217,7 +225,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
             {
                 public void onSuccess(TreeResponse result)
                 {
-                    logger.info("Validating {}", nextAddress);
+                    logger.info("Validating {}", SafeArg.of("endpoint", nextAddress));
                     session.waitForValidation(Pair.create(desc, nextAddress), nextTask);
                     taskExecutor.execute(nextTask);
                 }
@@ -237,8 +245,12 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
      */
     private ListenableFuture<List<TreeResponse>> sendDCAwareValidationRequest(Collection<InetAddress> endpoints)
     {
-        String message = String.format("Requesting merkle trees for %s (to %s)", desc.columnFamily, endpoints);
-        logger.info("[repair #{}] {}", desc.sessionId, message);
+        logger.info(
+                "[repair #{}] Requesting merkle trees for {} (to {})",
+                SafeArg.of("sessionId", desc.sessionId),
+                SafeArg.of("columnFamily", desc.columnFamily),
+                SafeArg.of("endpoints", endpoints)
+        );
         Tracing.traceRepair(message);
         int gcBefore = Keyspace.open(desc.keyspace).getColumnFamilyStore(desc.columnFamily).gcBefore(System.currentTimeMillis());
         List<ListenableFuture<TreeResponse>> tasks = new ArrayList<>(endpoints.size());
@@ -261,7 +273,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
             Queue<InetAddress> requests = entry.getValue();
             InetAddress address = requests.poll();
             ValidationTask firstTask = new ValidationTask(desc, address, gcBefore);
-            logger.info("Validating {}", address);
+            logger.info("Validating {}", SafeArg.of("endpoint", address));
             session.waitForValidation(Pair.create(desc, address), firstTask);
             tasks.add(firstTask);
             ValidationTask currentTask = firstTask;
@@ -274,7 +286,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
                 {
                     public void onSuccess(TreeResponse result)
                     {
-                        logger.info("Validating {}", nextAddress);
+                        logger.info("Validating {}", SafeArg.of("endpoint", nextAddress));
                         session.waitForValidation(Pair.create(desc, nextAddress), nextTask);
                         taskExecutor.execute(nextTask);
                     }

--- a/src/java/org/apache/cassandra/repair/RepairJob.java
+++ b/src/java/org/apache/cassandra/repair/RepairJob.java
@@ -177,6 +177,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
      */
     private ListenableFuture<List<TreeResponse>> sendValidationRequest(Collection<InetAddress> endpoints)
     {
+        String message = String.format("Requesting merkle trees for %s (to %s)", desc.columnFamily, endpoints);
         logger.info(
                 "[repair #{}] Requesting merkle trees for {} (to {})",
                 SafeArg.of("sessionId", desc.sessionId),
@@ -201,6 +202,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
      */
     private ListenableFuture<List<TreeResponse>> sendSequentialValidationRequest(Collection<InetAddress> endpoints)
     {
+        String message = String.format("Requesting merkle trees for %s (to %s)", desc.columnFamily, endpoints);
         logger.info(
                 "[repair #{}] Requesting merkle trees for {} (to {})",
                 SafeArg.of("sessionId", desc.sessionId),
@@ -247,6 +249,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
      */
     private ListenableFuture<List<TreeResponse>> sendDCAwareValidationRequest(Collection<InetAddress> endpoints)
     {
+        String message = String.format("Requesting merkle trees for %s (to %s)", desc.columnFamily, endpoints);
         logger.info(
                 "[repair #{}] Requesting merkle trees for {} (to {})",
                 SafeArg.of("sessionId", desc.sessionId),

--- a/src/java/org/apache/cassandra/repair/RepairJob.java
+++ b/src/java/org/apache/cassandra/repair/RepairJob.java
@@ -21,6 +21,8 @@ import java.net.InetAddress;
 import java.util.*;
 
 import com.google.common.util.concurrent.*;
+import com.palantir.logsafe.SafeArg;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/java/org/apache/cassandra/repair/RepairJob.java
+++ b/src/java/org/apache/cassandra/repair/RepairJob.java
@@ -21,7 +21,6 @@ import java.net.InetAddress;
 import java.util.*;
 
 import com.google.common.util.concurrent.*;
-import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 
 import org.slf4j.Logger;
@@ -151,7 +150,6 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
             public void onSuccess(List<SyncStat> stats)
             {
                 logger.info(String.format("[repair #{}] {} is fully synced", SafeArg.of("sessionId", session.getId()), SafeArg.of("columnFamily", desc.columnFamily)));
-                logErrorTest("LCHEUNG LOG TEST {} {}", SafeArg.of("sessionId", session.getId()), SafeArg.of("columnFamily", desc.columnFamily));
                 SystemDistributedKeyspace.successfulRepairJob(session.getId(), desc.keyspace, desc.columnFamily);
                 set(new RepairResult(desc, stats));
             }
@@ -169,10 +167,6 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
 
         // Wait for validation to complete
         Futures.getUnchecked(validations);
-    }
-
-    private static void logErrorTest(String errorMessageFmt, Arg<?>... args) {
-        logger.error(errorMessageFmt, (Object[]) args);
     }
 
     /**

--- a/src/java/org/apache/cassandra/repair/RepairJob.java
+++ b/src/java/org/apache/cassandra/repair/RepairJob.java
@@ -21,6 +21,7 @@ import java.net.InetAddress;
 import java.util.*;
 
 import com.google.common.util.concurrent.*;
+import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 
 import org.slf4j.Logger;
@@ -150,6 +151,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
             public void onSuccess(List<SyncStat> stats)
             {
                 logger.info(String.format("[repair #{}] {} is fully synced", SafeArg.of("sessionId", session.getId()), SafeArg.of("columnFamily", desc.columnFamily)));
+                logErrorTest("LCHEUNG LOG TEST {} {}", SafeArg.of("sessionId", session.getId()), SafeArg.of("columnFamily", desc.columnFamily));
                 SystemDistributedKeyspace.successfulRepairJob(session.getId(), desc.keyspace, desc.columnFamily);
                 set(new RepairResult(desc, stats));
             }
@@ -167,6 +169,10 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
 
         // Wait for validation to complete
         Futures.getUnchecked(validations);
+    }
+
+    private static void logErrorTest(String errorMessageFmt, Arg<?>... args) {
+        logger.error(errorMessageFmt, (Object[]) args);
     }
 
     /**

--- a/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
+++ b/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
@@ -195,7 +195,7 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
     }
 
     private void logErrorAndSendFailureResponse(InetAddress to, int id, String errorMessageFmt, Arg<?>... args) {
-        logger.error(errorMessageFmt, (Object[]) args);
+        logger.error(errorMessageFmt, (Arg[]) args);
 
         MessageOut reply = new MessageOut(MessagingService.Verb.INTERNAL_RESPONSE)
                 .withParameter(MessagingService.FAILURE_RESPONSE_PARAM, MessagingService.ONE_BYTE);

--- a/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
+++ b/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
@@ -24,6 +24,10 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,15 +66,15 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
                 case PREPARE_GLOBAL_MESSAGE:
                 case PREPARE_MESSAGE:
                     PrepareMessage prepareMessage = (PrepareMessage) message.payload;
-                    logger.debug("Preparing, {}", prepareMessage);
+                    logger.debug("Preparing, {}", SafeArg.of("prepareMessage", prepareMessage));
                     List<ColumnFamilyStore> columnFamilyStores = new ArrayList<>(prepareMessage.cfIds.size());
                     for (UUID cfId : prepareMessage.cfIds)
                     {
                         ColumnFamilyStore columnFamilyStore = ColumnFamilyStore.getIfExists(cfId);
                         if (columnFamilyStore == null)
                         {
-                            logErrorAndSendFailureResponse(String.format("Table with id %s was dropped during prepare phase of repair",
-                                                                         cfId.toString()), message.from, id);
+                            logErrorAndSendFailureResponse(message.from, id,
+                                    "Table with id {} was dropped during prepare phase of repair", SafeArg.of("columnFamilyId", cfId.toString()));
                             return;
                         }
                         columnFamilyStores.add(columnFamilyStore);
@@ -80,7 +84,10 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
                     boolean isGlobal = peerVersion == null ||
                                        peerVersion.compareTo(ActiveRepairService.SUPPORTS_GLOBAL_PREPARE_FLAG_VERSION) < 0 ||
                                        message.payload.messageType.equals(RepairMessage.Type.PREPARE_GLOBAL_MESSAGE);
-                    logger.debug("Received prepare message: global message = {}, peerVersion = {},", message.payload.messageType.equals(RepairMessage.Type.PREPARE_GLOBAL_MESSAGE), peerVersion);
+                    logger.debug(
+                            "Received prepare message: global message = {}, peerVersion = {},",
+                            SafeArgs.of("messageType", message.payload.messageType.equals(RepairMessage.Type.PREPARE_GLOBAL_MESSAGE)),
+                            SafeArgs.of("peerVersion", peerVersion));
                     ActiveRepairService.instance.registerParentRepairSession(prepareMessage.parentRepairSession,
                                                                              message.from,
                                                                              columnFamilyStores,
@@ -91,12 +98,15 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
                     break;
 
                 case SNAPSHOT:
-                    logger.debug("Snapshotting {}", desc);
+                    logger.debug("Snapshotting {}", SafeArgs.of("repairJobDesc", desc));
                     final ColumnFamilyStore cfs = ColumnFamilyStore.getIfExists(desc.keyspace, desc.columnFamily);
                     if (cfs == null)
                     {
-                        logErrorAndSendFailureResponse(String.format("Table %s.%s was dropped during snapshot phase of repair",
-                                                                     desc.keyspace, desc.columnFamily), message.from, id);
+                        logErrorAndSendFailureResponse(
+                                message.from,
+                                id,
+                                "Table {}.{} was dropped during snapshot phase of repair",
+                                SafeArg.of("keyspace", desc.keyspace)l, SafeArg.of("columnFamily", desc.columnFamily));
                         return;
                     }
                     ActiveRepairService.ParentRepairSession prs = ActiveRepairService.instance.getParentRepairSession(desc.parentSessionId);
@@ -117,18 +127,18 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
                             }
                         }, true); //ephemeral snapshot, if repair fails, it will be cleaned next startup
                     }
-                    logger.debug("Enqueuing response to snapshot request {} to {}", desc.sessionId, message.from);
+                    logger.debug("Enqueuing response to snapshot request {} to {}", SafeArg.of("sessionId", desc.sessionId), SafeArg.of("messageFrom", message.from));
                     MessagingService.instance().sendReply(new MessageOut(MessagingService.Verb.INTERNAL_RESPONSE), id, message.from);
                     break;
 
                 case VALIDATION_REQUEST:
                     ValidationRequest validationRequest = (ValidationRequest) message.payload;
-                    logger.debug("Validating {}", validationRequest);
+                    logger.debug("Validating {}", SafeArg.of("validationRequest", validationRequest));
                     // trigger read-only compaction
                     ColumnFamilyStore store = ColumnFamilyStore.getIfExists(desc.keyspace, desc.columnFamily);
                     if (store == null)
                     {
-                        logger.error("Table {}.{} was dropped during snapshot phase of repair", desc.keyspace, desc.columnFamily);
+                        logger.error("Table {}.{} was dropped during snapshot phase of repair", SafeArg.of("keyspace", desc.keyspace), SafeArg.of("columnFamily", desc.columnFamily));
                         MessagingService.instance().sendOneWay(new ValidationComplete(desc).createMessage(), message.from);
                         return;
                     }
@@ -140,7 +150,7 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
                 case SYNC_REQUEST:
                     // forwarded sync request
                     SyncRequest request = (SyncRequest) message.payload;
-                    logger.debug("Syncing {}", request);
+                    logger.debug("Syncing {}", SafeArg.of("syncRequest", request));
                     long repairedAt = ActiveRepairService.UNREPAIRED_SSTABLE;
                     if (desc.parentSessionId != null && ActiveRepairService.instance.getParentRepairSession(desc.parentSessionId) != null)
                         repairedAt = ActiveRepairService.instance.getParentRepairSession(desc.parentSessionId).getRepairedAt();
@@ -151,7 +161,7 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
 
                 case ANTICOMPACTION_REQUEST:
                     AnticompactionRequest anticompactionRequest = (AnticompactionRequest) message.payload;
-                    logger.debug("Got anticompaction request {}", anticompactionRequest);
+                    logger.debug("Got anticompaction request {}", SafeArg.of("anticompactionRequest", anticompactionRequest));
                     ListenableFuture<?> compactionDone = ActiveRepairService.instance.doAntiCompaction(anticompactionRequest.parentRepairSession, anticompactionRequest.successfulRanges);
                     compactionDone.addListener(new Runnable()
                     {
@@ -184,11 +194,11 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
         }
     }
 
-    private void logErrorAndSendFailureResponse(String errorMessage, InetAddress to, int id)
-    {
-        logger.error(errorMessage);
+    private void logErrorAndSendFailureResponse(InetAddress to, int id, String errorMessageFmt, Arg<?>... args) {
+        logger.error(errorMessageFmt, args);
+
         MessageOut reply = new MessageOut(MessagingService.Verb.INTERNAL_RESPONSE)
-                               .withParameter(MessagingService.FAILURE_RESPONSE_PARAM, MessagingService.ONE_BYTE);
+                .withParameter(MessagingService.FAILURE_RESPONSE_PARAM, MessagingService.ONE_BYTE);
         MessagingService.instance().sendReply(reply, id, to);
     }
 }

--- a/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
+++ b/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
@@ -195,7 +195,7 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
     }
 
     private void logErrorAndSendFailureResponse(InetAddress to, int id, String errorMessageFmt, Arg<?>... args) {
-        logger.error(errorMessageFmt, (Arg[]) args);
+        logger.error(errorMessageFmt, (Object[]) args);
 
         MessageOut reply = new MessageOut(MessagingService.Verb.INTERNAL_RESPONSE)
                 .withParameter(MessagingService.FAILURE_RESPONSE_PARAM, MessagingService.ONE_BYTE);

--- a/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
+++ b/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
@@ -86,8 +86,8 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
                                        message.payload.messageType.equals(RepairMessage.Type.PREPARE_GLOBAL_MESSAGE);
                     logger.debug(
                             "Received prepare message: global message = {}, peerVersion = {},",
-                            SafeArgs.of("messageType", message.payload.messageType.equals(RepairMessage.Type.PREPARE_GLOBAL_MESSAGE)),
-                            SafeArgs.of("peerVersion", peerVersion));
+                            SafeArg.of("messageType", message.payload.messageType.equals(RepairMessage.Type.PREPARE_GLOBAL_MESSAGE)),
+                            SafeArg.of("peerVersion", peerVersion));
                     ActiveRepairService.instance.registerParentRepairSession(prepareMessage.parentRepairSession,
                                                                              message.from,
                                                                              columnFamilyStores,
@@ -98,7 +98,7 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
                     break;
 
                 case SNAPSHOT:
-                    logger.debug("Snapshotting {}", SafeArgs.of("repairJobDesc", desc));
+                    logger.debug("Snapshotting {}", SafeArg.of("repairJobDesc", desc));
                     final ColumnFamilyStore cfs = ColumnFamilyStore.getIfExists(desc.keyspace, desc.columnFamily);
                     if (cfs == null)
                     {
@@ -106,7 +106,7 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
                                 message.from,
                                 id,
                                 "Table {}.{} was dropped during snapshot phase of repair",
-                                SafeArg.of("keyspace", desc.keyspace)l, SafeArg.of("columnFamily", desc.columnFamily));
+                                SafeArg.of("keyspace", desc.keyspace), SafeArg.of("columnFamily", desc.columnFamily));
                         return;
                     }
                     ActiveRepairService.ParentRepairSession prs = ActiveRepairService.instance.getParentRepairSession(desc.parentSessionId);
@@ -195,7 +195,7 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
     }
 
     private void logErrorAndSendFailureResponse(InetAddress to, int id, String errorMessageFmt, Arg<?>... args) {
-        logger.error(errorMessageFmt, args);
+        logger.error(errorMessageFmt, (Object[]) args);
 
         MessageOut reply = new MessageOut(MessagingService.Verb.INTERNAL_RESPONSE)
                 .withParameter(MessagingService.FAILURE_RESPONSE_PARAM, MessagingService.ONE_BYTE);

--- a/src/java/org/apache/cassandra/repair/RepairRunnable.java
+++ b/src/java/org/apache/cassandra/repair/RepairRunnable.java
@@ -31,6 +31,9 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.*;
 
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,9 +143,8 @@ public class RepairRunnable extends WrappedRunnable implements ProgressEventNoti
         }
 
         final long startTime = System.currentTimeMillis();
-        String message = String.format("Starting repair command #%d, repairing keyspace %s with %s", cmd, keyspace,
-                                       options);
-        logger.info(message);
+        logger.info("Starting repair command #{}, repairing keyspace {} with {}", SafeArg.of("cmd", cmd), SafeArg.of("keyspace", keyspace), SafeArg.of("options", options));
+
         fireProgressEvent(tag, new ProgressEvent(ProgressEventType.START, 0, 100, message));
         if (options.isTraced())
         {
@@ -258,9 +260,11 @@ public class RepairRunnable extends WrappedRunnable implements ProgressEventNoti
                      * {@link org.apache.cassandra.utils.progress.jmx.LegacyJMXProgressSupport}
                      * for backward-compatibility support.
                      */
-                    String message = String.format("Repair session %s for range %s finished", session.getId(),
-                                                   session.getRange().toString());
-                    logger.info(message);
+                    logger.info(
+                            "Repair session {} for range {} finished",
+                            SafeArg.of("sessionId", session.getId()),
+                            SafeArg.of("range", session.getRange().toString())
+                    );
                     fireProgressEvent(tag, new ProgressEvent(ProgressEventType.PROGRESS,
                                                              progress.incrementAndGet(),
                                                              totalProgress,
@@ -274,9 +278,12 @@ public class RepairRunnable extends WrappedRunnable implements ProgressEventNoti
                      * {@link org.apache.cassandra.utils.progress.jmx.LegacyJMXProgressSupport}
                      * for backward-compatibility support.
                      */
-                    String message = String.format("Repair session %s for range %s failed with error %s",
-                                                   session.getId(), session.getRange().toString(), t.getMessage());
-                    logger.error(message, t);
+                    logger.error(
+                            "Repair session {} for range {} failed with error {}" + t,
+                            SafeArg.of("sessionId", session.getId()),
+                            SafeArg.of("range", session.getRange().toString()),
+                            UnsafeArg.of("errorMessage", t.getMessage())
+                    );
                     fireProgressEvent(tag, new ProgressEvent(ProgressEventType.PROGRESS,
                                                              progress.incrementAndGet(),
                                                              totalProgress,
@@ -342,7 +349,12 @@ public class RepairRunnable extends WrappedRunnable implements ProgressEventNoti
                                                                           true, true);
                 String message = String.format("Repair command #%d finished in %s for keyspace %s", cmd, duration, keyspace);
                 fireProgressEvent(tag, new ProgressEvent(ProgressEventType.COMPLETE, progress.get(), totalProgress, message));
-                logger.info(message);
+                logger.info(
+                        "Repair command {} finished in {} for keyspace {}",
+                        SafeArg.of("command", cmd),
+                        SafeArg.of("duration", duration),
+                        SafeArg.of("keyspace", keyspace)
+                );
                 if (options.isTraced() && traceState != null)
                 {
                     for (ProgressListener listener : listeners)

--- a/src/java/org/apache/cassandra/repair/RepairRunnable.java
+++ b/src/java/org/apache/cassandra/repair/RepairRunnable.java
@@ -143,6 +143,8 @@ public class RepairRunnable extends WrappedRunnable implements ProgressEventNoti
         }
 
         final long startTime = System.currentTimeMillis();
+        String message = String.format("Starting repair command #%d, repairing keyspace %s with %s", cmd, keyspace,
+                options);
         logger.info("Starting repair command #{}, repairing keyspace {} with {}", SafeArg.of("cmd", cmd), SafeArg.of("keyspace", keyspace), SafeArg.of("options", options));
 
         fireProgressEvent(tag, new ProgressEvent(ProgressEventType.START, 0, 100, message));
@@ -260,6 +262,8 @@ public class RepairRunnable extends WrappedRunnable implements ProgressEventNoti
                      * {@link org.apache.cassandra.utils.progress.jmx.LegacyJMXProgressSupport}
                      * for backward-compatibility support.
                      */
+                    String message = String.format("Repair session %s for range %s finished", session.getId(),
+                            session.getRange().toString());
                     logger.info(
                             "Repair session {} for range {} finished",
                             SafeArg.of("sessionId", session.getId()),
@@ -278,6 +282,8 @@ public class RepairRunnable extends WrappedRunnable implements ProgressEventNoti
                      * {@link org.apache.cassandra.utils.progress.jmx.LegacyJMXProgressSupport}
                      * for backward-compatibility support.
                      */
+                    String message = String.format("Repair session %s for range %s failed with error %s",
+                            session.getId(), session.getRange().toString(), t.getMessage());
                     logger.error(
                             "Repair session {} for range {} failed with error {}" + t,
                             SafeArg.of("sessionId", session.getId()),

--- a/src/java/org/apache/cassandra/repair/RepairSession.java
+++ b/src/java/org/apache/cassandra/repair/RepairSession.java
@@ -26,6 +26,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.*;
+
+import com.palantir.logsafe.SafeArg;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -173,7 +176,12 @@ public class RepairSession extends AbstractFuture<RepairSessionResult> implement
         }
 
         String message = String.format("Received merkle tree for %s from %s", desc.columnFamily, endpoint);
-        logger.info("[repair #{}] {}", getId(), message);
+        logger.info(
+                "[repair #{}] Received merkle tree for {} from {}",
+                SafeArg.of("sessionId", getId()),
+                SafeArg.of("columnFamily", desc.columnFamily),
+                SafeArg.of("endpoint", endpoint)
+        );
         Tracing.traceRepair(message);
         task.treeReceived(tree);
     }
@@ -194,7 +202,13 @@ public class RepairSession extends AbstractFuture<RepairSessionResult> implement
             return;
         }
 
-        logger.debug(String.format("[repair #%s] Repair completed between %s and %s on %s", getId(), nodes.endpoint1, nodes.endpoint2, desc.columnFamily));
+        logger.debug(
+                "[repair #{}] Repair completed between {} and {} on {}",
+                SafeArg.of("sessionId", getId()),
+                SafeArg.of("endpoint1", nodes.endpoint1),
+                SafeArg.of("endpoint2", nodes.endpoint2),
+                SafeArg.of("columnFamily", desc.columnFamily)
+        );
         task.syncComplete(success);
     }
 
@@ -221,13 +235,25 @@ public class RepairSession extends AbstractFuture<RepairSessionResult> implement
         if (terminated)
             return;
 
-        logger.info(String.format("[repair #%s] new session: will sync %s on range %s for %s.%s", getId(), repairedNodes(), range, keyspace, Arrays.toString(cfnames)));
+        logger.info(
+                "[repair #{}] new session: will sync {} on range {} for {}.{}",
+                SafeArg.of("sessionId", getId()),
+                SafeArg.of("endpoints", repairedNodes()),
+                SafeArg.of("range", range),
+                SafeArg.of("keyspace", keyspace),
+                SafeArg.of("columnFamilies", Arrays.toString(cfnames))
+        );
         Tracing.traceRepair("Syncing range {}", range);
         SystemDistributedKeyspace.startRepairs(getId(), parentRepairSession, keyspace, cfnames, range, endpoints);
 
         if (endpoints.isEmpty())
         {
-            logger.info("[repair #{}] {}", getId(), message = String.format("No neighbors to repair with on range %s: session completed", range));
+            message = String.format("No neighbors to repair with on range %s: session completed", range);
+            logger.info(
+                    "[repair #{}] No neighbors to repair with on range {}: session completed",
+                    SafeArg.of("repairId", getId()),
+                    SafeArg.of("range", range)
+            );
             Tracing.traceRepair(message);
             set(new RepairSessionResult(id, keyspace, range, Lists.<RepairResult>newArrayList()));
             SystemDistributedKeyspace.failRepairs(getId(), keyspace, cfnames, new RuntimeException(message));
@@ -240,7 +266,7 @@ public class RepairSession extends AbstractFuture<RepairSessionResult> implement
             if (!FailureDetector.instance.isAlive(endpoint))
             {
                 message = String.format("Cannot proceed on repair because a neighbor (%s) is dead: session failed", endpoint);
-                logger.error("[repair #{}] {}", getId(), message);
+                logger.error("[repair #{}] Cannot proceed on repair because a neighbor {} is dead: session failed", SafeArg.of("sessionId", getId()), SafeArg.of("endpoint", endpoint));
                 Exception e = new IOException(message);
                 setException(e);
                 SystemDistributedKeyspace.failRepairs(getId(), keyspace, cfnames, e);
@@ -263,7 +289,7 @@ public class RepairSession extends AbstractFuture<RepairSessionResult> implement
             public void onSuccess(List<RepairResult> results)
             {
                 // this repair session is completed
-                logger.info("[repair #{}] {}", getId(), "Session completed successfully");
+                logger.info("[repair #{}] Session completed successfully", SafeArg.of("sessionId", getId()));
                 Tracing.traceRepair("Completed sync of range {}", range);
                 set(new RepairSessionResult(id, keyspace, range, results));
 
@@ -274,7 +300,7 @@ public class RepairSession extends AbstractFuture<RepairSessionResult> implement
 
             public void onFailure(Throwable t)
             {
-                logger.error(String.format("[repair #%s] Session completed with the following error", getId()), t);
+                logger.error("[repair {}] Session completed with the following error", SafeArg.of("sessionId", getId()), t);
                 Tracing.traceRepair("Session completed with the following error: {}", t);
                 forceShutdown(t);
             }
@@ -331,7 +357,7 @@ public class RepairSession extends AbstractFuture<RepairSessionResult> implement
             return;
 
         Exception exception = new IOException(String.format("Endpoint %s died", endpoint));
-        logger.error(String.format("[repair #%s] session completed with the following error", getId()), exception);
+        logger.error("[repair {}] session completed with the following error", SafeArg.of("sessionId", getId()), exception);
         // If a node failed, we stop everything (though there could still be some activity in the background)
         forceShutdown(exception);
     }

--- a/src/java/org/apache/cassandra/repair/RepairTracker.java
+++ b/src/java/org/apache/cassandra/repair/RepairTracker.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.palantir.logsafe.SafeArg;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,11 +83,11 @@ public class RepairTracker implements ProgressListener
 
     private void updateProgressState(StorageServiceMBean.ProgressState state, int command)
     {
-        logger.info("Updating state for repair command {} to {}", command, state);
+        logger.info("Updating state for repair command {} to {}", SafeArg.of("command", command), SafeArg.of("state", state));
         commandToProgressState.put(command, state);
         if (isCompleteState(state))
         {
-            logger.info("No longer collapsing identical repairs on top of repair command {}", command);
+            logger.info("No longer collapsing identical repairs on top of repair command {}", SafeArg.of("command", command));
             argsToMostRecentRepair.inverse().remove(command);
         }
     }
@@ -118,7 +119,7 @@ public class RepairTracker implements ProgressListener
                 return;
             default:
                 logger.error("Unrecognized ProgressEventType. Setting ProgressState to UNKNOWN for repair command {}",
-                             command);
+                             SafeArg.of("command", command));
                 newState = StorageServiceMBean.ProgressState.UNKNOWN;
         }
         if (newState != currentState)

--- a/src/java/org/apache/cassandra/repair/StreamingRepairTask.java
+++ b/src/java/org/apache/cassandra/repair/StreamingRepairTask.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.repair;
 
 import java.net.InetAddress;
 
+import com.palantir.logsafe.SafeArg;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +57,12 @@ public class StreamingRepairTask implements Runnable, StreamEventHandler
     {
         InetAddress dest = request.dst;
         InetAddress preferred = SystemKeyspace.getPreferredIP(dest);
-        logger.info(String.format("[streaming task #%s] Performing streaming repair of %d ranges with %s", desc.sessionId, request.ranges.size(), request.dst));
+        logger.info(
+                "[streaming task #{}] Performing streaming repair of {} ranges with {}",
+                SafeArg.of("sessionId", desc.sessionId),
+                SafeArg.of("rangeCount", request.ranges.size()),
+                SafeArg.of("destination", request.dst)
+        );
         boolean isIncremental = false;
         if (desc.parentSessionId != null)
         {
@@ -82,7 +89,11 @@ public class StreamingRepairTask implements Runnable, StreamEventHandler
      */
     public void onSuccess(StreamState state)
     {
-        logger.info(String.format("[repair #%s] streaming task succeed, returning response to %s", desc.sessionId, request.initiator));
+        logger.info(
+                "[repair #{}] streaming task succeeded, returning response to {}",
+                SafeArg.of("sessionId", desc.sessionId),
+                SafeArg.of("initiator", request.initiator)
+        );
         MessagingService.instance().sendOneWay(new SyncComplete(desc, request.src, request.dst, true).createMessage(), request.initiator);
     }
 

--- a/src/java/org/apache/cassandra/repair/SyncTask.java
+++ b/src/java/org/apache/cassandra/repair/SyncTask.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.util.concurrent.AbstractFuture;
+import com.palantir.logsafe.SafeArg;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,17 +64,30 @@ public abstract class SyncTask extends AbstractFuture<SyncStat> implements Runna
         stat = new SyncStat(new NodePair(r1.endpoint, r2.endpoint), differences.size());
 
         // choose a repair method based on the significance of the difference
-        String format = String.format("[repair #%s] Endpoints %s and %s %%s for %s", desc.sessionId, r1.endpoint, r2.endpoint, desc.columnFamily);
         if (differences.isEmpty())
         {
-            logger.info(String.format(format, "are consistent"));
+            logger.info(
+                    "[repair #{}] Endpoints {} and {} {} for {}",
+                    SafeArg.of("sessionId", desc.sessionId),
+                    SafeArg.of("endpoint1", r1.endpoint),
+                    SafeArg.of("endpoint2", r2.endpoint),
+                    "are consistent",
+                    SafeArg.of("columnFamily", desc.columnFamily)
+            );
             Tracing.traceRepair("Endpoint {} is consistent with {} for {}", r1.endpoint, r2.endpoint, desc.columnFamily);
             set(stat);
             return;
         }
 
         // non-0 difference: perform streaming repair
-        logger.info(String.format(format, "have " + differences.size() + " range(s) out of sync"));
+        logger.info(
+                "[repair #{}] Endpoints {} and {} have {} range(s) out of sync for {}",
+                SafeArg.of("sessionId", desc.sessionId),
+                SafeArg.of("endpoint1", r1.endpoint),
+                SafeArg.of("endpoint2", r2.endpoint),
+                SafeArg.of("differenceCount", differences.size()),
+                SafeArg.of("columnFamily", desc.columnFamily)
+        );
         Tracing.traceRepair("Endpoint {} has {} range(s) out of sync with {} for {}", r1.endpoint, differences.size(), r2.endpoint, desc.columnFamily);
         startSync(differences);
     }

--- a/src/java/org/apache/cassandra/repair/SyncTask.java
+++ b/src/java/org/apache/cassandra/repair/SyncTask.java
@@ -67,11 +67,10 @@ public abstract class SyncTask extends AbstractFuture<SyncStat> implements Runna
         if (differences.isEmpty())
         {
             logger.info(
-                    "[repair #{}] Endpoints {} and {} {} for {}",
+                    "[repair #{}] Endpoints {} and {} are consistent for {}",
                     SafeArg.of("sessionId", desc.sessionId),
                     SafeArg.of("endpoint1", r1.endpoint),
                     SafeArg.of("endpoint2", r2.endpoint),
-                    "are consistent",
                     SafeArg.of("columnFamily", desc.columnFamily)
             );
             Tracing.traceRepair("Endpoint {} is consistent with {} for {}", r1.endpoint, r2.endpoint, desc.columnFamily);

--- a/src/java/org/apache/cassandra/repair/SystemDistributedKeyspace.java
+++ b/src/java/org/apache/cassandra/repair/SystemDistributedKeyspace.java
@@ -32,6 +32,8 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 
+import com.palantir.logsafe.UnsafeArg;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -200,7 +202,7 @@ public final class SystemDistributedKeyspace
         }
         catch (Throwable t)
         {
-            logger.error("Error executing query "+fmtQry, t);
+            logger.error("Error executing query {}", UnsafeArg.of("query", fmtQry), t);
         }
     }
 

--- a/src/java/org/apache/cassandra/repair/Validator.java
+++ b/src/java/org/apache/cassandra/repair/Validator.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Random;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.palantir.logsafe.SafeArg;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -118,7 +119,7 @@ public class Validator implements Runnable
                 }
             }
         }
-        logger.debug("Prepared AEService tree of size {} for {}", tree.size(), desc);
+        logger.debug("Prepared AEService tree of size {} for {}", SafeArg.of("treeSize", tree.size()), SafeArg.of("repairJob", desc));
         ranges = tree.invalids();
     }
 
@@ -222,9 +223,9 @@ public class Validator implements Runnable
         if (logger.isDebugEnabled())
         {
             // log distribution of rows in tree
-            logger.debug("Validated {} partitions for {}.  Partitions per leaf are:", validated, desc.sessionId);
+            logger.debug("Validated {} partitions for {}.  Partitions per leaf are:", SafeArg.of("validated", validated), SafeArg.of("sessionId", desc.sessionId));
             tree.histogramOfRowCountPerLeaf().log(logger);
-            logger.debug("Validated {} partitions for {}.  Partition sizes are:", validated, desc.sessionId);
+            logger.debug("Validated {} partitions for {}.  Partition sizes are:", SafeArg.of("validated", validated), SafeArg.of("sessionId", desc.sessionId));
             tree.histogramOfRowSizePerLeaf().log(logger);
         }
     }
@@ -250,7 +251,7 @@ public class Validator implements Runnable
      */
     public void fail()
     {
-        logger.error("Failed creating a merkle tree for {}, {} (see log for details)", desc, initiator);
+        logger.error("Failed creating a merkle tree for {}, {} (see log for details)", SafeArg.of("repairJob", desc), SafeArg.of("endpoint", initiator));
         // send fail message only to nodes >= version 2.0
         MessagingService.instance().sendOneWay(new ValidationComplete(desc).createMessage(), initiator);
     }
@@ -263,7 +264,12 @@ public class Validator implements Runnable
         // respond to the request that triggered this validation
         if (!initiator.equals(FBUtilities.getBroadcastAddress()))
         {
-            logger.info(String.format("[repair #%s] Sending completed merkle tree to %s for %s.%s", desc.sessionId, initiator, desc.keyspace, desc.columnFamily));
+            logger.info(
+                    "[repair {}] Sending completed merkle tree to {} for {}.{}",
+                    SafeArg.of("sessionId", desc.sessionId),
+                    SafeArg.of("endpoint", initiator),
+                    SafeArg.of("keyspace", desc.keyspace),
+                    SafeArg.of("columnFamily", desc.columnFamily));
             Tracing.traceRepair("Sending completed merkle tree to {} for {}.{}", initiator, desc.keyspace, desc.columnFamily);
         }
         MessagingService.instance().sendOneWay(new ValidationComplete(desc, tree).createMessage(), initiator);


### PR DESCRIPTION
Added safearg/unsafearg wherever I saw any `logger` usages in this package. Unrolled some `String.format` usages and referred to the arguments directly. Also worth looking at is the `RepairMessageVerbHandler::logErrorAndSendFailureResponse` function which I edited to take variable amount of safe/unsafe args.

Tested by deploying my local version of cassandra to sls form of the service to view logs.
```
# cqlsh
CREATE KEYSPACE my_keyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};
USE my_keyspace;
CREATE TABLE users (   user_id UUID PRIMARY KEY,   first_name text,   last_name text,   email text );
CONSISTENCY LOCAL_ONE;
INSERT INTO users (user_id, first_name, last_name, email) VALUES (uuid(), 'John', 'Doe', 'john.doe@example.com');
```
then
```
./nodetool repair my_keyspace;
```
then view logs by tailing `/var/log/service.log`