### PR TITLE
Make initial token allocation strategy pluggable

### DIFF
--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -69,6 +69,7 @@ public class Config
 
     /* Hashing strategy Random or OPHF */
     public String partitioner;
+    public String tokenAllocator = "RandomTokenAllocator";
 
     public Boolean auto_bootstrap = true;
     public volatile boolean hinted_handoff_enabled_global = true;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -89,6 +89,7 @@ public class DatabaseDescriptor
 
     /* Strategy to allocate initial tokens during bootstrap if not specified. */
     private static ITokenAllocator tokenAllocator;
+    private static String tokenAllocatorName;
 
     private static Config.DiskAccessMode indexAccessMode;
 
@@ -414,6 +415,7 @@ public class DatabaseDescriptor
         {
             throw new ConfigurationException("Invalid tokenAllocator class " + conf.tokenAllocator, false);
         }
+        tokenAllocatorName = tokenAllocator.getClass().getCanonicalName();
 
         if (config.gc_log_threshold_in_ms < 0)
         {
@@ -937,6 +939,10 @@ public class DatabaseDescriptor
     public static ITokenAllocator getTokenAllocator()
     {
         return tokenAllocator;
+    }
+
+    public static String getTokenAllocatorName() {
+        return tokenAllocatorName;
     }
 
     /* For tests ONLY, don't use otherwise or all hell will break loose */

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -47,6 +47,7 @@ import org.apache.cassandra.config.EncryptionOptions.ServerEncryptionOptions;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.ITokenAllocator;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.sstable.format.SSTableFormat;
@@ -85,6 +86,9 @@ public class DatabaseDescriptor
     /* Hashing strategy Random or OPHF */
     private static IPartitioner partitioner;
     private static String paritionerName;
+
+    /* Strategy to allocate initial tokens during bootstrap if not specified. */
+    private static ITokenAllocator tokenAllocator;
 
     private static Config.DiskAccessMode indexAccessMode;
 
@@ -396,6 +400,20 @@ public class DatabaseDescriptor
             throw new ConfigurationException("Invalid partitioner class " + conf.partitioner, false);
         }
         paritionerName = partitioner.getClass().getCanonicalName();
+
+        /* Token allocation strategy */
+        if (conf.tokenAllocator == null)
+        {
+            throw new ConfigurationException("Missing directive: tokenAllocator", false);
+        }
+        try
+        {
+            tokenAllocator = FBUtilities.newTokenAllocator(System.getProperty("cassandra.tokenAllocator", conf.tokenAllocator));
+        }
+        catch (Exception e)
+        {
+            throw new ConfigurationException("Invalid tokenAllocator class " + conf.tokenAllocator, false);
+        }
 
         if (config.gc_log_threshold_in_ms < 0)
         {
@@ -914,6 +932,11 @@ public class DatabaseDescriptor
     public static String getPartitionerName()
     {
         return paritionerName;
+    }
+
+    public static ITokenAllocator getTokenAllocator()
+    {
+        return tokenAllocator;
     }
 
     /* For tests ONLY, don't use otherwise or all hell will break loose */

--- a/src/java/org/apache/cassandra/dht/BootStrapper.java
+++ b/src/java/org/apache/cassandra/dht/BootStrapper.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.db.Keyspace;
@@ -175,22 +176,13 @@ public class BootStrapper extends ProgressEventNotifierSupport
         if (numTokens < 1)
             throw new ConfigurationException("num_tokens must be >= 1");
 
-        if (numTokens == 1)
-            logger.warn("Picking random token for a single vnode.  You should probably add more vnodes; failing that, you should probably specify the token manually");
-
-        return DatabaseDescriptor.getTokenAllocator().allocateTokens(metadata, numTokens);
+        return allocateTokens(metadata, numTokens);
     }
 
-    public static Collection<Token> getRandomTokens(TokenMetadata metadata, int numTokens)
+    public static Collection<Token> allocateTokens(TokenMetadata metadata, int numTokens)
     {
-        Set<Token> tokens = new HashSet<>(numTokens);
-        while (tokens.size() < numTokens)
-        {
-            Token token = StorageService.getPartitioner().getRandomToken();
-            if (metadata.getEndpoint(token) == null)
-                tokens.add(token);
-        }
-        return tokens;
+        logger.info("Allocating tokens to node using: {}", SafeArg.of("tokenAllocator", DatabaseDescriptor.getTokenAllocatorName()));
+        return DatabaseDescriptor.getTokenAllocator().allocateTokens(metadata, numTokens);
     }
 
     public static class StringSerializer implements IVersionedSerializer<String>

--- a/src/java/org/apache/cassandra/dht/BootStrapper.java
+++ b/src/java/org/apache/cassandra/dht/BootStrapper.java
@@ -178,7 +178,7 @@ public class BootStrapper extends ProgressEventNotifierSupport
         if (numTokens == 1)
             logger.warn("Picking random token for a single vnode.  You should probably add more vnodes; failing that, you should probably specify the token manually");
 
-        return getRandomTokens(metadata, numTokens);
+        return DatabaseDescriptor.getTokenAllocator().allocateTokens(metadata, numTokens);
     }
 
     public static Collection<Token> getRandomTokens(TokenMetadata metadata, int numTokens)

--- a/src/java/org/apache/cassandra/dht/ITokenAllocator.java
+++ b/src/java/org/apache/cassandra/dht/ITokenAllocator.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht;
+
+import java.util.Collection;
+
+import org.apache.cassandra.locator.TokenMetadata;
+
+public interface ITokenAllocator
+{
+    Collection<Token> allocateTokens(TokenMetadata metadata, int numTokens);
+}

--- a/src/java/org/apache/cassandra/dht/RandomTokenAllocator.java
+++ b/src/java/org/apache/cassandra/dht/RandomTokenAllocator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.cassandra.locator.TokenMetadata;
+import org.apache.cassandra.service.StorageService;
+
+public class RandomTokenAllocator implements ITokenAllocator
+{
+    public Collection<Token> allocateTokens(TokenMetadata metadata, int numTokens)
+    {
+        Set<Token> tokens = new HashSet<>(numTokens);
+        while (tokens.size() < numTokens)
+        {
+            Token token = StorageService.getPartitioner().getRandomToken();
+            if (metadata.getEndpoint(token) == null)
+                tokens.add(token);
+        }
+        return tokens;
+    }
+}

--- a/src/java/org/apache/cassandra/dht/RandomTokenAllocator.java
+++ b/src/java/org/apache/cassandra/dht/RandomTokenAllocator.java
@@ -22,11 +22,18 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.palantir.logsafe.SafeArg;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.locator.TokenMetadata;
 import org.apache.cassandra.service.StorageService;
 
 public class RandomTokenAllocator implements ITokenAllocator
 {
+    private static final Logger logger = LoggerFactory.getLogger(RandomTokenAllocator.class);
+
     public Collection<Token> allocateTokens(TokenMetadata metadata, int numTokens)
     {
         Set<Token> tokens = new HashSet<>(numTokens);
@@ -36,6 +43,13 @@ public class RandomTokenAllocator implements ITokenAllocator
             if (metadata.getEndpoint(token) == null)
                 tokens.add(token);
         }
+
+        if (DatabaseDescriptor.getNumTokens() == 1)
+            logger.warn("Generated single random token {}. Random tokens will result in an unbalanced ring; see http://wiki.apache.org/cassandra/Operations",
+                        SafeArg.of("token", tokens));
+        else
+            logger.info("Generated random tokens. tokens are {}", SafeArg.of("tokens", tokens));
+
         return tokens;
     }
 }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1071,12 +1071,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             {
                 if (initialTokens.size() < 1)
                 {
-                    bootstrapTokens = BootStrapper.getRandomTokens(tokenMetadata, DatabaseDescriptor.getNumTokens());
-                    if (DatabaseDescriptor.getNumTokens() == 1)
-                        logger.warn("Generated random token {}. Random tokens will result in an unbalanced ring; see http://wiki.apache.org/cassandra/Operations",
-                                    SafeArg.of("token", bootstrapTokens));
-                    else
-                        logger.info("Generated random tokens. tokens are {}", SafeArg.of("tokens", bootstrapTokens));
+                    bootstrapTokens = BootStrapper.allocateTokens(tokenMetadata, DatabaseDescriptor.getNumTokens());
                 }
                 else
                 {

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -47,6 +47,7 @@ import org.apache.cassandra.auth.IRoleManager;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.ITokenAllocator;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.ConfigurationException;
@@ -455,6 +456,13 @@ public class FBUtilities
         if (!partitionerClassName.contains("."))
             partitionerClassName = "org.apache.cassandra.dht." + partitionerClassName;
         return FBUtilities.instanceOrConstruct(partitionerClassName, "partitioner");
+    }
+
+    public static ITokenAllocator newTokenAllocator(String tokenAllocatorClassName) throws ConfigurationException
+    {
+        if (!tokenAllocatorClassName.contains("."))
+            tokenAllocatorClassName = "org.apache.cassandra.dht." + tokenAllocatorClassName;
+        return FBUtilities.instanceOrConstruct(tokenAllocatorClassName, "tokenAllocator");
     }
 
     public static IAuthorizer newAuthorizer(String className) throws ConfigurationException


### PR DESCRIPTION
Following up from my investigation on ring ownership skew and token allocations, I want to make the initial token allocation behaviour pluggable so I can test different strategies safely.

Copied the approach directly from how `partitioner` works, except I've set a default value which defaults to the existing random allocation behaviour, so existing installations should be unaffected. 