### PR TITLE
Add metric for table size relative to storage load

### DIFF
--- a/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
@@ -455,9 +455,14 @@ public class ColumnFamilyMetrics
             }
         });
         liveDiskSpaceUsed = createColumnFamilyCounter("LiveDiskSpaceUsed");
-        liveDiskSpaceUsedRatio = Metrics.register(
-            factory.createMetricName("LiveDiskSpaceUsedRatio"),
-            () -> (double) liveDiskSpaceUsed.getCount() / StorageMetrics.load.getCount());
+        liveDiskSpaceUsedRatio = Metrics.register(factory.createMetricName("LiveDiskSpaceUsedRatio"), new RatioGauge()
+        {
+            @Override
+            protected Ratio getRatio()
+            {
+                return Ratio.of(liveDiskSpaceUsed.getCount(), StorageMetrics.load.getCount());
+            }
+        });
         totalDiskSpaceUsed = createColumnFamilyCounter("TotalDiskSpaceUsed");
         minRowSize = createColumnFamilyGauge("MinRowSize", new Gauge<Long>()
         {

--- a/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
@@ -93,6 +93,8 @@ public class ColumnFamilyMetrics
     public final Counter liveDiskSpaceUsed;
     /** Total disk space used by SSTables belonging to this CF, including obsolete ones waiting to be GC'd */
     public final Counter totalDiskSpaceUsed;
+    /** Total disk space used by SSTables belonging to this CF, including obsolete ones waiting to be GC'd, relative to global storage load. */
+    public final Gauge<Double> totalDiskSpaceUsedRelativeToGlobalStorageLoad;
     /** Size of the smallest compacted row */
     public final Gauge<Long> minRowSize;
     /** Size of the largest compacted row */
@@ -454,6 +456,12 @@ public class ColumnFamilyMetrics
         });
         liveDiskSpaceUsed = createColumnFamilyCounter("LiveDiskSpaceUsed");
         totalDiskSpaceUsed = createColumnFamilyCounter("TotalDiskSpaceUsed");
+        totalDiskSpaceUsedRelativeToGlobalStorageLoad = createColumnFamilyGauge("TotalDiskSpaceUsedRelativeToGlobalStorageLoad", new Gauge<Double>() {
+            @Override
+            public Double getValue() {
+                return (double) totalDiskSpaceUsed.getCount() / StorageMetrics.load.getCount();
+            }
+        });
         minRowSize = createColumnFamilyGauge("MinRowSize", new Gauge<Long>()
         {
             public Long getValue()

--- a/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
@@ -92,7 +92,7 @@ public class ColumnFamilyMetrics
     /** Disk space used by SSTables belonging to this CF */
     public final Counter liveDiskSpaceUsed;
     /** Disk space used by SSTables belonging to this CF, relative to global storage load. */
-    public final Gauge<Double> liveDiskSpaceUsedRelativeToGlobalStorageLoad;
+    public final Gauge<Double> liveDiskSpaceUsedRatio;
     /** Total disk space used by SSTables belonging to this CF, including obsolete ones waiting to be GC'd */
     public final Counter totalDiskSpaceUsed;
     /** Size of the smallest compacted row */
@@ -455,8 +455,8 @@ public class ColumnFamilyMetrics
             }
         });
         liveDiskSpaceUsed = createColumnFamilyCounter("LiveDiskSpaceUsed");
-        liveDiskSpaceUsedRelativeToGlobalStorageLoad = Metrics.register(
-            factory.createMetricName("LiveDiskSpaceUsedRelativeToGlobalStorageLoad"),
+        liveDiskSpaceUsedRatio = Metrics.register(
+            factory.createMetricName("LiveDiskSpaceUsedRatio"),
             () -> (double) liveDiskSpaceUsed.getCount() / StorageMetrics.load.getCount());
         totalDiskSpaceUsed = createColumnFamilyCounter("TotalDiskSpaceUsed");
         minRowSize = createColumnFamilyGauge("MinRowSize", new Gauge<Long>()

--- a/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
@@ -91,10 +91,10 @@ public class ColumnFamilyMetrics
     public final Gauge<Integer> liveSSTableCount;
     /** Disk space used by SSTables belonging to this CF */
     public final Counter liveDiskSpaceUsed;
+    /** Disk space used by SSTables belonging to this CF, relative to global storage load. */
+    public final Gauge<Double> liveDiskSpaceUsedRelativeToGlobalStorageLoad;
     /** Total disk space used by SSTables belonging to this CF, including obsolete ones waiting to be GC'd */
     public final Counter totalDiskSpaceUsed;
-    /** Total disk space used by SSTables belonging to this CF, including obsolete ones waiting to be GC'd, relative to global storage load. */
-    public final Gauge<Double> totalDiskSpaceUsedRelativeToGlobalStorageLoad;
     /** Size of the smallest compacted row */
     public final Gauge<Long> minRowSize;
     /** Size of the largest compacted row */
@@ -455,13 +455,10 @@ public class ColumnFamilyMetrics
             }
         });
         liveDiskSpaceUsed = createColumnFamilyCounter("LiveDiskSpaceUsed");
+        liveDiskSpaceUsedRelativeToGlobalStorageLoad = Metrics.register(
+            factory.createMetricName("LiveDiskSpaceUsedRelativeToGlobalStorageLoad"),
+            () -> (double) liveDiskSpaceUsed.getCount() / StorageMetrics.load.getCount());
         totalDiskSpaceUsed = createColumnFamilyCounter("TotalDiskSpaceUsed");
-        totalDiskSpaceUsedRelativeToGlobalStorageLoad = createColumnFamilyGauge("TotalDiskSpaceUsedRelativeToGlobalStorageLoad", new Gauge<Double>() {
-            @Override
-            public Double getValue() {
-                return (double) totalDiskSpaceUsed.getCount() / StorageMetrics.load.getCount();
-            }
-        });
         minRowSize = createColumnFamilyGauge("MinRowSize", new Gauge<Long>()
         {
             public Long getValue()


### PR DESCRIPTION
This PR adds a metric for a columnfamily's storage load relative to global storage load. This will help establish tables that are so large that we might no longer be able to compact them if we are also running short on disk space.