### PR TITLE
Backport Intelligent Token Allocation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -85,7 +85,7 @@ Merged from 2.1:
  * Fix compaction and flush exception not captured (CASSANDRA-13833)
  * Make BatchlogManagerMBean.forceBatchlogReplay() blocking (CASSANDRA-13809)
  * Uncaught exceptions in Netty pipeline (CASSANDRA-13649)
- * Prevent integer overflow on exabyte filesystems (CASSANDRA-13067) 
+ * Prevent integer overflow on exabyte filesystems (CASSANDRA-13067)
  * Fix queries with LIMIT and filtering on clustering columns (CASSANDRA-11223)
  * Fix potential NPE when resume bootstrap fails (CASSANDRA-13272)
  * Fix toJSONString for the UDT, tuple and collection types (CASSANDRA-13592)
@@ -132,7 +132,7 @@ Merged from 2.1:
  * Fix negative mean latency metric (CASSANDRA-12876)
  * Use only one file pointer when creating commitlog segments (CASSANDRA-12539)
  * Fix speculative retry bugs (CASSANDRA-13009)
- * Fix handling of nulls and unsets in IN conditions (CASSANDRA-12981) 
+ * Fix handling of nulls and unsets in IN conditions (CASSANDRA-12981)
  * Remove support for non-JavaScript UDFs (CASSANDRA-12883)
  * Fix DynamicEndpointSnitch noop in multi-datacenter situations (CASSANDRA-13074)
  * cqlsh copy-from: encode column names to avoid primary key parsing errors (CASSANDRA-12909)
@@ -263,19 +263,19 @@ Merged from 2.1:
  * Do not consider local node a valid source during replace (CASSANDRA-11848)
  * Avoid holding SSTableReaders for duration of incremental repair (CASSANDRA-11739)
  * Add message dropped tasks to nodetool netstats (CASSANDRA-11855)
- * Don't compute expensive MaxPurgeableTimestamp until we've verified there's an 
+ * Don't compute expensive MaxPurgeableTimestamp until we've verified there's an
    expired tombstone (CASSANDRA-11834)
  * Add option to disable use of severity in DynamicEndpointSnitch (CASSANDRA-11737)
  * cqlsh COPY FROM fails for null values with non-prepared statements (CASSANDRA-11631)
  * Make cython optional in pylib/setup.py (CASSANDRA-11630)
- * Change order of directory searching for cassandra.in.sh to favor local one 
+ * Change order of directory searching for cassandra.in.sh to favor local one
    (CASSANDRA-11628)
  * cqlsh COPY FROM fails with []{} chars in UDT/tuple fields/values (CASSANDRA-11633)
  * clqsh: COPY FROM throws TypeError with Cython extensions enabled (CASSANDRA-11574)
  * cqlsh: COPY FROM ignores NULL values in conversion (CASSANDRA-11549)
  * (cqlsh) Fix potential COPY deadlock when parent process is terminating child
    processes (CASSANDRA-11505)
- * Validate levels when building LeveledScanner to avoid overlaps with orphaned 
+ * Validate levels when building LeveledScanner to avoid overlaps with orphaned
    sstables (CASSANDRA-9935)
 
 
@@ -500,7 +500,7 @@ Merged from 2.1:
  * Defer default role manager setup until all nodes are on 2.2+ (CASSANDRA-9761)
  * Cancel transaction for sstables we wont redistribute index summary
    for (CASSANDRA-10270)
- * Handle missing RoleManager in config after upgrade to 2.2 (CASSANDRA-10209) 
+ * Handle missing RoleManager in config after upgrade to 2.2 (CASSANDRA-10209)
  * Retry snapshot deletion after compaction and gc on Windows (CASSANDRA-10222)
  * Fix failure to start with space in directory path on Windows (CASSANDRA-10239)
  * Fix repair hang when snapshot failed (CASSANDRA-10057)
@@ -627,7 +627,7 @@ Merged from 2.1:
  * (cqlsh) Fix bad check for CQL compatibility when DESCRIBE'ing
    COMPACT STORAGE tables with no clustering columns
  * Eliminate strong self-reference chains in sstable ref tidiers (CASSANDRA-9656)
- * Ensure StreamSession uses canonical sstable reader instances (CASSANDRA-9700) 
+ * Ensure StreamSession uses canonical sstable reader instances (CASSANDRA-9700)
  * Ensure memtable book keeping is not corrupted in the event we shrink usage (CASSANDRA-9681)
  * Update internal python driver for cqlsh (CASSANDRA-9064)
  * Fix IndexOutOfBoundsException when inserting tuple with too many

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -24,6 +24,17 @@ cluster_name: 'Test Cluster'
 # multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
 num_tokens: 256
 
+# Triggers automatic allocation of num_tokens tokens for this node. The allocation
+# algorithm attempts to choose tokens in a way that optimizes replicated load over
+# the nodes in the datacenter for the replication strategy used by the specified
+# keyspace.
+#
+# The load assigned to each node will be close to proportional to its number of
+# vnodes.
+#
+# Only supported with the Murmur3Partitioner.
+# allocate_tokens_keyspace: KEYSPACE
+
 # initial_token allows you to specify tokens manually.  While you can use # it with
 # vnodes (num_tokens > 1, above) -- in which case you should provide a 
 # comma-separated list -- it's primarily used when adding nodes # to legacy clusters 

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1,4 +1,4 @@
-# Cassandra storage config YAML 
+# Cassandra storage config YAML
 
 # NOTE:
 #   See http://wiki.apache.org/cassandra/StorageConfiguration for
@@ -26,18 +26,24 @@ num_tokens: 256
 
 # Triggers automatic allocation of num_tokens tokens for this node. The allocation
 # algorithm attempts to choose tokens in a way that optimizes replicated load over
-# the nodes in the datacenter for the replication strategy used by the specified
-# keyspace.
+# the nodes in the datacenter for the replica factor.
 #
 # The load assigned to each node will be close to proportional to its number of
 # vnodes.
 #
 # Only supported with the Murmur3Partitioner.
-# allocate_tokens_keyspace: KEYSPACE
 
-# initial_token allows you to specify tokens manually.  While you can use # it with
+# Replica factor is determined via the replication strategy used by the specified
+# keyspace.
+# allocate_tokens_for_keyspace: KEYSPACE
+
+# Replica factor is explicitly set, regardless of keyspace or datacenter.
+# This is the replica factor within the datacenter, like NTS.
+# allocate_tokens_for_local_replication_factor: 3
+
+# initial_token allows you to specify tokens manually.  While you can use it with
 # vnodes (num_tokens > 1, above) -- in which case you should provide a 
-# comma-separated list -- it's primarily used when adding nodes # to legacy clusters 
+# comma-separated list -- it's primarily used when adding nodes # to legacy clusters
 # that do not have vnodes enabled.
 # initial_token:
 
@@ -284,14 +290,14 @@ counter_cache_save_period: 7200
 #
 # the default option is "periodic" where writes may be acked immediately
 # and the CommitLog is simply synced every commitlog_sync_period_in_ms
-# milliseconds. 
+# milliseconds.
 commitlog_sync: periodic
 commitlog_sync_period_in_ms: 10000
 
 # The size of the individual commitlog file segments.  A commitlog
 # segment may be archived, deleted, or recycled once all the data
 # in it (potentially from each columnfamily in the system) has been
-# flushed to sstables.  
+# flushed to sstables.
 #
 # The default size is 32, which is almost always fine, but if you are
 # archiving commitlog segments (see commitlog_archiving.properties),
@@ -339,7 +345,7 @@ concurrent_counter_writes: 32
 # the smaller of 1/4 of heap or 512MB.
 # file_cache_size_in_mb: 512
 
-# Total permitted memory to use for memtables. Cassandra will stop 
+# Total permitted memory to use for memtables. Cassandra will stop
 # accepting writes when the limit is exceeded until a flush completes,
 # and will trigger a flush based on memtable_cleanup_threshold
 # If omitted, Cassandra will set both to 1/4 the size of the heap.
@@ -375,11 +381,11 @@ memtable_allocation_type: heap_buffers
 
 # This sets the amount of memtable flush writer threads.  These will
 # be blocked by disk io, and each one will hold a memtable in memory
-# while blocked. 
+# while blocked.
 #
 # memtable_flush_writers defaults to the smaller of (number of disks,
 # number of cores), with a minimum of 2 and a maximum of 8.
-# 
+#
 # If your data directories are backed by SSD, you should increase this
 # to the number of cores.
 #memtable_flush_writers: 8
@@ -805,7 +811,7 @@ request_scheduler: org.apache.cassandra.scheduler.NoScheduler
 # NoScheduler - Has no options
 # RoundRobin
 #  - throttle_limit -- The throttle_limit is the number of in-flight
-#                      requests per client.  Requests beyond 
+#                      requests per client.  Requests beyond
 #                      that limit are queued up until
 #                      running requests can complete.
 #                      The value of 80 here is twice the number of

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -87,6 +87,8 @@ public class Config
     public Integer num_tokens = 1;
     /** Triggers automatic allocation of tokens if set, using the replication strategy of the referenced keyspace */
     public String allocate_tokens_for_keyspace = null;
+    /** Triggers automatic allocation of tokens if set, based on the provided replica count for a datacenter */
+    public Integer allocate_tokens_for_local_replication_factor = null;
 
     public long native_transport_idle_timeout_in_ms = 0L;
 

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -85,6 +85,8 @@ public class Config
     /* initial token in the ring */
     public String initial_token;
     public Integer num_tokens = 1;
+    /** Triggers automatic allocation of tokens if set, using the replication strategy of the referenced keyspace */
+    public String allocate_tokens_for_keyspace = null;
 
     public long native_transport_idle_timeout_in_ms = 0L;
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -986,9 +986,14 @@ public class DatabaseDescriptor
         return tokensFromString(System.getProperty("cassandra.initial_token", conf.initial_token));
     }
 
-    public static String getAllocateTokensKeyspace()
+    public static String getAllocateTokensForKeyspace()
     {
-        return System.getProperty("cassandra.allocate_tokens_keyspace", conf.allocate_tokens_for_keyspace);
+        return System.getProperty("cassandra.allocate_tokens_for_keyspace", conf.allocate_tokens_for_keyspace);
+    }
+
+    public static Integer getAllocateTokensForLocalRf()
+    {
+        return Integer.parseInt(System.getProperty("cassandra.allocate_tokens_for_local_replication_factor", conf.allocate_tokens_for_local_replication_factor.toString()));
     }
 
     public static Collection<String> tokensFromString(String tokenString)

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -986,6 +986,11 @@ public class DatabaseDescriptor
         return tokensFromString(System.getProperty("cassandra.initial_token", conf.initial_token));
     }
 
+    public static String getAllocateTokensKeyspace()
+    {
+        return System.getProperty("cassandra.allocate_tokens_keyspace", conf.allocate_tokens_for_keyspace);
+    }
+
     public static Collection<String> tokensFromString(String tokenString)
     {
         List<String> tokens = new ArrayList<String>();

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -993,7 +993,7 @@ public class DatabaseDescriptor
 
     public static Integer getAllocateTokensForLocalRf()
     {
-        return Integer.parseInt(System.getProperty("cassandra.allocate_tokens_for_local_replication_factor", conf.allocate_tokens_for_local_replication_factor.toString()));
+        return Integer.getInteger("cassandra.allocate_tokens_for_local_replication_factor", conf.allocate_tokens_for_local_replication_factor);
     }
 
     public static Collection<String> tokensFromString(String tokenString)

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -76,7 +76,7 @@ public class CommitLog implements CommitLogMBean
     volatile Configuration configuration;
     final public String location;
 
-    static private CommitLog construct()
+    private static CommitLog construct()
     {
         CommitLog log = new CommitLog(DatabaseDescriptor.getCommitLogLocation(), CommitLogArchiver.construct());
 

--- a/src/java/org/apache/cassandra/db/commitlog/CompressedSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CompressedSegment.java
@@ -35,7 +35,7 @@ import org.apache.cassandra.utils.SyncUtil;
  */
 public class CompressedSegment extends CommitLogSegment
 {
-    static private final ThreadLocal<ByteBuffer> compressedBufferHolder = new ThreadLocal<ByteBuffer>() {
+    private static final ThreadLocal<ByteBuffer> compressedBufferHolder = new ThreadLocal<ByteBuffer>() {
         protected ByteBuffer initialValue()
         {
             return ByteBuffer.allocate(0);

--- a/src/java/org/apache/cassandra/dht/BootStrapper.java
+++ b/src/java/org/apache/cassandra/dht/BootStrapper.java
@@ -159,7 +159,8 @@ public class BootStrapper extends ProgressEventNotifierSupport
      */
     public static Collection<Token> getBootstrapTokens(final TokenMetadata metadata, InetAddress address, int schemaWaitDelay, Collection<String> initialTokens) throws ConfigurationException
     {
-        String allocationKeyspace = DatabaseDescriptor.getAllocateTokensKeyspace();
+        String allocationKeyspace = DatabaseDescriptor.getAllocateTokensForKeyspace();
+        Integer allocationLocalRf = DatabaseDescriptor.getAllocateTokensForLocalRf();
         if (initialTokens.size() > 0 && allocationKeyspace != null)
             logger.warn("manually specified tokens override automatic allocation");
 
@@ -173,6 +174,9 @@ public class BootStrapper extends ProgressEventNotifierSupport
 
         if (allocationKeyspace != null)
             return allocateTokens(metadata, address, allocationKeyspace, numTokens, schemaWaitDelay);
+
+        if (allocationLocalRf != null)
+            return allocateTokens(metadata, address, allocationLocalRf, numTokens, schemaWaitDelay);
 
         if (numTokens == 1)
             logger.warn("Picking random token for a single vnode.  You should probably add more vnodes and/or use the automatic token allocation mechanism.");
@@ -211,6 +215,20 @@ public class BootStrapper extends ProgressEventNotifierSupport
         AbstractReplicationStrategy rs = ks.getReplicationStrategy();
 
         return TokenAllocation.allocateTokens(metadata, rs, StorageService.getPartitioner(), address, numTokens);
+    }
+
+
+    static Collection<Token> allocateTokens(final TokenMetadata metadata,
+                                            InetAddress address,
+                                            int rf,
+                                            int numTokens,
+                                            int schemaWaitDelay)
+    {
+        StorageService.instance.waitForSchema(schemaWaitDelay);
+        if (!FBUtilities.getBroadcastAddress().equals(InetAddress.getLoopbackAddress()))
+            Gossiper.waitToSettle();
+
+        return TokenAllocation.allocateTokens(metadata, rf, StorageService.getPartitioner(), address, numTokens);
     }
 
     public static Collection<Token> getRandomTokens(TokenMetadata metadata, int numTokens)

--- a/src/java/org/apache/cassandra/dht/BootStrapper.java
+++ b/src/java/org/apache/cassandra/dht/BootStrapper.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.dht.tokenallocator.TokenAllocation;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.gms.FailureDetector;
 import org.apache.cassandra.io.IVersionedSerializer;
@@ -151,34 +152,59 @@ public class BootStrapper extends ProgressEventNotifierSupport
 
     /**
      * if initialtoken was specified, use that (split on comma).
-     * otherwise, if num_tokens == 1, pick a token to assume half the load of the most-loaded node.
+     * otherwise, if allocationKeyspace is specified use the token allocation algorithm to generate suitable tokens
      * else choose num_tokens tokens at random
      */
-    public static Collection<Token> getBootstrapTokens(final TokenMetadata metadata, Collection<String> initialTokens) throws ConfigurationException
+    public static Collection<Token> getBootstrapTokens(final TokenMetadata metadata, InetAddress address) throws ConfigurationException
     {
+        String allocationKeyspace = DatabaseDescriptor.getAllocateTokensKeyspace();
+        Collection<String> initialTokens = DatabaseDescriptor.getInitialTokens();
+        if (initialTokens.size() > 0 && allocationKeyspace != null)
+            logger.warn("manually specified tokens override automatic allocation");
+
         // if user specified tokens, use those
         if (initialTokens.size() > 0)
-        {
-            logger.trace("tokens manually specified as {}",  initialTokens);
-            List<Token> tokens = new ArrayList<>(initialTokens.size());
-            for (String tokenString : initialTokens)
-            {
-                Token token = StorageService.getPartitioner().getTokenFactory().fromString(tokenString);
-                if (metadata.getEndpoint(token) != null)
-                    throw new ConfigurationException("Bootstrapping to existing token " + tokenString + " is not allowed (decommission/removenode the old node first).");
-                tokens.add(token);
-            }
-            return tokens;
-        }
+            return getSpecifiedTokens(metadata, initialTokens);
 
         int numTokens = DatabaseDescriptor.getNumTokens();
         if (numTokens < 1)
             throw new ConfigurationException("num_tokens must be >= 1");
 
+        if (allocationKeyspace != null)
+            return allocateTokens(metadata, address, allocationKeyspace, numTokens);
+
         if (numTokens == 1)
-            logger.warn("Picking random token for a single vnode.  You should probably add more vnodes; failing that, you should probably specify the token manually");
+            logger.warn("Picking random token for a single vnode.  You should probably add more vnodes and/or use the automatic token allocation mechanism.");
 
         return getRandomTokens(metadata, numTokens);
+    }
+
+    private static Collection<Token> getSpecifiedTokens(final TokenMetadata metadata,
+                                                                Collection<String> initialTokens)
+    {
+        logger.debug("tokens manually specified as {}",  initialTokens);
+        List<Token> tokens = new ArrayList<>(initialTokens.size());
+        for (String tokenString : initialTokens)
+        {
+            Token token = StorageService.getPartitioner().getTokenFactory().fromString(tokenString);
+            if (metadata.getEndpoint(token) != null)
+                throw new ConfigurationException("Bootstrapping to existing token " + tokenString + " is not allowed (decommission/removenode the old node first).");
+            tokens.add(token);
+        }
+        return tokens;
+    }
+
+    static Collection<Token> allocateTokens(final TokenMetadata metadata,
+                                            InetAddress address,
+                                            String allocationKeyspace,
+                                            int numTokens)
+    {
+        Keyspace ks = Keyspace.open(allocationKeyspace);
+        if (ks == null)
+            throw new ConfigurationException("Problem opening token allocation keyspace " + allocationKeyspace);
+        AbstractReplicationStrategy rs = ks.getReplicationStrategy();
+
+        return TokenAllocation.allocateTokens(metadata, rs, StorageService.getPartitioner(), address, numTokens);
     }
 
     public static Collection<Token> getRandomTokens(TokenMetadata metadata, int numTokens)

--- a/src/java/org/apache/cassandra/dht/BootStrapper.java
+++ b/src/java/org/apache/cassandra/dht/BootStrapper.java
@@ -34,12 +34,14 @@ import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.dht.tokenallocator.TokenAllocation;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.gms.FailureDetector;
+import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.locator.TokenMetadata;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.streaming.*;
+import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.progress.ProgressEvent;
 import org.apache.cassandra.utils.progress.ProgressEventNotifierSupport;
 import org.apache.cassandra.utils.progress.ProgressEventType;
@@ -155,10 +157,9 @@ public class BootStrapper extends ProgressEventNotifierSupport
      * otherwise, if allocationKeyspace is specified use the token allocation algorithm to generate suitable tokens
      * else choose num_tokens tokens at random
      */
-    public static Collection<Token> getBootstrapTokens(final TokenMetadata metadata, InetAddress address) throws ConfigurationException
+    public static Collection<Token> getBootstrapTokens(final TokenMetadata metadata, InetAddress address, int schemaWaitDelay, Collection<String> initialTokens) throws ConfigurationException
     {
         String allocationKeyspace = DatabaseDescriptor.getAllocateTokensKeyspace();
-        Collection<String> initialTokens = DatabaseDescriptor.getInitialTokens();
         if (initialTokens.size() > 0 && allocationKeyspace != null)
             logger.warn("manually specified tokens override automatic allocation");
 
@@ -171,7 +172,7 @@ public class BootStrapper extends ProgressEventNotifierSupport
             throw new ConfigurationException("num_tokens must be >= 1");
 
         if (allocationKeyspace != null)
-            return allocateTokens(metadata, address, allocationKeyspace, numTokens);
+            return allocateTokens(metadata, address, allocationKeyspace, numTokens, schemaWaitDelay);
 
         if (numTokens == 1)
             logger.warn("Picking random token for a single vnode.  You should probably add more vnodes and/or use the automatic token allocation mechanism.");
@@ -180,9 +181,9 @@ public class BootStrapper extends ProgressEventNotifierSupport
     }
 
     private static Collection<Token> getSpecifiedTokens(final TokenMetadata metadata,
-                                                                Collection<String> initialTokens)
+                                                        Collection<String> initialTokens)
     {
-        logger.debug("tokens manually specified as {}",  initialTokens);
+        logger.info("tokens manually specified as {}",  initialTokens);
         List<Token> tokens = new ArrayList<>(initialTokens.size());
         for (String tokenString : initialTokens)
         {
@@ -197,8 +198,13 @@ public class BootStrapper extends ProgressEventNotifierSupport
     static Collection<Token> allocateTokens(final TokenMetadata metadata,
                                             InetAddress address,
                                             String allocationKeyspace,
-                                            int numTokens)
+                                            int numTokens,
+                                            int schemaWaitDelay)
     {
+        StorageService.instance.waitForSchema(schemaWaitDelay);
+        if (!FBUtilities.getBroadcastAddress().equals(InetAddress.getLoopbackAddress()))
+            Gossiper.waitToSettle();
+
         Keyspace ks = Keyspace.open(allocationKeyspace);
         if (ks == null)
             throw new ConfigurationException("Problem opening token allocation keyspace " + allocationKeyspace);
@@ -216,6 +222,8 @@ public class BootStrapper extends ProgressEventNotifierSupport
             if (metadata.getEndpoint(token) == null)
                 tokens.add(token);
         }
+
+        logger.info("Generated random tokens. tokens are {}", tokens);
         return tokens;
     }
 

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -158,6 +158,11 @@ public class ByteOrderedPartitioner implements IPartitioner
         return new BytesToken(bytesForBig(midpair.left, sigbytes, midpair.right));
     }
 
+    public Token split(Token left, Token right, double ratioToLeft)
+    {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Convert a byte array containing the most significant of 'sigbytes' bytes
      * representing a big-endian magnitude into a BigInteger.

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -116,6 +116,20 @@ public class ByteOrderedPartitioner implements IPartitioner
         {
             return token;
         }
+
+        @Override
+        public double size(Token next)
+        {
+            throw new UnsupportedOperationException(String.format("Token type %s does not support token allocation.",
+                                                                  getClass().getSimpleName()));
+        }
+
+        @Override
+        public Token increaseSlightly()
+        {
+            throw new UnsupportedOperationException(String.format("Token type %s does not support token allocation.",
+                                                                  getClass().getSimpleName()));
+        }
     }
 
     public BytesToken getToken(ByteBuffer key)

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -187,7 +187,7 @@ public class ByteOrderedPartitioner implements IPartitioner
         BigInteger right = bigForBytes(rToken.token, sigbytes);
 
         Pair<BigInteger,Boolean> midpair = FBUtilities.midpoint(left, right, 8*sigbytes);
-        return new BytesToken(bytesForBig(midpair.left, sigbytes, false));
+        return new BytesToken(bytesForBig(midpair.left, sigbytes, midpair.right));
     }
 
     public Token split(Token left, Token right, double ratioToLeft)
@@ -239,7 +239,7 @@ public class ByteOrderedPartitioner implements IPartitioner
         if (sigbytes != bytes.length)
         {
             b = new byte[sigbytes];
-            System.arraycopy(bytes, 0, b, 0, bytes.length);
+            System.arraycopy(bytes, 0, b, 0, Math.min(bytes.length, b.length));
         } else
             b = bytes;
         return new BigInteger(1, b);

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class ByteOrderedPartitioner implements IPartitioner
 {
@@ -203,9 +204,13 @@ public class ByteOrderedPartitioner implements IPartitioner
 
     public BytesToken getRandomToken()
     {
-        Random r = new Random();
+        return getRandomToken(ThreadLocalRandom.current());
+    }
+
+    public BytesToken getRandomToken(Random random)
+    {
         byte[] buffer = new byte[16];
-        r.nextBytes(buffer);
+        random.nextBytes(buffer);
         return new BytesToken(buffer);
     }
 

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -33,7 +33,9 @@ import org.apache.cassandra.utils.Pair;
 
 import org.apache.commons.lang3.ArrayUtils;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.MathContext;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,6 +48,12 @@ import java.util.concurrent.ThreadLocalRandom;
 public class ByteOrderedPartitioner implements IPartitioner
 {
     public static final BytesToken MINIMUM = new BytesToken(ArrayUtils.EMPTY_BYTE_ARRAY);
+    public static final BytesToken MAXIMUM = new BytesToken(new byte[16]);
+    public static final BigDecimal MAX_TOKEN_MAGNITUDE;
+    static {
+        Arrays.fill(MAXIMUM.token, (byte) 0xFF);
+        MAX_TOKEN_MAGNITUDE = new BigDecimal(bigForBytes(MAXIMUM.token, 16));
+    }
 
     public static final BigInteger BYTE_MASK = new BigInteger("255");
 
@@ -121,15 +129,39 @@ public class ByteOrderedPartitioner implements IPartitioner
         @Override
         public double size(Token next)
         {
-            throw new UnsupportedOperationException(String.format("Token type %s does not support token allocation.",
-                                                                  getClass().getSimpleName()));
+            BytesToken n = (BytesToken) next;
+            BigDecimal size = new BigDecimal(bigForBytes(n.token, 16).subtract(bigForBytes(token, 16)));
+            BigDecimal d = size.divide(MAX_TOKEN_MAGNITUDE, MathContext.DECIMAL64); // Scale so that the full range is 1.
+            return (d.compareTo(BigDecimal.ZERO) > 0 ? d : d.add(BigDecimal.ONE)).doubleValue(); // Adjust for signed long, also making sure t.size(t) == 1.
         }
 
         @Override
         public Token increaseSlightly()
         {
-            throw new UnsupportedOperationException(String.format("Token type %s does not support token allocation.",
-                                                                  getClass().getSimpleName()));
+            if (token.length < 16)
+            {
+                byte[] newToken = Arrays.copyOf(token, token.length + 1);
+                newToken[token.length] = 0;
+                return new BytesToken(newToken);
+            }
+            else if (Arrays.equals(token, MAXIMUM.token))
+            {
+                return MINIMUM;
+            }
+            else
+            {
+                byte[] result = new byte[16];
+                System.arraycopy(token, 0, result, 0, 16);
+                for (int i = 15; i >= 0; i--) {
+                    if (result[i] != (byte) 0xFF) {
+                        result[i]++;
+                        break;
+                    } else {
+                        result[i] = 0;
+                    }
+                }
+                return new BytesToken(result);
+            }
         }
     }
 
@@ -147,12 +179,12 @@ public class ByteOrderedPartitioner implements IPartitioner
 
     public BytesToken midpoint(Token lt, Token rt)
     {
-        BytesToken ltoken = (BytesToken) lt;
-        BytesToken rtoken = (BytesToken) rt;
+        BytesToken lToken = (BytesToken) lt;
+        BytesToken rToken = (BytesToken) rt;
 
-        int sigbytes = Math.max(ltoken.token.length, rtoken.token.length);
-        BigInteger left = bigForBytes(ltoken.token, sigbytes);
-        BigInteger right = bigForBytes(rtoken.token, sigbytes);
+        int sigbytes = Math.max(lToken.token.length, rToken.token.length);
+        BigInteger left = bigForBytes(lToken.token, sigbytes);
+        BigInteger right = bigForBytes(rToken.token, sigbytes);
 
         Pair<BigInteger,Boolean> midpair = FBUtilities.midpoint(left, right, 8*sigbytes);
         return new BytesToken(bytesForBig(midpair.left, sigbytes, midpair.right));
@@ -160,14 +192,48 @@ public class ByteOrderedPartitioner implements IPartitioner
 
     public Token split(Token left, Token right, double ratioToLeft)
     {
-        throw new UnsupportedOperationException();
+        BytesToken lToken = (BytesToken) left;
+        BytesToken rToken = (BytesToken) right;
+
+        int sigbytes = 16;
+        BigDecimal l = new BigDecimal(bigForBytes(lToken.token, 16)),
+                   r = new BigDecimal(bigForBytes(rToken.token, 16)),
+                   ratio = BigDecimal.valueOf(ratioToLeft);
+        byte[] newToken;
+
+        if (l.compareTo(r) < 0)
+        {
+            newToken = bytesForBig(r.subtract(l).multiply(ratio).add(l).toBigInteger(), sigbytes, false);
+        }
+        else
+        {
+            // wrapping case
+            // L + ((R - min) + (max - L)) * pct
+            BigInteger maxTokenInt = bigForBytes(MAXIMUM.token, MAXIMUM.token.length);
+            BigInteger minTokenInt = bigForBytes(MINIMUM.token, MINIMUM.token.length);
+            BigDecimal max = new BigDecimal(maxTokenInt);
+            BigDecimal min = new BigDecimal(minTokenInt);
+
+            BigInteger token = max.subtract(min).add(r).subtract(l).multiply(ratio).add(l).toBigInteger();
+
+            if (token.compareTo(maxTokenInt) <= 0)
+            {
+                newToken = bytesForBig(token, sigbytes, false);
+            }
+            else
+            {
+                // if the value is above maximum
+                newToken = bytesForBig(minTokenInt.add(token.subtract(maxTokenInt)), sigbytes, false);
+            }
+        }
+        return new BytesToken(newToken);
     }
 
     /**
      * Convert a byte array containing the most significant of 'sigbytes' bytes
      * representing a big-endian magnitude into a BigInteger.
      */
-    protected BigInteger bigForBytes(byte[] bytes, int sigbytes)
+    protected static BigInteger bigForBytes(byte[] bytes, int sigbytes)
     {
         byte[] b;
         if (sigbytes != bytes.length)
@@ -184,7 +250,7 @@ public class ByteOrderedPartitioner implements IPartitioner
      * If remainder is true, an additional byte with the high order bit enabled
      * will be added to the end of the array
      */
-    protected byte[] bytesForBig(BigInteger big, int sigbytes, boolean remainder)
+    protected static byte[] bytesForBig(BigInteger big, int sigbytes, boolean remainder)
     {
         byte[] bytes = new byte[sigbytes + (remainder ? 1 : 0)];
         if (remainder)

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -187,7 +187,7 @@ public class ByteOrderedPartitioner implements IPartitioner
         BigInteger right = bigForBytes(rToken.token, sigbytes);
 
         Pair<BigInteger,Boolean> midpair = FBUtilities.midpoint(left, right, 8*sigbytes);
-        return new BytesToken(bytesForBig(midpair.left, sigbytes, midpair.right));
+        return new BytesToken(bytesForBig(midpair.left, sigbytes, false));
     }
 
     public Token split(Token left, Token right, double ratioToLeft)

--- a/src/java/org/apache/cassandra/dht/ComparableObjectToken.java
+++ b/src/java/org/apache/cassandra/dht/ComparableObjectToken.java
@@ -66,4 +66,18 @@ abstract class ComparableObjectToken<C extends Comparable<C>> extends Token
 
         return token.compareTo(((ComparableObjectToken<C>) o).token);
     }
+
+    @Override
+    public double size(Token next)
+    {
+        throw new UnsupportedOperationException(String.format("Token type %s does not support token allocation.",
+                                                              getClass().getSimpleName()));
+    }
+
+    @Override
+    public Token increaseSlightly()
+    {
+        throw new UnsupportedOperationException(String.format("Token type %s does not support token allocation.",
+                                                              getClass().getSimpleName()));
+    }
 }

--- a/src/java/org/apache/cassandra/dht/IPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/IPartitioner.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.dht;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -59,6 +60,13 @@ public interface IPartitioner
      * @return a randomly generated token
      */
     public Token getRandomToken();
+
+    /**
+     * @param random instance of Random to use when generating the token
+     *
+     * @return a randomly generated token
+     */
+    public Token getRandomToken(Random random);
 
     public Token.TokenFactory getTokenFactory();
 

--- a/src/java/org/apache/cassandra/dht/IPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/IPartitioner.java
@@ -44,6 +44,11 @@ public interface IPartitioner
     public Token midpoint(Token left, Token right);
 
     /**
+     * Calculate a Token which take approximate 0 <= ratioToLeft <= 1 ownership of the given range.
+     */
+    public Token split(Token left, Token right, double ratioToLeft);
+
+    /**
      * @return A Token smaller than all others in the range that is being partitioned.
      * Not legal to assign to a node or key.  (But legal to use in range scans.)
      */

--- a/src/java/org/apache/cassandra/dht/LocalPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/LocalPartitioner.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.CachedHashDecoratedKey;
@@ -60,6 +61,11 @@ public class LocalPartitioner implements IPartitioner
     }
 
     public LocalToken getRandomToken()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    public LocalToken getRandomToken(Random random)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/java/org/apache/cassandra/dht/LocalPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/LocalPartitioner.java
@@ -50,6 +50,11 @@ public class LocalPartitioner implements IPartitioner
         throw new UnsupportedOperationException();
     }
 
+    public Token split(Token left, Token right, double ratioToLeft)
+    {
+        throw new UnsupportedOperationException();
+    }
+
     public LocalToken getMinimumToken()
     {
         return new LocalToken(ByteBufferUtil.EMPTY_BYTE_BUFFER);

--- a/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java
+++ b/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java
@@ -79,6 +79,42 @@ public class Murmur3Partitioner implements IPartitioner
         return new LongToken(midpoint.longValue());
     }
 
+    public Token split(Token lToken, Token rToken, double ratioToLeft)
+    {
+        BigDecimal l = BigDecimal.valueOf(((LongToken) lToken).token),
+                   r = BigDecimal.valueOf(((LongToken) rToken).token),
+                   ratio = BigDecimal.valueOf(ratioToLeft);
+        long newToken;
+
+        if (l.compareTo(r) < 0)
+        {
+            newToken = r.subtract(l).multiply(ratio).add(l).toBigInteger().longValue();
+        }
+        else
+        {
+            // wrapping case
+            // L + ((R - min) + (max - L)) * pct
+            BigDecimal max = BigDecimal.valueOf(MAXIMUM);
+            BigDecimal min = BigDecimal.valueOf(MINIMUM.token);
+
+            BigInteger token = max.subtract(min).add(r).subtract(l).multiply(ratio).add(l).toBigInteger();
+
+            BigInteger maxToken = BigInteger.valueOf(MAXIMUM);
+
+            if (token.compareTo(maxToken) <= 0)
+            {
+                newToken = token.longValue();
+            }
+            else
+            {
+                // if the value is above maximum
+                BigInteger minToken = BigInteger.valueOf(MINIMUM.token);
+                newToken = minToken.add(token.subtract(maxToken)).longValue();
+            }
+        }
+        return new LongToken(newToken);
+    }
+
     public LongToken getMinimumToken()
     {
         return MINIMUM;

--- a/src/java/org/apache/cassandra/dht/OrderPreservingPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/OrderPreservingPartitioner.java
@@ -21,6 +21,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.cassandra.config.*;
 import org.apache.cassandra.db.DecoratedKey;
@@ -37,6 +38,8 @@ import org.apache.cassandra.utils.Pair;
 
 public class OrderPreservingPartitioner implements IPartitioner
 {
+    private static final String rndchars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
     public static final StringToken MINIMUM = new StringToken("");
 
     public static final BigInteger CHAR_MASK = new BigInteger("65535");
@@ -106,12 +109,14 @@ public class OrderPreservingPartitioner implements IPartitioner
 
     public StringToken getRandomToken()
     {
-        String chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-        Random r = new Random();
+        return getRandomToken(ThreadLocalRandom.current());
+    }
+
+    public StringToken getRandomToken(Random random)
+    {
         StringBuilder buffer = new StringBuilder();
-        for (int j = 0; j < 16; j++) {
-            buffer.append(chars.charAt(r.nextInt(chars.length())));
-        }
+        for (int j = 0; j < 16; j++)
+            buffer.append(rndchars.charAt(random.nextInt(rndchars.length())));
         return new StringToken(buffer.toString());
     }
 

--- a/src/java/org/apache/cassandra/dht/OrderPreservingPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/OrderPreservingPartitioner.java
@@ -63,6 +63,11 @@ public class OrderPreservingPartitioner implements IPartitioner
         return new StringToken(stringForBig(midpair.left, sigchars, midpair.right));
     }
 
+    public Token split(Token left, Token right, double ratioToLeft)
+    {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Copies the characters of the given string into a BigInteger.
      *

--- a/src/java/org/apache/cassandra/dht/RandomPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/RandomPartitioner.java
@@ -152,6 +152,19 @@ public class RandomPartitioner implements IPartitioner
         {
             return HEAP_SIZE;
         }
+
+        public Token increaseSlightly()
+        {
+            return new BigIntegerToken(token.add(BigInteger.ONE));
+        }
+
+        public double size(Token next)
+        {
+            BigIntegerToken n = (BigIntegerToken) next;
+            BigInteger v = n.token.subtract(token);  // Overflow acceptable and desired.
+            double d = Math.scalb(v.doubleValue(), -127); // Scale so that the full range is 1.
+            return d > 0.0 ? d : (d + 1.0); // Adjust for signed long, also making sure t.size(t) == 1.
+        }
     }
 
     public BigIntegerToken getToken(ByteBuffer key)

--- a/src/java/org/apache/cassandra/dht/RandomPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/RandomPartitioner.java
@@ -63,6 +63,32 @@ public class RandomPartitioner implements IPartitioner
         return new BigIntegerToken(midpair.left);
     }
 
+    public Token split(Token ltoken, Token rtoken, double ratioToLeft)
+    {
+        BigDecimal left = ltoken.equals(MINIMUM) ? BigDecimal.ZERO : new BigDecimal(((BigIntegerToken)ltoken).token),
+                   right = rtoken.equals(MINIMUM) ? BigDecimal.ZERO : new BigDecimal(((BigIntegerToken)rtoken).token),
+                   ratio = BigDecimal.valueOf(ratioToLeft);
+
+        BigInteger newToken;
+
+        if (left.compareTo(right) < 0)
+        {
+            newToken = right.subtract(left).multiply(ratio).add(left).toBigInteger();
+        }
+        else
+        {
+            // wrapping case
+            // L + ((R - min) + (max - L)) * ratio
+            BigDecimal max = new BigDecimal(MAXIMUM);
+
+            newToken = max.add(right).subtract(left).multiply(ratio).add(left).toBigInteger().mod(MAXIMUM);
+        }
+
+        assert isValidToken(newToken) : "Invalid tokens from split";
+
+        return new BigIntegerToken(newToken);
+    }
+
     public BigIntegerToken getMinimumToken()
     {
         return MINIMUM;
@@ -82,6 +108,10 @@ public class RandomPartitioner implements IPartitioner
         if ( token.signum() == -1 )
             token = token.multiply(BigInteger.valueOf(-1L));
         return new BigIntegerToken(token);
+    }
+
+    private boolean isValidToken(BigInteger token) {
+        return token.compareTo(ZERO) >= 0 && token.compareTo(MAXIMUM) <= 0;
     }
 
     private final Token.TokenFactory tokenFactory = new Token.TokenFactory()
@@ -107,11 +137,8 @@ public class RandomPartitioner implements IPartitioner
         {
             try
             {
-                BigInteger i = new BigInteger(token);
-                if (i.compareTo(ZERO) < 0)
-                    throw new ConfigurationException("Token must be >= 0");
-                if (i.compareTo(MAXIMUM) > 0)
-                    throw new ConfigurationException("Token must be <= 2**127");
+                if(!isValidToken(new BigInteger(token)))
+                    throw new ConfigurationException("Token must be >= 0 and <= 2**127");
             }
             catch (NumberFormatException e)
             {

--- a/src/java/org/apache/cassandra/dht/RandomPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/RandomPartitioner.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.dht;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.security.MessageDigest;
 import java.util.*;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -43,6 +44,29 @@ public class RandomPartitioner implements IPartitioner
     public static final BigInteger ZERO = new BigInteger("0");
     public static final BigIntegerToken MINIMUM = new BigIntegerToken("-1");
     public static final BigInteger MAXIMUM = new BigInteger("2").pow(127);
+
+    /**
+     * Maintain a separate threadlocal message digest, exclusively for token hashing. This is necessary because
+     * when Tracing is enabled and using the default tracing implementation, creating the mutations for the trace
+     * events involves tokenizing the partition keys. This happens multiple times whilst servicing a ReadCommand,
+     * and so can interfere with the stateful digest calculation if the node is a replica producing a digest response.
+     */
+    private static final ThreadLocal<MessageDigest> localMD5Digest = new ThreadLocal<MessageDigest>()
+    {
+        @Override
+        protected MessageDigest initialValue()
+        {
+            return FBUtilities.newMessageDigest("MD5");
+        }
+
+        @Override
+        public MessageDigest get()
+        {
+            MessageDigest digest = super.get();
+            digest.reset();
+            return digest;
+        }
+    };
 
     private static final int HEAP_SIZE = (int) ObjectSizes.measureDeep(new BigIntegerToken(FBUtilities.hashToBigInteger(ByteBuffer.allocate(1))));
 
@@ -70,7 +94,15 @@ public class RandomPartitioner implements IPartitioner
 
     public BigIntegerToken getRandomToken()
     {
-        BigInteger token = FBUtilities.hashToBigInteger(GuidGenerator.guidAsBytes());
+        BigInteger token = hashToBigInteger(GuidGenerator.guidAsBytes());
+        if ( token.signum() == -1 )
+            token = token.multiply(BigInteger.valueOf(-1L));
+        return new BigIntegerToken(token);
+    }
+
+    public BigIntegerToken getRandomToken(Random random)
+    {
+        BigInteger token = hashToBigInteger(GuidGenerator.guidAsBytes(random, "host/127.0.0.1", 0));
         if ( token.signum() == -1 )
             token = token.multiply(BigInteger.valueOf(-1L));
         return new BigIntegerToken(token);
@@ -208,5 +240,16 @@ public class RandomPartitioner implements IPartitioner
     public AbstractType<?> getTokenValidator()
     {
         return IntegerType.instance;
+    }
+
+    private static BigInteger hashToBigInteger(ByteBuffer data)
+    {
+        MessageDigest messageDigest = localMD5Digest.get();
+        if (data.hasArray())
+            messageDigest.update(data.array(), data.arrayOffset() + data.position(), data.remaining());
+        else
+            messageDigest.update(data.duplicate());
+
+        return new BigInteger(messageDigest.digest()).abs();
     }
 }

--- a/src/java/org/apache/cassandra/dht/RandomPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/RandomPartitioner.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.dht;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.security.MessageDigest;
 import java.util.*;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -44,29 +43,6 @@ public class RandomPartitioner implements IPartitioner
     public static final BigInteger ZERO = new BigInteger("0");
     public static final BigIntegerToken MINIMUM = new BigIntegerToken("-1");
     public static final BigInteger MAXIMUM = new BigInteger("2").pow(127);
-
-    /**
-     * Maintain a separate threadlocal message digest, exclusively for token hashing. This is necessary because
-     * when Tracing is enabled and using the default tracing implementation, creating the mutations for the trace
-     * events involves tokenizing the partition keys. This happens multiple times whilst servicing a ReadCommand,
-     * and so can interfere with the stateful digest calculation if the node is a replica producing a digest response.
-     */
-    private static final ThreadLocal<MessageDigest> localMD5Digest = new ThreadLocal<MessageDigest>()
-    {
-        @Override
-        protected MessageDigest initialValue()
-        {
-            return FBUtilities.newMessageDigest("MD5");
-        }
-
-        @Override
-        public MessageDigest get()
-        {
-            MessageDigest digest = super.get();
-            digest.reset();
-            return digest;
-        }
-    };
 
     private static final int HEAP_SIZE = (int) ObjectSizes.measureDeep(new BigIntegerToken(FBUtilities.hashToBigInteger(ByteBuffer.allocate(1))));
 
@@ -94,7 +70,7 @@ public class RandomPartitioner implements IPartitioner
 
     public BigIntegerToken getRandomToken()
     {
-        BigInteger token = hashToBigInteger(GuidGenerator.guidAsBytes());
+        BigInteger token = FBUtilities.hashToBigInteger(GuidGenerator.guidAsBytes());
         if ( token.signum() == -1 )
             token = token.multiply(BigInteger.valueOf(-1L));
         return new BigIntegerToken(token);
@@ -102,13 +78,14 @@ public class RandomPartitioner implements IPartitioner
 
     public BigIntegerToken getRandomToken(Random random)
     {
-        BigInteger token = hashToBigInteger(GuidGenerator.guidAsBytes(random, "host/127.0.0.1", 0));
+        BigInteger token = FBUtilities.hashToBigInteger(GuidGenerator.guidAsBytes(random, 0));
         if ( token.signum() == -1 )
             token = token.multiply(BigInteger.valueOf(-1L));
         return new BigIntegerToken(token);
     }
 
-    private final Token.TokenFactory tokenFactory = new Token.TokenFactory() {
+    private final Token.TokenFactory tokenFactory = new Token.TokenFactory()
+    {
         public ByteBuffer toByteArray(Token token)
         {
             BigIntegerToken bigIntegerToken = (BigIntegerToken) token;
@@ -169,7 +146,8 @@ public class RandomPartitioner implements IPartitioner
 
         // convenience method for testing
         @VisibleForTesting
-        public BigIntegerToken(String token) {
+        public BigIntegerToken(String token)
+        {
             this(new BigInteger(token));
         }
 
@@ -214,17 +192,20 @@ public class RandomPartitioner implements IPartitioner
         // 0-case
         if (!i.hasNext()) { throw new RuntimeException("No nodes present in the cluster. Has this node finished starting up?"); }
         // 1-case
-        if (sortedTokens.size() == 1) {
+        if (sortedTokens.size() == 1)
+        {
             ownerships.put(i.next(), new Float(1.0));
         }
         // n-case
-        else {
+        else
+        {
             // NOTE: All divisions must take place in BigDecimals, and all modulo operators must take place in BigIntegers.
             final BigInteger ri = MAXIMUM;                                                  //  (used for addition later)
             final BigDecimal r  = new BigDecimal(ri);                                       // The entire range, 2**127
             Token start = i.next(); BigInteger ti = ((BigIntegerToken)start).token;  // The first token and its value
             Token t; BigInteger tim1 = ti;                                                  // The last token and its value (after loop)
-            while (i.hasNext()) {
+            while (i.hasNext())
+            {
                 t = i.next(); ti = ((BigIntegerToken)t).token;                                      // The next token and its value
                 float x = new BigDecimal(ti.subtract(tim1).add(ri).mod(ri)).divide(r).floatValue(); // %age = ((T(i) - T(i-1) + R) % R) / R
                 ownerships.put(t, x);                                                               // save (T(i) -> %age)
@@ -240,16 +221,5 @@ public class RandomPartitioner implements IPartitioner
     public AbstractType<?> getTokenValidator()
     {
         return IntegerType.instance;
-    }
-
-    private static BigInteger hashToBigInteger(ByteBuffer data)
-    {
-        MessageDigest messageDigest = localMD5Digest.get();
-        if (data.hasArray())
-            messageDigest.update(data.array(), data.arrayOffset() + data.position(), data.remaining());
-        else
-            messageDigest.update(data.duplicate());
-
-        return new BigInteger(messageDigest.digest()).abs();
     }
 }

--- a/src/java/org/apache/cassandra/dht/Token.java
+++ b/src/java/org/apache/cassandra/dht/Token.java
@@ -73,6 +73,18 @@ public abstract class Token implements RingPosition<Token>, Serializable
     abstract public long getHeapSize();
     abstract public Object getTokenValue();
 
+    /**
+     * Returns a measure for the token space covered between this token and next.
+     * Used by the token allocation algorithm (see CASSANDRA-7032).
+     */
+    abstract public double size(Token next);
+    /**
+     * Returns a token that is slightly greater than this. Used to avoid clashes
+     * between nodes in separate datacentres trying to use the same token via
+     * the token allocation algorithm.
+     */
+    abstract public Token increaseSlightly();
+
     public Token getToken()
     {
         return this;

--- a/src/java/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocator.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocator.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht.tokenallocator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Set;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Queues;
+
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Token;
+
+public class NoReplicationTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
+{
+    PriorityQueue<Weighted<UnitInfo>> sortedUnits = Queues.newPriorityQueue();
+    Map<Unit, PriorityQueue<Weighted<TokenInfo>>> tokensInUnits = Maps.newHashMap();
+
+    private static final double MAX_TAKEOVER_RATIO = 0.90;
+    private static final double MIN_TAKEOVER_RATIO = 1.0 - MAX_TAKEOVER_RATIO;
+
+    public NoReplicationTokenAllocator(NavigableMap<Token, Unit> sortedTokens,
+                                       ReplicationStrategy<Unit> strategy,
+                                       IPartitioner partitioner)
+    {
+        super(sortedTokens, strategy, partitioner);
+    }
+
+    /**
+     * Construct the token ring as a CircularList of TokenInfo,
+     * and populate the ownership of the UnitInfo's provided
+     */
+    private TokenInfo<Unit> createTokenInfos(Map<Unit, UnitInfo<Unit>> units)
+    {
+        if (units.isEmpty())
+            return null;
+
+        // build the circular list
+        TokenInfo<Unit> prev = null;
+        TokenInfo<Unit> first = null;
+        for (Map.Entry<Token, Unit> en : sortedTokens.entrySet())
+        {
+            Token t = en.getKey();
+            UnitInfo<Unit> ni = units.get(en.getValue());
+            TokenInfo<Unit> ti = new TokenInfo<>(t, ni);
+            first = ti.insertAfter(first, prev);
+            prev = ti;
+        }
+
+        TokenInfo<Unit> curr = first;
+        tokensInUnits.clear();
+        sortedUnits.clear();
+        do
+        {
+            populateTokenInfoAndAdjustUnit(curr);
+            curr = curr.next;
+        } while (curr != first);
+
+        for (UnitInfo<Unit> unitInfo : units.values())
+        {
+            sortedUnits.add(new Weighted<UnitInfo>(unitInfo.ownership, unitInfo));
+        }
+
+        return first;
+    }
+
+    /**
+     * Used in tests.
+     */
+    protected void createTokenInfos()
+    {
+        createTokenInfos(createUnitInfos(Maps.newHashMap()));
+    }
+
+    private void populateTokenInfoAndAdjustUnit(TokenInfo<Unit> token)
+    {
+        token.replicationStart = token.prevInRing().token;
+        token.replicationThreshold = token.token;
+        token.replicatedOwnership = token.replicationStart.size(token.token);
+        token.owningUnit.ownership += token.replicatedOwnership;
+
+        PriorityQueue<Weighted<TokenInfo>> unitTokens = tokensInUnits.get(token.owningUnit.unit);
+        if (unitTokens == null)
+        {
+            unitTokens = Queues.newPriorityQueue();
+            tokensInUnits.put(token.owningUnit.unit, unitTokens);
+        }
+        unitTokens.add(new Weighted<TokenInfo>(token.replicatedOwnership, token));
+    }
+
+    private Collection<Token> generateRandomTokens(UnitInfo<Unit> newUnit, int numTokens, Map<Unit, UnitInfo<Unit>> unitInfos)
+    {
+        Set<Token> tokens = new HashSet<>(numTokens);
+        while (tokens.size() < numTokens)
+        {
+            Token token = partitioner.getRandomToken();
+            if (!sortedTokens.containsKey(token))
+            {
+                tokens.add(token);
+                sortedTokens.put(token, newUnit.unit);
+            }
+        }
+        unitInfos.put(newUnit.unit, newUnit);
+        createTokenInfos(unitInfos);
+        return tokens;
+    }
+
+    public Collection<Token> addUnit(Unit newUnit, int numTokens)
+    {
+        assert !tokensInUnits.containsKey(newUnit);
+
+        Map<Object, GroupInfo> groups = Maps.newHashMap();
+        UnitInfo<Unit> newUnitInfo = new UnitInfo<>(newUnit, 0, groups, strategy);
+        Map<Unit, UnitInfo<Unit>> unitInfos = createUnitInfos(groups);
+
+        if (unitInfos.isEmpty())
+            return generateRandomTokens(newUnitInfo, numTokens, unitInfos);
+
+        if (numTokens > sortedTokens.size())
+            return generateRandomTokens(newUnitInfo, numTokens, unitInfos);
+
+        TokenInfo<Unit> head = createTokenInfos(unitInfos);
+
+        // Select the nodes we will work with, extract them from sortedUnits and calculate targetAverage
+        double targetAverage = 0.0;
+        double sum = 0.0;
+        List<Weighted<UnitInfo>> unitsToChange = new ArrayList<>();
+
+        for (int i = 0; i < numTokens; i++)
+        {
+            Weighted<UnitInfo> unit = sortedUnits.peek();
+
+            if (unit == null)
+                break;
+
+            sum += unit.weight;
+            double average = sum / (unitsToChange.size() + 2); // unit and newUnit must be counted
+            if (unit.weight <= average)
+                // No point to include later nodes, target can only decrease from here.
+                break;
+
+            sortedUnits.remove();
+            unitsToChange.add(unit);
+            targetAverage = average;
+        }
+
+        List<Token> newTokens = Lists.newArrayListWithCapacity(numTokens);
+
+        int nr = 0;
+        // calculate the tokens
+        for (Weighted<UnitInfo> unit : unitsToChange)
+        {
+            // TODO: Any better ways to assign how many tokens to change in each node?
+            int tokensToChange = numTokens / unitsToChange.size() + (nr < numTokens % unitsToChange.size() ? 1 : 0);
+
+            Queue<Weighted<TokenInfo>> unitTokens = tokensInUnits.get(unit.value.unit);
+            List<Weighted<TokenInfo>> tokens = Lists.newArrayListWithCapacity(tokensToChange);
+
+            double workWeight = 0;
+            // Extract biggest vnodes and calculate how much weight we can work with.
+            for (int i = 0; i < tokensToChange; i++)
+            {
+                Weighted<TokenInfo> wt = unitTokens.remove();
+                tokens.add(wt);
+                workWeight += wt.weight;
+                unit.value.ownership -= wt.weight;
+            }
+
+            double toTakeOver = unit.weight - targetAverage;
+            // Split toTakeOver proportionally between the vnodes.
+            for (Weighted<TokenInfo> wt : tokens)
+            {
+                double slice;
+                Token token;
+
+                if (toTakeOver < workWeight)
+                {
+                    // Spread decrease.
+                    slice = toTakeOver / workWeight;
+
+                    if (slice < MIN_TAKEOVER_RATIO)
+                        slice = MIN_TAKEOVER_RATIO;
+                    if (slice > MAX_TAKEOVER_RATIO)
+                        slice = MAX_TAKEOVER_RATIO;
+                }
+                else
+                {
+                    slice = MAX_TAKEOVER_RATIO;
+                }
+                token = partitioner.split(wt.value.prevInRing().token, wt.value.token, slice);
+
+                //Token selected, now change all data
+                sortedTokens.put(token, newUnit);
+
+                TokenInfo<Unit> ti = new TokenInfo<>(token, newUnitInfo);
+
+                ti.insertAfter(head, wt.value.prevInRing());
+
+                populateTokenInfoAndAdjustUnit(ti);
+                populateTokenInfoAndAdjustUnit(wt.value);
+                newTokens.add(token);
+            }
+
+            // adjust the weight for current unit
+            sortedUnits.add(new Weighted<>(unit.value.ownership, unit.value));
+            ++nr;
+        }
+        sortedUnits.add(new Weighted<>(newUnitInfo.ownership, newUnitInfo));
+
+        return newTokens;
+    }
+
+    /**
+     * For testing, remove the given unit preserving correct state of the allocator.
+     */
+    void removeUnit(Unit n)
+    {
+        Iterator<Weighted<UnitInfo>> it = sortedUnits.iterator();
+        while (it.hasNext())
+        {
+            if (it.next().value.unit.equals(n))
+            {
+                it.remove();
+                break;
+            }
+        }
+
+        PriorityQueue<Weighted<TokenInfo>> tokenInfos = tokensInUnits.remove(n);
+        Collection<Token> tokens = Lists.newArrayListWithCapacity(tokenInfos.size());
+        for (Weighted<TokenInfo> tokenInfo : tokenInfos)
+        {
+            tokens.add(tokenInfo.value.token);
+        }
+        sortedTokens.keySet().removeAll(tokens);
+    }
+
+    public int getReplicas()
+    {
+        return 1;
+    }
+}

--- a/src/java/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocator.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocator.java
@@ -113,23 +113,6 @@ public class NoReplicationTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
         unitTokens.add(new Weighted<TokenInfo>(token.replicatedOwnership, token));
     }
 
-    private Collection<Token> generateRandomTokens(UnitInfo<Unit> newUnit, int numTokens, Map<Unit, UnitInfo<Unit>> unitInfos)
-    {
-        Set<Token> tokens = new HashSet<>(numTokens);
-        while (tokens.size() < numTokens)
-        {
-            Token token = partitioner.getRandomToken();
-            if (!sortedTokens.containsKey(token))
-            {
-                tokens.add(token);
-                sortedTokens.put(token, newUnit.unit);
-            }
-        }
-        unitInfos.put(newUnit.unit, newUnit);
-        createTokenInfos(unitInfos);
-        return tokens;
-    }
-
     public Collection<Token> addUnit(Unit newUnit, int numTokens)
     {
         assert !tokensInUnits.containsKey(newUnit);
@@ -139,10 +122,10 @@ public class NoReplicationTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
         Map<Unit, UnitInfo<Unit>> unitInfos = createUnitInfos(groups);
 
         if (unitInfos.isEmpty())
-            return generateRandomTokens(newUnitInfo, numTokens, unitInfos);
+            return generateSplits(newUnit, numTokens);
 
         if (numTokens > sortedTokens.size())
-            return generateRandomTokens(newUnitInfo, numTokens, unitInfos);
+            return generateSplits(newUnit, numTokens);
 
         TokenInfo<Unit> head = createTokenInfos(unitInfos);
 
@@ -170,7 +153,19 @@ public class NoReplicationTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
         }
 
         List<Token> newTokens = Lists.newArrayListWithCapacity(numTokens);
+        // Generate different size nodes, at most at 2/(numTokens*2+1) difference,
+        // but tighten the spread as the number of nodes grows (since it increases the time until we need to use nodes
+        // we have just split).
+        double sizeCorrection = Math.min(1.0, (numTokens + 1.0) / (unitInfos.size() + 1.0));
+        double spread = targetAverage * sizeCorrection * 2.0 / (2 * numTokens + 1);
 
+        // The biggest target is assigned to the biggest existing node. This should result in better balance in
+        // the amount of data that needs to be streamed from the different sources to the new node.
+        double target = targetAverage + spread / 2;
+
+        // This step intentionally divides by the count (rather than count - 1) because we also need to count the new
+        // node. This leaves the last position in the spread (i.e. the smallest size, least data to stream) for it.
+        double step = spread / unitsToChange.size();
         int nr = 0;
         // calculate the tokens
         for (Weighted<UnitInfo> unit : unitsToChange)
@@ -191,7 +186,7 @@ public class NoReplicationTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
                 unit.value.ownership -= wt.weight;
             }
 
-            double toTakeOver = unit.weight - targetAverage;
+            double toTakeOver = unit.weight - target;
             // Split toTakeOver proportionally between the vnodes.
             for (Weighted<TokenInfo> wt : tokens)
             {
@@ -228,6 +223,7 @@ public class NoReplicationTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
 
             // adjust the weight for current unit
             sortedUnits.add(new Weighted<>(unit.value.ownership, unit.value));
+            target -= step;
             ++nr;
         }
         sortedUnits.add(new Weighted<>(newUnitInfo.ownership, newUnitInfo));
@@ -262,5 +258,10 @@ public class NoReplicationTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
     public int getReplicas()
     {
         return 1;
+    }
+
+    public String toString()
+    {
+        return getClass().getSimpleName();
     }
 }

--- a/src/java/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocator.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocator.java
@@ -20,14 +20,12 @@ package org.apache.cassandra.dht.tokenallocator;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.PriorityQueue;
 import java.util.Queue;
-import java.util.Set;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -229,6 +227,12 @@ public class NoReplicationTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
         sortedUnits.add(new Weighted<>(newUnitInfo.ownership, newUnitInfo));
 
         return newTokens;
+    }
+
+    @Override
+    Collection<Token> generateSplits(Unit newUnit, int numTokens)
+    {
+        return super.generateSplits(newUnit, numTokens);
     }
 
     /**

--- a/src/java/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocator.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocator.java
@@ -1,0 +1,805 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.dht.tokenallocator;
+
+import java.util.*;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Token;
+
+/**
+ * A Replication Aware allocator for tokens, that attempts to ensure an even distribution of ownership across
+ * the known cluster for the provided replication strategy.
+ *
+ * A unit is shorthand for a "unit of ownership" which translates roughly to a node, or a disk on the node,
+ * a CPU on the node, or some other relevant unit of ownership. These units should be the lowest rung over which
+ * ownership needs to be evenly distributed. At the moment only nodes as a whole are treated as units, but that
+ * will change with the introduction of token ranges per disk.
+ */
+class ReplicationAwareTokenAllocator<Unit> implements TokenAllocator<Unit>
+{
+    final NavigableMap<Token, Unit> sortedTokens;
+    final Multimap<Unit, Token> unitToTokens;
+    final ReplicationStrategy<Unit> strategy;
+    final IPartitioner partitioner;
+    final int replicas;
+
+    ReplicationAwareTokenAllocator(NavigableMap<Token, Unit> sortedTokens, ReplicationStrategy<Unit> strategy, IPartitioner partitioner)
+    {
+        this.sortedTokens = sortedTokens;
+        unitToTokens = HashMultimap.create();
+        for (Map.Entry<Token, Unit> en : sortedTokens.entrySet())
+            unitToTokens.put(en.getValue(), en.getKey());
+        this.strategy = strategy;
+        this.replicas = strategy.replicas();
+        this.partitioner = partitioner;
+    }
+
+    public Collection<Token> addUnit(Unit newUnit, int numTokens)
+    {
+        assert !unitToTokens.containsKey(newUnit);
+
+        if (unitCount() < replicas)
+            // Allocation does not matter; everything replicates everywhere.
+            return generateRandomTokens(newUnit, numTokens);
+        if (numTokens > sortedTokens.size())
+            // Some of the heuristics below can't deal with this case. Use random for now, later allocations can fix any problems this may cause.
+            return generateRandomTokens(newUnit, numTokens);
+
+        // ============= construct our initial token ring state =============
+
+        double optTokenOwnership = optimalTokenOwnership(numTokens);
+        Map<Object, GroupInfo> groups = Maps.newHashMap();
+        Map<Unit, UnitInfo<Unit>> unitInfos = createUnitInfos(groups);
+        if (groups.size() < replicas)
+        {
+            // We need at least replicas groups to do allocation correctly. If there aren't enough, 
+            // use random allocation.
+            // This part of the code should only be reached via the RATATest. StrategyAdapter should disallow
+            // token allocation in this case as the algorithm is not able to cover the behavior of NetworkTopologyStrategy.
+            return generateRandomTokens(newUnit, numTokens);
+        }
+
+        // initialise our new unit's state (with an idealised ownership)
+        // strategy must already know about this unit
+        UnitInfo<Unit> newUnitInfo = new UnitInfo<>(newUnit, numTokens * optTokenOwnership, groups, strategy);
+
+        // build the current token ring state
+        TokenInfo<Unit> tokens = createTokenInfos(unitInfos, newUnitInfo.group);
+        newUnitInfo.tokenCount = numTokens;
+
+        // ============= construct and rank our candidate token allocations =============
+
+        // walk the token ring, constructing the set of candidates in ring order
+        // as the midpoints between all existing tokens
+        CandidateInfo<Unit> candidates = createCandidates(tokens, newUnitInfo, optTokenOwnership);
+
+        // Evaluate the expected improvements from all candidates and form a priority queue.
+        PriorityQueue<Weighted<CandidateInfo<Unit>>> improvements = new PriorityQueue<>(sortedTokens.size());
+        CandidateInfo<Unit> candidate = candidates;
+        do
+        {
+            double impr = evaluateImprovement(candidate, optTokenOwnership, 1.0 / numTokens);
+            improvements.add(new Weighted<>(impr, candidate));
+            candidate = candidate.next;
+        } while (candidate != candidates);
+
+        // ============= iteratively take the best candidate, and re-rank =============
+
+        CandidateInfo<Unit> bestToken = improvements.remove().value;
+        for (int vn = 1; ; ++vn)
+        {
+            candidates = bestToken.removeFrom(candidates);
+            confirmCandidate(bestToken);
+
+            if (vn == numTokens)
+                break;
+
+            while (true)
+            {
+                // Get the next candidate in the queue. Its improvement may have changed (esp. if multiple tokens
+                // were good suggestions because they could improve the same problem)-- evaluate it again to check
+                // if it is still a good candidate.
+                bestToken = improvements.remove().value;
+                double impr = evaluateImprovement(bestToken, optTokenOwnership, (vn + 1.0) / numTokens);
+                Weighted<CandidateInfo<Unit>> next = improvements.peek();
+
+                // If it is better than the next in the queue, it is good enough. This is a heuristic that doesn't
+                // get the best results, but works well enough and on average cuts search time by a factor of O(vnodes).
+                if (next == null || impr >= next.weight)
+                    break;
+                improvements.add(new Weighted<>(impr, bestToken));
+            }
+        }
+
+        return ImmutableList.copyOf(unitToTokens.get(newUnit));
+    }
+
+    private Collection<Token> generateRandomTokens(Unit newUnit, int numTokens)
+    {
+        Set<Token> tokens = new HashSet<>(numTokens);
+        while (tokens.size() < numTokens)
+        {
+            Token token = partitioner.getRandomToken();
+            if (!sortedTokens.containsKey(token))
+            {
+                tokens.add(token);
+                sortedTokens.put(token, newUnit);
+                unitToTokens.put(newUnit, token);
+            }
+        }
+        return tokens;
+    }
+
+    private Map<Unit, UnitInfo<Unit>> createUnitInfos(Map<Object, GroupInfo> groups)
+    {
+        Map<Unit, UnitInfo<Unit>> map = Maps.newHashMap();
+        for (Unit n : sortedTokens.values())
+        {
+            UnitInfo<Unit> ni = map.get(n);
+            if (ni == null)
+                map.put(n, ni = new UnitInfo<>(n, 0, groups, strategy));
+            ni.tokenCount++;
+        }
+        return map;
+    }
+
+    /**
+     * Construct the token ring as a CircularList of TokenInfo,
+     * and populate the ownership of the UnitInfo's provided
+     */
+    private TokenInfo<Unit> createTokenInfos(Map<Unit, UnitInfo<Unit>> units, GroupInfo newUnitGroup)
+    {
+        // build the circular list
+        TokenInfo<Unit> prev = null;
+        TokenInfo<Unit> first = null;
+        for (Map.Entry<Token, Unit> en : sortedTokens.entrySet())
+        {
+            Token t = en.getKey();
+            UnitInfo<Unit> ni = units.get(en.getValue());
+            TokenInfo<Unit> ti = new TokenInfo<>(t, ni);
+            first = ti.insertAfter(first, prev);
+            prev = ti;
+        }
+
+        TokenInfo<Unit> curr = first;
+        do
+        {
+            populateTokenInfoAndAdjustUnit(curr, newUnitGroup);
+            curr = curr.next;
+        } while (curr != first);
+
+        return first;
+    }
+
+    private CandidateInfo<Unit> createCandidates(TokenInfo<Unit> tokens, UnitInfo<Unit> newUnitInfo, double initialTokenOwnership)
+    {
+        TokenInfo<Unit> curr = tokens;
+        CandidateInfo<Unit> first = null;
+        CandidateInfo<Unit> prev = null;
+        do
+        {
+            CandidateInfo<Unit> candidate = new CandidateInfo<Unit>(partitioner.midpoint(curr.prev.token, curr.token), curr, newUnitInfo);
+            first = candidate.insertAfter(first, prev);
+
+            candidate.replicatedOwnership = initialTokenOwnership;
+            populateCandidate(candidate);
+
+            prev = candidate;
+            curr = curr.next;
+        } while (curr != tokens);
+        prev.next = first;
+        return first;
+    }
+
+    private void populateCandidate(CandidateInfo<Unit> candidate)
+    {
+        // Only finding replication start would do.
+        populateTokenInfo(candidate, candidate.owningUnit.group);
+    }
+
+    /**
+     * Incorporates the selected candidate into the ring, adjusting ownership information and calculated token
+     * information.
+     */
+    private void confirmCandidate(CandidateInfo<Unit> candidate)
+    {
+        // This process is less efficient than it could be (loops through each vnode's replication span instead
+        // of recalculating replicationStart, replicationThreshold from existing data + new token data in an O(1)
+        // case analysis similar to evaluateImprovement). This is fine as the method does not dominate processing
+        // time.
+
+        // Put the accepted candidate in the token list.
+        UnitInfo<Unit> newUnit = candidate.owningUnit;
+        Token newToken = candidate.token;
+        sortedTokens.put(newToken, newUnit.unit);
+        unitToTokens.put(newUnit.unit, newToken);
+
+        TokenInfo<Unit> prev = candidate.prevInRing();
+        TokenInfo<Unit> newTokenInfo = new TokenInfo<>(newToken, newUnit);
+        newTokenInfo.replicatedOwnership = candidate.replicatedOwnership;
+        newTokenInfo.insertAfter(prev, prev);   // List is not empty so this won't need to change head of list.
+
+        // Update data for candidate.
+        populateTokenInfoAndAdjustUnit(newTokenInfo, newUnit.group);
+
+        ReplicationVisitor replicationVisitor = new ReplicationVisitor();
+        assert newTokenInfo.next == candidate.split;
+        for (TokenInfo<Unit> curr = newTokenInfo.next; !replicationVisitor.visitedAll(); curr = curr.next)
+        {
+            // update the candidate between curr and next
+            candidate = candidate.next;
+            populateCandidate(candidate);
+
+            if (!replicationVisitor.add(curr.owningUnit.group))
+                continue;    // If we've already seen this group, the token cannot be affected.
+
+            populateTokenInfoAndAdjustUnit(curr, newUnit.group);
+        }
+
+        replicationVisitor.clean();
+    }
+
+    /**
+     * Calculates the {@code replicationStart} of a token, as well as {@code replicationThreshold} which is chosen in a way
+     * that permits {@code findUpdatedReplicationStart} to quickly identify changes in ownership.
+     */
+    private Token populateTokenInfo(BaseTokenInfo<Unit, ?> token, GroupInfo newUnitGroup)
+    {
+        GroupInfo tokenGroup = token.owningUnit.group;
+        PopulateVisitor visitor = new PopulateVisitor();
+
+        // Replication start = the end of a token from the RF'th different group seen before the token.
+        Token replicationStart;
+        // The end of a token from the RF-1'th different group seen before the token.
+        Token replicationThreshold = token.token;
+        GroupInfo currGroup;
+        for (TokenInfo<Unit> curr = token.prevInRing(); ; curr = curr.prev)
+        {
+            replicationStart = curr.token;
+            currGroup = curr.owningUnit.group;
+            if (!visitor.add(currGroup))
+                continue; // Group is already seen.
+            if (visitor.visitedAll())
+                break;
+
+            replicationThreshold = replicationStart;
+            // Another instance of the same group precedes us in the replication range of the ring,
+            // so this is where our replication range begins
+            if (currGroup == tokenGroup)
+                break;
+        }
+        if (newUnitGroup == tokenGroup)
+            // new token is always a boundary (as long as it's closer than replicationStart)
+            replicationThreshold = token.token;
+        else if (newUnitGroup != currGroup && visitor.seen(newUnitGroup))
+            // already has new group in replication span before last seen. cannot be affected
+            replicationThreshold = replicationStart;
+        visitor.clean();
+
+        token.replicationThreshold = replicationThreshold;
+        token.replicationStart = replicationStart;
+        return replicationStart;
+    }
+
+    private void populateTokenInfoAndAdjustUnit(TokenInfo<Unit> populate, GroupInfo newUnitGroup)
+    {
+        Token replicationStart = populateTokenInfo(populate, newUnitGroup);
+        double newOwnership = replicationStart.size(populate.token);
+        double oldOwnership = populate.replicatedOwnership;
+        populate.replicatedOwnership = newOwnership;
+        populate.owningUnit.ownership += newOwnership - oldOwnership;
+    }
+
+    /**
+     * Evaluates the improvement in variance for both units and individual tokens when candidate is inserted into the
+     * ring.
+     */
+    private double evaluateImprovement(CandidateInfo<Unit> candidate, double optTokenOwnership, double newUnitMult)
+    {
+        double tokenChange = 0;
+
+        UnitInfo<Unit> candidateUnit = candidate.owningUnit;
+        Token candidateEnd = candidate.token;
+
+        // Form a chain of units affected by the insertion to be able to qualify change of unit ownership.
+        // A unit may be affected more than once.
+        UnitAdjustmentTracker<Unit> unitTracker = new UnitAdjustmentTracker<>(candidateUnit);
+
+        // Reflect change in ownership of the splitting token (candidate).
+        tokenChange += applyOwnershipAdjustment(candidate, candidateUnit, candidate.replicationStart, candidateEnd, optTokenOwnership, unitTracker);
+
+        // Loop through all vnodes that replicate candidate or split and update their ownership.
+        ReplicationVisitor replicationVisitor = new ReplicationVisitor();
+        for (TokenInfo<Unit> curr = candidate.split; !replicationVisitor.visitedAll(); curr = curr.next)
+        {
+            UnitInfo<Unit> currUnit = curr.owningUnit;
+
+            if (!replicationVisitor.add(currUnit.group))
+                continue;    // If this group is already seen, the token cannot be affected.
+
+            Token replicationEnd = curr.token;
+            Token replicationStart = findUpdatedReplicationStart(curr, candidate);
+            tokenChange += applyOwnershipAdjustment(curr, currUnit, replicationStart, replicationEnd, optTokenOwnership, unitTracker);
+        }
+        replicationVisitor.clean();
+
+        double nodeChange = unitTracker.calculateUnitChange(newUnitMult, optTokenOwnership);
+        return -(tokenChange + nodeChange);
+    }
+
+    /**
+     * Returns the start of the replication span for the token {@code curr} when {@code candidate} is inserted into the
+     * ring.
+     */
+    private Token findUpdatedReplicationStart(TokenInfo<Unit> curr, CandidateInfo<Unit> candidate)
+    {
+        return furtherStartToken(curr.replicationThreshold, candidate.token, curr.token);
+    }
+
+    /**
+     * Applies the ownership adjustment for the given element, updating tracked unit ownership and returning the change
+     * of variance.
+     */
+    private double applyOwnershipAdjustment(BaseTokenInfo<Unit, ?> curr, UnitInfo<Unit> currUnit,
+            Token replicationStart, Token replicationEnd,
+            double optTokenOwnership, UnitAdjustmentTracker<Unit> unitTracker)
+    {
+        double oldOwnership = curr.replicatedOwnership;
+        double newOwnership = replicationStart.size(replicationEnd);
+        double tokenCount = currUnit.tokenCount;
+        assert tokenCount > 0;
+        unitTracker.add(currUnit, newOwnership - oldOwnership);
+        return (sq(newOwnership - optTokenOwnership) - sq(oldOwnership - optTokenOwnership)) / sq(tokenCount);
+    }
+
+    /**
+     * Tracker for unit ownership changes. The changes are tracked by a chain of UnitInfos where the adjustedOwnership
+     * field is being updated as we see changes in token ownership.
+     *
+     * The chain ends with an element that points to itself; this element must be specified as argument to the
+     * constructor as well as be the first unit with which 'add' is called; when calculating the variance change
+     * a separate multiplier is applied to it (used to permit more freedom in choosing the first tokens of a unit).
+     */
+    private static class UnitAdjustmentTracker<Unit>
+    {
+        UnitInfo<Unit> unitsChain;
+
+        UnitAdjustmentTracker(UnitInfo<Unit> newUnit)
+        {
+            unitsChain = newUnit;
+        }
+
+        void add(UnitInfo<Unit> currUnit, double diff)
+        {
+            if (currUnit.prevUsed == null)
+            {
+                assert unitsChain.prevUsed != null || currUnit == unitsChain;
+
+                currUnit.adjustedOwnership = currUnit.ownership + diff;
+                currUnit.prevUsed = unitsChain;
+                unitsChain = currUnit;
+            }
+            else
+            {
+                currUnit.adjustedOwnership += diff;
+            }
+        }
+
+        double calculateUnitChange(double newUnitMult, double optTokenOwnership)
+        {
+            double unitChange = 0;
+            UnitInfo<Unit> unitsChain = this.unitsChain;
+            // Now loop through the units chain and add the unit-level changes. Also clear the groups' seen marks.
+            while (true)
+            {
+                double newOwnership = unitsChain.adjustedOwnership;
+                double oldOwnership = unitsChain.ownership;
+                double tokenCount = unitsChain.tokenCount;
+                double diff = (sq(newOwnership / tokenCount - optTokenOwnership) - sq(oldOwnership / tokenCount - optTokenOwnership));
+                UnitInfo<Unit> prev = unitsChain.prevUsed;
+                unitsChain.prevUsed = null;
+                if (unitsChain != prev)
+                    unitChange += diff;
+                else
+                {
+                    unitChange += diff * newUnitMult;
+                    break;
+                }
+                unitsChain = prev;
+            }
+            this.unitsChain = unitsChain;
+            return unitChange;
+        }
+    }
+
+
+    /**
+     * Helper class for marking/unmarking visited a chain of groups
+     */
+    private abstract class GroupVisitor
+    {
+        GroupInfo groupChain = GroupInfo.TERMINATOR;
+        int seen = 0;
+
+        abstract GroupInfo prevSeen(GroupInfo group);
+        abstract void setPrevSeen(GroupInfo group, GroupInfo prevSeen);
+
+        // true iff this is the first time we've visited this group
+        boolean add(GroupInfo group)
+        {
+            if (prevSeen(group) != null)
+                return false;
+            ++seen;
+            setPrevSeen(group, groupChain);
+            groupChain = group;
+            return true;
+        }
+
+        boolean visitedAll()
+        {
+            return seen >= replicas;
+        }
+
+        boolean seen(GroupInfo group)
+        {
+            return prevSeen(group) != null;
+        }
+
+        // Clean group seen markers.
+        void clean()
+        {
+            GroupInfo groupChain = this.groupChain;
+            while (groupChain != GroupInfo.TERMINATOR)
+            {
+                GroupInfo prev = prevSeen(groupChain);
+                setPrevSeen(groupChain, null);
+                groupChain = prev;
+            }
+            this.groupChain = GroupInfo.TERMINATOR;
+        }
+    }
+
+    private class ReplicationVisitor extends GroupVisitor
+    {
+        GroupInfo prevSeen(GroupInfo group)
+        {
+            return group.prevSeen;
+        }
+
+        void setPrevSeen(GroupInfo group, GroupInfo prevSeen)
+        {
+            group.prevSeen = prevSeen;
+        }
+    }
+
+    private class PopulateVisitor extends GroupVisitor
+    {
+        GroupInfo prevSeen(GroupInfo group)
+        {
+            return group.prevPopulate;
+        }
+
+        void setPrevSeen(GroupInfo group, GroupInfo prevSeen)
+        {
+            group.prevPopulate = prevSeen;
+        }
+    }
+
+    private Map.Entry<Token, Unit> mapEntryFor(Token t)
+    {
+        Map.Entry<Token, Unit> en = sortedTokens.floorEntry(t);
+        if (en == null)
+            en = sortedTokens.lastEntry();
+        return en;
+    }
+
+    Unit unitFor(Token t)
+    {
+        return mapEntryFor(t).getValue();
+    }
+
+    private double optimalTokenOwnership(int tokensToAdd)
+    {
+        return 1.0 * replicas / (sortedTokens.size() + tokensToAdd);
+    }
+
+    /**
+     * Selects from {@code t1}, {@code t2} the token that forms a bigger range with {@code towards} as the upper bound,
+     * taking into account wrapping.
+     * Unlike Token.size(), equality is taken to mean "same as" rather than covering the whole range.
+     */
+    private static Token furtherStartToken(Token t1, Token t2, Token towards)
+    {
+        if (t1.equals(towards))
+            return t2;
+        if (t2.equals(towards))
+            return t1;
+
+        return t1.size(towards) > t2.size(towards) ? t1 : t2;
+    }
+
+    private static double sq(double d)
+    {
+        return d * d;
+    }
+
+
+    /**
+     * For testing, remove the given unit preserving correct state of the allocator.
+     */
+    void removeUnit(Unit n)
+    {
+        Collection<Token> tokens = unitToTokens.removeAll(n);
+        sortedTokens.keySet().removeAll(tokens);
+    }
+
+    int unitCount()
+    {
+        return unitToTokens.asMap().size();
+    }
+
+    public String toString()
+    {
+        return getClass().getSimpleName();
+    }
+
+    // get or initialise the shared GroupInfo associated with the unit
+    private static <Unit> GroupInfo getGroup(Unit unit, Map<Object, GroupInfo> groupMap, ReplicationStrategy<Unit> strategy)
+    {
+        Object groupClass = strategy.getGroup(unit);
+        GroupInfo group = groupMap.get(groupClass);
+        if (group == null)
+            groupMap.put(groupClass, group = new GroupInfo(groupClass));
+        return group;
+    }
+
+    /**
+     * Unique group object that one or more UnitInfo objects link to.
+     */
+    private static class GroupInfo
+    {
+        /**
+         * Group identifier given by ReplicationStrategy.getGroup(Unit).
+         */
+        final Object group;
+
+        /**
+         * Seen marker. When non-null, the group is already seen in replication walks.
+         * Also points to previous seen group to enable walking the seen groups and clearing the seen markers.
+         */
+        GroupInfo prevSeen = null;
+        /**
+         * Same marker/chain used by populateTokenInfo.
+         */
+        GroupInfo prevPopulate = null;
+
+        /**
+         * Value used as terminator for seen chains.
+         */
+        static GroupInfo TERMINATOR = new GroupInfo(null);
+
+        public GroupInfo(Object group)
+        {
+            this.group = group;
+        }
+
+        public String toString()
+        {
+            return group.toString() + (prevSeen != null ? "*" : "");
+        }
+    }
+
+    /**
+     * Unit information created and used by ReplicationAwareTokenDistributor. Contained vnodes all point to the same
+     * instance.
+     */
+    static class UnitInfo<Unit>
+    {
+        final Unit unit;
+        final GroupInfo group;
+        double ownership;
+        int tokenCount;
+
+        /**
+         * During evaluateImprovement this is used to form a chain of units affected by the candidate insertion.
+         */
+        UnitInfo<Unit> prevUsed;
+        /**
+         * During evaluateImprovement this holds the ownership after the candidate insertion.
+         */
+        double adjustedOwnership;
+
+        private UnitInfo(Unit unit, GroupInfo group)
+        {
+            this.unit = unit;
+            this.group = group;
+            this.tokenCount = 0;
+        }
+
+        public UnitInfo(Unit unit, double ownership, Map<Object, GroupInfo> groupMap, ReplicationStrategy<Unit> strategy)
+        {
+            this(unit, getGroup(unit, groupMap, strategy));
+            this.ownership = ownership;
+        }
+
+        public String toString()
+        {
+            return String.format("%s%s(%.2e)%s",
+                    unit, unit == group.group ? (group.prevSeen != null ? "*" : "") : ":" + group.toString(),
+                    ownership, prevUsed != null ? (prevUsed == this ? "#" : "->" + prevUsed.toString()) : "");
+        }
+    }
+
+    private static class CircularList<T extends CircularList<T>>
+    {
+        T prev;
+        T next;
+
+        /**
+         * Inserts this after unit in the circular list which starts at head. Returns the new head of the list, which
+         * only changes if head was null.
+         */
+        @SuppressWarnings("unchecked")
+        T insertAfter(T head, T unit)
+        {
+            if (head == null)
+            {
+                return prev = next = (T) this;
+            }
+            assert unit != null;
+            assert unit.next != null;
+            prev = unit;
+            next = unit.next;
+            prev.next = (T) this;
+            next.prev = (T) this;
+            return head;
+        }
+
+        /**
+         * Removes this from the list that starts at head. Returns the new head of the list, which only changes if the
+         * head was removed.
+         */
+        T removeFrom(T head)
+        {
+            next.prev = prev;
+            prev.next = next;
+            return this == head ? (this == next ? null : next) : head;
+        }
+    }
+
+    private static class BaseTokenInfo<Unit, T extends BaseTokenInfo<Unit, T>> extends CircularList<T>
+    {
+        final Token token;
+        final UnitInfo<Unit> owningUnit;
+
+        /**
+         * Start of the replication span for the vnode, i.e. the first token of the RF'th group seen before the token.
+         * The replicated ownership of the unit is the range between {@code replicationStart} and {@code token}.
+         */
+        Token replicationStart;
+        /**
+         * The closest position that the new candidate can take to become the new replication start. If candidate is
+         * closer, the start moves to this position. Used to determine replicationStart after insertion of new token.
+         *
+         * Usually the RF minus one boundary, i.e. the first token of the RF-1'th group seen before the token.
+         */
+        Token replicationThreshold;
+        /**
+         * Current replicated ownership. This number is reflected in the owning unit's ownership.
+         */
+        double replicatedOwnership = 0;
+
+        public BaseTokenInfo(Token token, UnitInfo<Unit> owningUnit)
+        {
+            this.token = token;
+            this.owningUnit = owningUnit;
+        }
+
+        public String toString()
+        {
+            return String.format("%s(%s)", token, owningUnit);
+        }
+
+        /**
+         * Previous unit in the token ring. For existing tokens this is prev,
+         * for candidates it's "split".
+         */
+        TokenInfo<Unit> prevInRing()
+        {
+            return null;
+        }
+    }
+
+    /**
+     * TokenInfo about existing tokens/vnodes.
+     */
+    private static class TokenInfo<Unit> extends BaseTokenInfo<Unit, TokenInfo<Unit>>
+    {
+        public TokenInfo(Token token, UnitInfo<Unit> owningUnit)
+        {
+            super(token, owningUnit);
+        }
+
+        TokenInfo<Unit> prevInRing()
+        {
+            return prev;
+        }
+    }
+
+    /**
+     * TokenInfo about candidate new tokens/vnodes.
+     */
+    private static class CandidateInfo<Unit> extends BaseTokenInfo<Unit, CandidateInfo<Unit>>
+    {
+        // directly preceding token in the current token ring
+        final TokenInfo<Unit> split;
+
+        public CandidateInfo(Token token, TokenInfo<Unit> split, UnitInfo<Unit> owningUnit)
+        {
+            super(token, owningUnit);
+            this.split = split;
+        }
+
+        TokenInfo<Unit> prevInRing()
+        {
+            return split.prev;
+        }
+    }
+
+    static void dumpTokens(String lead, BaseTokenInfo<?, ?> tokens)
+    {
+        BaseTokenInfo<?, ?> token = tokens;
+        do
+        {
+            System.out.format("%s%s: rs %s rt %s size %.2e\n", lead, token, token.replicationStart, token.replicationThreshold, token.replicatedOwnership);
+            token = token.next;
+        } while (token != null && token != tokens);
+    }
+
+    static class Weighted<T> implements Comparable<Weighted<T>>
+    {
+        final double weight;
+        final T value;
+
+        public Weighted(double weight, T value)
+        {
+            this.weight = weight;
+            this.value = value;
+        }
+
+        @Override
+        public int compareTo(Weighted<T> o)
+        {
+            int cmp = Double.compare(o.weight, this.weight);
+            return cmp;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("%s<%s>", value, weight);
+        }
+    }
+}
+

--- a/src/java/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocator.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocator.java
@@ -36,23 +36,23 @@ import org.apache.cassandra.dht.Token;
  * ownership needs to be evenly distributed. At the moment only nodes as a whole are treated as units, but that
  * will change with the introduction of token ranges per disk.
  */
-class ReplicationAwareTokenAllocator<Unit> implements TokenAllocator<Unit>
+class ReplicationAwareTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
 {
-    final NavigableMap<Token, Unit> sortedTokens;
     final Multimap<Unit, Token> unitToTokens;
-    final ReplicationStrategy<Unit> strategy;
-    final IPartitioner partitioner;
     final int replicas;
 
     ReplicationAwareTokenAllocator(NavigableMap<Token, Unit> sortedTokens, ReplicationStrategy<Unit> strategy, IPartitioner partitioner)
     {
-        this.sortedTokens = sortedTokens;
+        super(sortedTokens, strategy, partitioner);
         unitToTokens = HashMultimap.create();
         for (Map.Entry<Token, Unit> en : sortedTokens.entrySet())
             unitToTokens.put(en.getValue(), en.getKey());
-        this.strategy = strategy;
         this.replicas = strategy.replicas();
-        this.partitioner = partitioner;
+    }
+
+    public int getReplicas()
+    {
+        return replicas;
     }
 
     public Collection<Token> addUnit(Unit newUnit, int numTokens)
@@ -149,19 +149,6 @@ class ReplicationAwareTokenAllocator<Unit> implements TokenAllocator<Unit>
             }
         }
         return tokens;
-    }
-
-    private Map<Unit, UnitInfo<Unit>> createUnitInfos(Map<Object, GroupInfo> groups)
-    {
-        Map<Unit, UnitInfo<Unit>> map = Maps.newHashMap();
-        for (Unit n : sortedTokens.values())
-        {
-            UnitInfo<Unit> ni = map.get(n);
-            if (ni == null)
-                map.put(n, ni = new UnitInfo<>(n, 0, groups, strategy));
-            ni.tokenCount++;
-        }
-        return map;
     }
 
     /**
@@ -506,19 +493,6 @@ class ReplicationAwareTokenAllocator<Unit> implements TokenAllocator<Unit>
         }
     }
 
-    private Map.Entry<Token, Unit> mapEntryFor(Token t)
-    {
-        Map.Entry<Token, Unit> en = sortedTokens.floorEntry(t);
-        if (en == null)
-            en = sortedTokens.lastEntry();
-        return en;
-    }
-
-    Unit unitFor(Token t)
-    {
-        return mapEntryFor(t).getValue();
-    }
-
     private double optimalTokenOwnership(int tokensToAdd)
     {
         return 1.0 * replicas / (sortedTokens.size() + tokensToAdd);
@@ -554,7 +528,7 @@ class ReplicationAwareTokenAllocator<Unit> implements TokenAllocator<Unit>
         sortedTokens.keySet().removeAll(tokens);
     }
 
-    int unitCount()
+    public int unitCount()
     {
         return unitToTokens.asMap().size();
     }
@@ -562,189 +536,6 @@ class ReplicationAwareTokenAllocator<Unit> implements TokenAllocator<Unit>
     public String toString()
     {
         return getClass().getSimpleName();
-    }
-
-    // get or initialise the shared GroupInfo associated with the unit
-    private static <Unit> GroupInfo getGroup(Unit unit, Map<Object, GroupInfo> groupMap, ReplicationStrategy<Unit> strategy)
-    {
-        Object groupClass = strategy.getGroup(unit);
-        GroupInfo group = groupMap.get(groupClass);
-        if (group == null)
-            groupMap.put(groupClass, group = new GroupInfo(groupClass));
-        return group;
-    }
-
-    /**
-     * Unique group object that one or more UnitInfo objects link to.
-     */
-    private static class GroupInfo
-    {
-        /**
-         * Group identifier given by ReplicationStrategy.getGroup(Unit).
-         */
-        final Object group;
-
-        /**
-         * Seen marker. When non-null, the group is already seen in replication walks.
-         * Also points to previous seen group to enable walking the seen groups and clearing the seen markers.
-         */
-        GroupInfo prevSeen = null;
-        /**
-         * Same marker/chain used by populateTokenInfo.
-         */
-        GroupInfo prevPopulate = null;
-
-        /**
-         * Value used as terminator for seen chains.
-         */
-        static GroupInfo TERMINATOR = new GroupInfo(null);
-
-        public GroupInfo(Object group)
-        {
-            this.group = group;
-        }
-
-        public String toString()
-        {
-            return group.toString() + (prevSeen != null ? "*" : "");
-        }
-    }
-
-    /**
-     * Unit information created and used by ReplicationAwareTokenDistributor. Contained vnodes all point to the same
-     * instance.
-     */
-    static class UnitInfo<Unit>
-    {
-        final Unit unit;
-        final GroupInfo group;
-        double ownership;
-        int tokenCount;
-
-        /**
-         * During evaluateImprovement this is used to form a chain of units affected by the candidate insertion.
-         */
-        UnitInfo<Unit> prevUsed;
-        /**
-         * During evaluateImprovement this holds the ownership after the candidate insertion.
-         */
-        double adjustedOwnership;
-
-        private UnitInfo(Unit unit, GroupInfo group)
-        {
-            this.unit = unit;
-            this.group = group;
-            this.tokenCount = 0;
-        }
-
-        public UnitInfo(Unit unit, double ownership, Map<Object, GroupInfo> groupMap, ReplicationStrategy<Unit> strategy)
-        {
-            this(unit, getGroup(unit, groupMap, strategy));
-            this.ownership = ownership;
-        }
-
-        public String toString()
-        {
-            return String.format("%s%s(%.2e)%s",
-                    unit, unit == group.group ? (group.prevSeen != null ? "*" : "") : ":" + group.toString(),
-                    ownership, prevUsed != null ? (prevUsed == this ? "#" : "->" + prevUsed.toString()) : "");
-        }
-    }
-
-    private static class CircularList<T extends CircularList<T>>
-    {
-        T prev;
-        T next;
-
-        /**
-         * Inserts this after unit in the circular list which starts at head. Returns the new head of the list, which
-         * only changes if head was null.
-         */
-        @SuppressWarnings("unchecked")
-        T insertAfter(T head, T unit)
-        {
-            if (head == null)
-            {
-                return prev = next = (T) this;
-            }
-            assert unit != null;
-            assert unit.next != null;
-            prev = unit;
-            next = unit.next;
-            prev.next = (T) this;
-            next.prev = (T) this;
-            return head;
-        }
-
-        /**
-         * Removes this from the list that starts at head. Returns the new head of the list, which only changes if the
-         * head was removed.
-         */
-        T removeFrom(T head)
-        {
-            next.prev = prev;
-            prev.next = next;
-            return this == head ? (this == next ? null : next) : head;
-        }
-    }
-
-    private static class BaseTokenInfo<Unit, T extends BaseTokenInfo<Unit, T>> extends CircularList<T>
-    {
-        final Token token;
-        final UnitInfo<Unit> owningUnit;
-
-        /**
-         * Start of the replication span for the vnode, i.e. the first token of the RF'th group seen before the token.
-         * The replicated ownership of the unit is the range between {@code replicationStart} and {@code token}.
-         */
-        Token replicationStart;
-        /**
-         * The closest position that the new candidate can take to become the new replication start. If candidate is
-         * closer, the start moves to this position. Used to determine replicationStart after insertion of new token.
-         *
-         * Usually the RF minus one boundary, i.e. the first token of the RF-1'th group seen before the token.
-         */
-        Token replicationThreshold;
-        /**
-         * Current replicated ownership. This number is reflected in the owning unit's ownership.
-         */
-        double replicatedOwnership = 0;
-
-        public BaseTokenInfo(Token token, UnitInfo<Unit> owningUnit)
-        {
-            this.token = token;
-            this.owningUnit = owningUnit;
-        }
-
-        public String toString()
-        {
-            return String.format("%s(%s)", token, owningUnit);
-        }
-
-        /**
-         * Previous unit in the token ring. For existing tokens this is prev,
-         * for candidates it's "split".
-         */
-        TokenInfo<Unit> prevInRing()
-        {
-            return null;
-        }
-    }
-
-    /**
-     * TokenInfo about existing tokens/vnodes.
-     */
-    private static class TokenInfo<Unit> extends BaseTokenInfo<Unit, TokenInfo<Unit>>
-    {
-        public TokenInfo(Token token, UnitInfo<Unit> owningUnit)
-        {
-            super(token, owningUnit);
-        }
-
-        TokenInfo<Unit> prevInRing()
-        {
-            return prev;
-        }
     }
 
     /**
@@ -775,31 +566,6 @@ class ReplicationAwareTokenAllocator<Unit> implements TokenAllocator<Unit>
             System.out.format("%s%s: rs %s rt %s size %.2e\n", lead, token, token.replicationStart, token.replicationThreshold, token.replicatedOwnership);
             token = token.next;
         } while (token != null && token != tokens);
-    }
-
-    static class Weighted<T> implements Comparable<Weighted<T>>
-    {
-        final double weight;
-        final T value;
-
-        public Weighted(double weight, T value)
-        {
-            this.weight = weight;
-            this.value = value;
-        }
-
-        @Override
-        public int compareTo(Weighted<T> o)
-        {
-            int cmp = Double.compare(o.weight, this.weight);
-            return cmp;
-        }
-
-        @Override
-        public String toString()
-        {
-            return String.format("%s<%s>", value, weight);
-        }
     }
 }
 

--- a/src/java/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocator.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocator.java
@@ -61,9 +61,12 @@ class ReplicationAwareTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
 
         if (unitCount() < replicas)
             // Allocation does not matter; everything replicates everywhere.
+            //However, at this point it is
+            // important to start the cluster/datacenter with suitably varied token range sizes so that the algorithm
+            // can maintain good balance for any number of nodes.
             return generateRandomTokens(newUnit, numTokens);
         if (numTokens > sortedTokens.size())
-            // Some of the heuristics below can't deal with this case. Use random for now, later allocations can fix any problems this may cause.
+            // Some of the heuristics below can't deal with this very unlikely case. Use splits for now, later allocations can fix any problems this may cause.
             return generateRandomTokens(newUnit, numTokens);
 
         // ============= construct our initial token ring state =============
@@ -148,6 +151,13 @@ class ReplicationAwareTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
                 unitToTokens.put(newUnit, token);
             }
         }
+        return tokens;
+    }
+
+    Collection<Token> generateSplits(Unit newUnit, int numTokens)
+    {
+        Collection<Token> tokens = super.generateSplits(newUnit, numTokens);
+        unitToTokens.putAll(newUnit, tokens);
         return tokens;
     }
 

--- a/src/java/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocator.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocator.java
@@ -60,14 +60,14 @@ class ReplicationAwareTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
         assert !unitToTokens.containsKey(newUnit);
 
         if (unitCount() < replicas)
-            // Allocation does not matter; everything replicates everywhere.
-            //However, at this point it is
+            // Allocation does not matter for now; everything replicates everywhere. However, at this point it is
             // important to start the cluster/datacenter with suitably varied token range sizes so that the algorithm
             // can maintain good balance for any number of nodes.
-            return generateRandomTokens(newUnit, numTokens);
+            return generateSplits(newUnit, numTokens);
         if (numTokens > sortedTokens.size())
-            // Some of the heuristics below can't deal with this very unlikely case. Use splits for now, later allocations can fix any problems this may cause.
-            return generateRandomTokens(newUnit, numTokens);
+            // Some of the heuristics below can't deal with this very unlikely case. Use splits for now,
+            // later allocations can fix any problems this may cause.
+            return generateSplits(newUnit, numTokens);
 
         // ============= construct our initial token ring state =============
 
@@ -76,11 +76,11 @@ class ReplicationAwareTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
         Map<Unit, UnitInfo<Unit>> unitInfos = createUnitInfos(groups);
         if (groups.size() < replicas)
         {
-            // We need at least replicas groups to do allocation correctly. If there aren't enough, 
-            // use random allocation.
+            // We need at least replicas groups to do allocation correctly. If there aren't enough,
+            // use splits as above.
             // This part of the code should only be reached via the RATATest. StrategyAdapter should disallow
             // token allocation in this case as the algorithm is not able to cover the behavior of NetworkTopologyStrategy.
-            return generateRandomTokens(newUnit, numTokens);
+            return generateSplits(newUnit, numTokens);
         }
 
         // initialise our new unit's state (with an idealised ownership)
@@ -138,22 +138,14 @@ class ReplicationAwareTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
         return ImmutableList.copyOf(unitToTokens.get(newUnit));
     }
 
-    private Collection<Token> generateRandomTokens(Unit newUnit, int numTokens)
-    {
-        Set<Token> tokens = new HashSet<>(numTokens);
-        while (tokens.size() < numTokens)
-        {
-            Token token = partitioner.getRandomToken();
-            if (!sortedTokens.containsKey(token))
-            {
-                tokens.add(token);
-                sortedTokens.put(token, newUnit);
-                unitToTokens.put(newUnit, token);
-            }
-        }
-        return tokens;
-    }
+    /**
+     * Selects tokens by repeatedly splitting the largest range in the ring at the given ratio.
+     * This is used to choose tokens for the first nodes in the ring where the algorithm cannot be applied (e.g. when
+     * number of nodes < RF). It generates a reasonably chaotic initial token split, after which the algorithm behaves
+     * well for an unbounded number of nodes.
+     */
 
+    @Override
     Collection<Token> generateSplits(Unit newUnit, int numTokens)
     {
         Collection<Token> tokens = super.generateSplits(newUnit, numTokens);
@@ -566,16 +558,6 @@ class ReplicationAwareTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
         {
             return split.prev;
         }
-    }
-
-    static void dumpTokens(String lead, BaseTokenInfo<?, ?> tokens)
-    {
-        BaseTokenInfo<?, ?> token = tokens;
-        do
-        {
-            System.out.format("%s%s: rs %s rt %s size %.2e\n", lead, token, token.replicationStart, token.replicationThreshold, token.replicatedOwnership);
-            token = token.next;
-        } while (token != null && token != tokens);
     }
 }
 

--- a/src/java/org/apache/cassandra/dht/tokenallocator/ReplicationStrategy.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/ReplicationStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.dht.tokenallocator;
+
+interface ReplicationStrategy<Unit>
+{
+    int replicas();
+
+    /**
+     * Returns a group identifier. getGroup(a) == getGroup(b) iff a and b are on the same group.
+     * @return Some hashable object.
+     */
+    Object getGroup(Unit unit);
+}

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.dht.tokenallocator;
+
+import java.net.InetAddress;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import org.apache.commons.math.stat.descriptive.SummaryStatistics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.locator.AbstractReplicationStrategy;
+import org.apache.cassandra.locator.IEndpointSnitch;
+import org.apache.cassandra.locator.NetworkTopologyStrategy;
+import org.apache.cassandra.locator.SimpleStrategy;
+import org.apache.cassandra.locator.TokenMetadata;
+import org.apache.cassandra.locator.TokenMetadata.Topology;
+
+public class TokenAllocation
+{
+    private static final Logger logger = LoggerFactory.getLogger(TokenAllocation.class);
+
+    public static Collection<Token> allocateTokens(final TokenMetadata tokenMetadata,
+                                                   final AbstractReplicationStrategy rs,
+                                                   final IPartitioner partitioner,
+                                                   final InetAddress endpoint,
+                                                   int numTokens)
+    {
+        StrategyAdapter strategy = getStrategy(tokenMetadata, rs, endpoint);
+        Collection<Token> tokens = create(tokenMetadata, strategy, partitioner).addUnit(endpoint, numTokens);
+        tokens = adjustForCrossDatacenterClashes(tokenMetadata, strategy, tokens);
+
+        if (logger.isWarnEnabled())
+        {
+            logger.warn("Selected tokens {}", tokens);
+            SummaryStatistics os = replicatedOwnershipStats(tokenMetadata, rs, endpoint);
+            TokenMetadata tokenMetadataCopy = tokenMetadata.cloneOnlyTokenMap();
+            tokenMetadataCopy.updateNormalTokens(tokens, endpoint);
+            SummaryStatistics ns = replicatedOwnershipStats(tokenMetadataCopy, rs, endpoint);
+            logger.warn("Replicated node load in datacentre before allocation " + statToString(os));
+            logger.warn("Replicated node load in datacentre after allocation " + statToString(ns));
+
+            // TODO: Is it worth doing the replicated ownership calculation always to be able to raise this alarm?
+            if (ns.getStandardDeviation() > os.getStandardDeviation())
+                logger.warn("Unexpected growth in standard deviation after allocation.");
+        }
+        return tokens;
+    }
+
+    private static Collection<Token> adjustForCrossDatacenterClashes(final TokenMetadata tokenMetadata,
+                                                                     StrategyAdapter strategy, Collection<Token> tokens)
+    {
+        List<Token> filtered = Lists.newArrayListWithCapacity(tokens.size());
+
+        for (Token t : tokens)
+        {
+            while (tokenMetadata.getEndpoint(t) != null)
+            {
+                InetAddress other = tokenMetadata.getEndpoint(t);
+                if (strategy.inAllocationRing(other))
+                    throw new ConfigurationException(String.format("Allocated token %s already assigned to node %s. Is another node also allocating tokens?", t, other));
+                t = t.increaseSlightly();
+            }
+            filtered.add(t);
+        }
+        return filtered;
+    }
+
+    // return the ratio of ownership for each endpoint
+    public static Map<InetAddress, Double> evaluateReplicatedOwnership(TokenMetadata tokenMetadata, AbstractReplicationStrategy rs)
+    {
+        Map<InetAddress, Double> ownership = Maps.newHashMap();
+        List<Token> sortedTokens = tokenMetadata.sortedTokens();
+        Iterator<Token> it = sortedTokens.iterator();
+        Token current = it.next();
+        while (it.hasNext())
+        {
+            Token next = it.next();
+            addOwnership(tokenMetadata, rs, current, next, ownership);
+            current = next;
+        }
+        addOwnership(tokenMetadata, rs, current, sortedTokens.get(0), ownership);
+
+        return ownership;
+    }
+
+    static void addOwnership(final TokenMetadata tokenMetadata, final AbstractReplicationStrategy rs, Token current, Token next, Map<InetAddress, Double> ownership)
+    {
+        double size = current.size(next);
+        Token representative = current.getPartitioner().midpoint(current, next);
+        for (InetAddress n : rs.calculateNaturalEndpoints(representative, tokenMetadata))
+        {
+            Double v = ownership.get(n);
+            ownership.put(n, v != null ? v + size : size);
+        }
+    }
+
+    public static String statToString(SummaryStatistics stat)
+    {
+        return String.format("max %.2f min %.2f stddev %.4f", stat.getMax() / stat.getMean(), stat.getMin() / stat.getMean(), stat.getStandardDeviation());
+    }
+
+    public static SummaryStatistics replicatedOwnershipStats(TokenMetadata tokenMetadata,
+                                                             AbstractReplicationStrategy rs, InetAddress endpoint)
+    {
+        SummaryStatistics stat = new SummaryStatistics();
+        StrategyAdapter strategy = getStrategy(tokenMetadata, rs, endpoint);
+        for (Map.Entry<InetAddress, Double> en : evaluateReplicatedOwnership(tokenMetadata, rs).entrySet())
+        {
+            // Filter only in the same datacentre.
+            if (strategy.inAllocationRing(en.getKey()))
+                stat.addValue(en.getValue() / tokenMetadata.getTokens(en.getKey()).size());
+        }
+        return stat;
+    }
+
+    static TokenAllocator<InetAddress> create(TokenMetadata tokenMetadata, StrategyAdapter strategy, IPartitioner partitioner)
+    {
+        NavigableMap<Token, InetAddress> sortedTokens = new TreeMap<>();
+        for (Map.Entry<Token, InetAddress> en : tokenMetadata.getNormalAndBootstrappingTokenToEndpointMap().entrySet())
+        {
+            if (strategy.inAllocationRing(en.getValue()))
+                sortedTokens.put(en.getKey(), en.getValue());
+        }
+        return new ReplicationAwareTokenAllocator<>(sortedTokens, strategy, partitioner);
+    }
+
+    interface StrategyAdapter extends ReplicationStrategy<InetAddress>
+    {
+        // return true iff the provided endpoint occurs in the same virtual token-ring we are allocating for
+        // i.e. the set of the nodes that share ownership with the node we are allocating
+        // alternatively: return false if the endpoint's ownership is independent of the node we are allocating tokens for
+        boolean inAllocationRing(InetAddress other);
+    }
+
+    static StrategyAdapter getStrategy(final TokenMetadata tokenMetadata, final AbstractReplicationStrategy rs, final InetAddress endpoint)
+    {
+        if (rs instanceof NetworkTopologyStrategy)
+            return getStrategy(tokenMetadata, (NetworkTopologyStrategy) rs, rs.snitch, endpoint);
+        if (rs instanceof SimpleStrategy)
+            return getStrategy(tokenMetadata, (SimpleStrategy) rs, endpoint);
+        throw new ConfigurationException("Token allocation does not support replication strategy " + rs.getClass().getSimpleName());
+    }
+
+    static StrategyAdapter getStrategy(final TokenMetadata tokenMetadata, final SimpleStrategy rs, final InetAddress endpoint)
+    {
+        final int replicas = rs.getReplicationFactor();
+
+        return new StrategyAdapter()
+        {
+            @Override
+            public int replicas()
+            {
+                return replicas;
+            }
+
+            @Override
+            public Object getGroup(InetAddress unit)
+            {
+                return unit;
+            }
+
+            @Override
+            public boolean inAllocationRing(InetAddress other)
+            {
+                return true;
+            }
+        };
+    }
+
+    static StrategyAdapter getStrategy(final TokenMetadata tokenMetadata, final NetworkTopologyStrategy rs, final IEndpointSnitch snitch, final InetAddress endpoint)
+    {
+        final String dc = snitch.getDatacenter(endpoint);
+        final int replicas = rs.getReplicationFactor(dc);
+
+        Topology topology = tokenMetadata.getTopology();
+        int racks = topology.getDatacenterRacks().get(dc).size();
+
+        if (replicas >= racks)
+        {
+            return new StrategyAdapter()
+            {
+                @Override
+                public int replicas()
+                {
+                    return replicas;
+                }
+
+                @Override
+                public Object getGroup(InetAddress unit)
+                {
+                    return snitch.getRack(unit);
+                }
+
+                @Override
+                public boolean inAllocationRing(InetAddress other)
+                {
+                    return dc.equals(snitch.getDatacenter(other));
+                }
+            };
+        }
+        else if (racks == 1)
+        {
+            // One rack, each node treated as separate.
+            return new StrategyAdapter()
+            {
+                @Override
+                public int replicas()
+                {
+                    return replicas;
+                }
+
+                @Override
+                public Object getGroup(InetAddress unit)
+                {
+                    return unit;
+                }
+
+                @Override
+                public boolean inAllocationRing(InetAddress other)
+                {
+                    return dc.equals(snitch.getDatacenter(other));
+                }
+            };
+        }
+        else
+            throw new ConfigurationException(
+                                            String.format("Token allocation failed: the number of racks %d in datacentre %s is lower than its replication factor %d.",
+                                                          replicas, dc, racks));
+    }
+}
+

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
@@ -28,7 +28,7 @@ import java.util.TreeMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import org.apache.commons.math.stat.descriptive.SummaryStatistics;
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
@@ -252,8 +252,8 @@ public class TokenAllocation
         }
         else
             throw new ConfigurationException(
-                                            String.format("Token allocation failed: the number of racks %d in datacentre %s is lower than its replication factor %d.",
-                                                          replicas, dc, racks));
+                    String.format("Token allocation failed: the number of racks %d in datacenter %s is lower than its replication factor %d.",
+                                  racks, dc, replicas));
     }
 }
 

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
@@ -55,9 +55,6 @@ public class TokenAllocation
                                                    final InetAddress endpoint,
                                                    int numTokens)
     {
-        if (!FBUtilities.getBroadcastAddress().equals(InetAddress.getLoopbackAddress()))
-            Gossiper.waitToSettle();
-
         TokenMetadata tokenMetadataCopy = tokenMetadata.cloneOnlyTokenMap();
         StrategyAdapter strategy = getStrategy(tokenMetadataCopy, rs, endpoint);
         Collection<Token> tokens = create(tokenMetadata, strategy, partitioner).addUnit(endpoint, numTokens);

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
@@ -66,8 +66,8 @@ public class TokenAllocation
             SummaryStatistics os = replicatedOwnershipStats(tokenMetadataCopy, rs, endpoint);
             tokenMetadataCopy.updateNormalTokens(tokens, endpoint);
             SummaryStatistics ns = replicatedOwnershipStats(tokenMetadataCopy, rs, endpoint);
-            logger.warn("Replicated node load in datacentre before allocation {}", statToString(os));
-            logger.warn("Replicated node load in datacentre after allocation {}", statToString(ns));
+            logger.warn("Replicated node load in datacenter before allocation {}", statToString(os));
+            logger.warn("Replicated node load in datacenter after allocation {}", statToString(ns));
 
             // TODO: Is it worth doing the replicated ownership calculation always to be able to raise this alarm?
             if (ns.getStandardDeviation() > os.getStandardDeviation())

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
@@ -64,8 +64,8 @@ public class TokenAllocation
             SummaryStatistics os = replicatedOwnershipStats(tokenMetadataCopy, rs, endpoint);
             tokenMetadataCopy.updateNormalTokens(tokens, endpoint);
             SummaryStatistics ns = replicatedOwnershipStats(tokenMetadataCopy, rs, endpoint);
-            logger.warn("Replicated node load in datacentre before allocation " + statToString(os));
-            logger.warn("Replicated node load in datacentre after allocation " + statToString(ns));
+            logger.warn("Replicated node load in datacentre before allocation {}", statToString(os));
+            logger.warn("Replicated node load in datacentre after allocation {}", statToString(ns));
 
             // TODO: Is it worth doing the replicated ownership calculation always to be able to raise this alarm?
             if (ns.getStandardDeviation() > os.getStandardDeviation())
@@ -149,7 +149,7 @@ public class TokenAllocation
             if (strategy.inAllocationRing(en.getValue()))
                 sortedTokens.put(en.getKey(), en.getValue());
         }
-        return new ReplicationAwareTokenAllocator<>(sortedTokens, strategy, partitioner);
+        return TokenAllocatorFactory.createTokenAllocator(sortedTokens, strategy, partitioner);
     }
 
     interface StrategyAdapter extends ReplicationStrategy<InetAddress>

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
@@ -260,7 +260,7 @@ public class TokenAllocation
                 ? topology.getDatacenterRacks().get(dc).asMap().size()
                 : 1;
 
-        if (racks >= replicas)
+        if (racks > replicas)
         {
             return new StrategyAdapter()
             {
@@ -280,6 +280,32 @@ public class TokenAllocation
                 public boolean inAllocationRing(InetAddress other)
                 {
                     return dc.equals(snitch.getDatacenter(other));
+                }
+            };
+        }
+        else if (racks == replicas)
+        {
+            // When the number of racks is the same as the replication factor, everything must replicate exactly once
+            // in each rack. This is the same as having independent rings from each rack.
+            final String rack = snitch.getRack(endpoint);
+            return new StrategyAdapter()
+            {
+                @Override
+                public int replicas()
+                {
+                    return 1;
+                }
+
+                @Override
+                public Object getGroup(InetAddress unit)
+                {
+                    return unit;
+                }
+
+                @Override
+                public boolean inAllocationRing(InetAddress other)
+                {
+                    return dc.equals(snitch.getDatacenter(other)) && rack.equals(snitch.getRack(other));
                 }
             };
         }

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.gms.Gossiper;
@@ -73,6 +74,21 @@ public class TokenAllocation
             if (ns.getStandardDeviation() > os.getStandardDeviation())
                 logger.warn("Unexpected growth in standard deviation after allocation.");
         }
+        return tokens;
+    }
+
+    public static Collection<Token> allocateTokens(final TokenMetadata tokenMetadata,
+                                                   final int replicas,
+                                                   final IPartitioner partitioner,
+                                                   final InetAddress endpoint,
+                                                   int numTokens)
+    {
+        TokenMetadata tokenMetadataCopy = tokenMetadata.cloneOnlyTokenMap();
+        StrategyAdapter strategy = getStrategy(tokenMetadataCopy, replicas, endpoint);
+        Collection<Token> tokens = create(tokenMetadata, strategy, partitioner).addUnit(endpoint, numTokens);
+        tokens = adjustForCrossDatacenterClashes(tokenMetadata, strategy, tokens);
+        logger.warn("Selected tokens {}", tokens);
+        // SummaryStatistics is not implemented for `allocate_tokens_for_local_replication_factor`
         return tokens;
     }
 
@@ -201,7 +217,17 @@ public class TokenAllocation
     {
         final String dc = snitch.getDatacenter(endpoint);
         final int replicas = rs.getReplicationFactor(dc);
+        return getStrategy(tokenMetadata, replicas, snitch, endpoint);
+    }
 
+    static StrategyAdapter getStrategy(final TokenMetadata tokenMetadata, final int replicas, final InetAddress endpoint)
+    {
+        return getStrategy(tokenMetadata, replicas, DatabaseDescriptor.getEndpointSnitch(), endpoint);
+    }
+
+    static StrategyAdapter getStrategy(final TokenMetadata tokenMetadata, final int replicas, final IEndpointSnitch snitch, final InetAddress endpoint)
+    {
+        final String dc = snitch.getDatacenter(endpoint);
         if (replicas == 0 || replicas == 1)
         {
             // No replication, each node is treated as separate.

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
@@ -201,9 +201,9 @@ public class TokenAllocation
         final int replicas = rs.getReplicationFactor(dc);
 
         Topology topology = tokenMetadata.getTopology();
-        int racks = topology.getDatacenterRacks().get(dc).size();
+        int racks = topology.getDatacenterRacks().get(dc).asMap().size();
 
-        if (replicas >= racks)
+        if (racks >= replicas)
         {
             return new StrategyAdapter()
             {

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
@@ -36,12 +36,14 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.locator.IEndpointSnitch;
 import org.apache.cassandra.locator.NetworkTopologyStrategy;
 import org.apache.cassandra.locator.SimpleStrategy;
 import org.apache.cassandra.locator.TokenMetadata;
 import org.apache.cassandra.locator.TokenMetadata.Topology;
+import org.apache.cassandra.utils.FBUtilities;
 
 public class TokenAllocation
 {
@@ -53,6 +55,9 @@ public class TokenAllocation
                                                    final InetAddress endpoint,
                                                    int numTokens)
     {
+        if (!FBUtilities.getBroadcastAddress().equals(InetAddress.getLoopbackAddress()))
+            Gossiper.waitToSettle();
+
         TokenMetadata tokenMetadataCopy = tokenMetadata.cloneOnlyTokenMap();
         StrategyAdapter strategy = getStrategy(tokenMetadataCopy, rs, endpoint);
         Collection<Token> tokens = create(tokenMetadata, strategy, partitioner).addUnit(endpoint, numTokens);
@@ -199,6 +204,31 @@ public class TokenAllocation
     {
         final String dc = snitch.getDatacenter(endpoint);
         final int replicas = rs.getReplicationFactor(dc);
+
+        if (replicas == 0 || replicas == 1)
+        {
+            // No replication, each node is treated as separate.
+            return new StrategyAdapter()
+            {
+                @Override
+                public int replicas()
+                {
+                    return 1;
+                }
+
+                @Override
+                public Object getGroup(InetAddress unit)
+                {
+                    return unit;
+                }
+
+                @Override
+                public boolean inAllocationRing(InetAddress other)
+                {
+                    return dc.equals(snitch.getDatacenter(other));
+                }
+            };
+        }
 
         Topology topology = tokenMetadata.getTopology();
         int racks = topology.getDatacenterRacks().get(dc).asMap().size();

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
@@ -228,7 +228,11 @@ public class TokenAllocation
         }
 
         Topology topology = tokenMetadata.getTopology();
-        int racks = topology.getDatacenterRacks().get(dc).asMap().size();
+
+        // if topology hasn't been setup yet for this endpoint+rack then treat it as a separate unit
+        int racks = topology.getDatacenterRacks().get(dc) != null && topology.getDatacenterRacks().get(dc).containsKey(snitch.getRack(endpoint))
+                ? topology.getDatacenterRacks().get(dc).asMap().size()
+                : 1;
 
         if (racks >= replicas)
         {

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
@@ -53,15 +53,15 @@ public class TokenAllocation
                                                    final InetAddress endpoint,
                                                    int numTokens)
     {
-        StrategyAdapter strategy = getStrategy(tokenMetadata, rs, endpoint);
+        TokenMetadata tokenMetadataCopy = tokenMetadata.cloneOnlyTokenMap();
+        StrategyAdapter strategy = getStrategy(tokenMetadataCopy, rs, endpoint);
         Collection<Token> tokens = create(tokenMetadata, strategy, partitioner).addUnit(endpoint, numTokens);
         tokens = adjustForCrossDatacenterClashes(tokenMetadata, strategy, tokens);
 
         if (logger.isWarnEnabled())
         {
             logger.warn("Selected tokens {}", tokens);
-            SummaryStatistics os = replicatedOwnershipStats(tokenMetadata, rs, endpoint);
-            TokenMetadata tokenMetadataCopy = tokenMetadata.cloneOnlyTokenMap();
+            SummaryStatistics os = replicatedOwnershipStats(tokenMetadataCopy, rs, endpoint);
             tokenMetadataCopy.updateNormalTokens(tokens, endpoint);
             SummaryStatistics ns = replicatedOwnershipStats(tokenMetadataCopy, rs, endpoint);
             logger.warn("Replicated node load in datacentre before allocation " + statToString(os));

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocator.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocator.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.dht.tokenallocator;
+
+import java.util.Collection;
+
+import org.apache.cassandra.dht.Token;
+
+public interface TokenAllocator<Unit>
+{
+    public Collection<Token> addUnit(Unit newUnit, int numTokens);
+}

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocatorBase.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocatorBase.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht.tokenallocator;
+
+import java.util.Map;
+import java.util.NavigableMap;
+
+import com.google.common.collect.Maps;
+
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Token;
+
+public abstract class TokenAllocatorBase<Unit> implements TokenAllocator<Unit>
+{
+    final NavigableMap<Token, Unit> sortedTokens;
+    final ReplicationStrategy<Unit> strategy;
+    final IPartitioner partitioner;
+
+    protected TokenAllocatorBase(NavigableMap<Token, Unit> sortedTokens,
+                             ReplicationStrategy<Unit> strategy,
+                             IPartitioner partitioner)
+    {
+        this.sortedTokens = sortedTokens;
+        this.strategy = strategy;
+        this.partitioner = partitioner;
+    }
+
+    public abstract int getReplicas();
+
+    protected Map<Unit, UnitInfo<Unit>> createUnitInfos(Map<Object, GroupInfo> groups)
+    {
+        Map<Unit, UnitInfo<Unit>> map = Maps.newHashMap();
+        for (Unit n : sortedTokens.values())
+        {
+            UnitInfo<Unit> ni = map.get(n);
+            if (ni == null)
+                map.put(n, ni = new UnitInfo<>(n, 0, groups, strategy));
+            ni.tokenCount++;
+        }
+        return map;
+    }
+
+    private Map.Entry<Token, Unit> mapEntryFor(Token t)
+    {
+        Map.Entry<Token, Unit> en = sortedTokens.floorEntry(t);
+        if (en == null)
+            en = sortedTokens.lastEntry();
+        return en;
+    }
+
+    Unit unitFor(Token t)
+    {
+        return mapEntryFor(t).getValue();
+    }
+
+    // get or initialise the shared GroupInfo associated with the unit
+    private static <Unit> GroupInfo getGroup(Unit unit, Map<Object, GroupInfo> groupMap, ReplicationStrategy<Unit> strategy)
+    {
+        Object groupClass = strategy.getGroup(unit);
+        GroupInfo group = groupMap.get(groupClass);
+        if (group == null)
+            groupMap.put(groupClass, group = new GroupInfo(groupClass));
+        return group;
+    }
+
+    /**
+     * Unique group object that one or more UnitInfo objects link to.
+     */
+    static class GroupInfo
+    {
+        /**
+         * Group identifier given by ReplicationStrategy.getGroup(Unit).
+         */
+        final Object group;
+
+        /**
+         * Seen marker. When non-null, the group is already seen in replication walks.
+         * Also points to previous seen group to enable walking the seen groups and clearing the seen markers.
+         */
+        GroupInfo prevSeen = null;
+        /**
+         * Same marker/chain used by populateTokenInfo.
+         */
+        GroupInfo prevPopulate = null;
+
+        /**
+         * Value used as terminator for seen chains.
+         */
+        static GroupInfo TERMINATOR = new GroupInfo(null);
+
+        public GroupInfo(Object group)
+        {
+            this.group = group;
+        }
+
+        public String toString()
+        {
+            return group.toString() + (prevSeen != null ? "*" : "");
+        }
+    }
+
+    /**
+     * Unit information created and used by ReplicationAwareTokenDistributor. Contained vnodes all point to the same
+     * instance.
+     */
+    static class UnitInfo<Unit>
+    {
+        final Unit unit;
+        final GroupInfo group;
+        double ownership;
+        int tokenCount;
+
+        /**
+         * During evaluateImprovement this is used to form a chain of units affected by the candidate insertion.
+         */
+        UnitInfo<Unit> prevUsed;
+        /**
+         * During evaluateImprovement this holds the ownership after the candidate insertion.
+         */
+        double adjustedOwnership;
+
+        private UnitInfo(Unit unit, GroupInfo group)
+        {
+            this.unit = unit;
+            this.group = group;
+            this.tokenCount = 0;
+        }
+
+        public UnitInfo(Unit unit, double ownership, Map<Object, GroupInfo> groupMap, ReplicationStrategy<Unit> strategy)
+        {
+            this(unit, getGroup(unit, groupMap, strategy));
+            this.ownership = ownership;
+        }
+
+        public String toString()
+        {
+            return String.format("%s%s(%.2e)%s",
+                                 unit, unit == group.group ? (group.prevSeen != null ? "*" : "") : ":" + group.toString(),
+                                 ownership, prevUsed != null ? (prevUsed == this ? "#" : "->" + prevUsed.toString()) : "");
+        }
+    }
+
+    private static class CircularList<T extends CircularList<T>>
+    {
+        T prev;
+        T next;
+
+        /**
+         * Inserts this after unit in the circular list which starts at head. Returns the new head of the list, which
+         * only changes if head was null.
+         */
+        @SuppressWarnings("unchecked")
+        T insertAfter(T head, T unit)
+        {
+            if (head == null)
+            {
+                return prev = next = (T) this;
+            }
+            assert unit != null;
+            assert unit.next != null;
+            prev = unit;
+            next = unit.next;
+            prev.next = (T) this;
+            next.prev = (T) this;
+            return head;
+        }
+
+        /**
+         * Removes this from the list that starts at head. Returns the new head of the list, which only changes if the
+         * head was removed.
+         */
+        T removeFrom(T head)
+        {
+            next.prev = prev;
+            prev.next = next;
+            return this == head ? (this == next ? null : next) : head;
+        }
+    }
+
+    static class BaseTokenInfo<Unit, T extends BaseTokenInfo<Unit, T>> extends CircularList<T>
+    {
+        final Token token;
+        final UnitInfo<Unit> owningUnit;
+
+        /**
+         * Start of the replication span for the vnode, i.e. the first token of the RF'th group seen before the token.
+         * The replicated ownership of the unit is the range between {@code replicationStart} and {@code token}.
+         */
+        Token replicationStart;
+        /**
+         * The closest position that the new candidate can take to become the new replication start. If candidate is
+         * closer, the start moves to this position. Used to determine replicationStart after insertion of new token.
+         *
+         * Usually the RF minus one boundary, i.e. the first token of the RF-1'th group seen before the token.
+         */
+        Token replicationThreshold;
+        /**
+         * Current replicated ownership. This number is reflected in the owning unit's ownership.
+         */
+        double replicatedOwnership = 0;
+
+        public BaseTokenInfo(Token token, UnitInfo<Unit> owningUnit)
+        {
+            this.token = token;
+            this.owningUnit = owningUnit;
+        }
+
+        public String toString()
+        {
+            return String.format("%s(%s)", token, owningUnit);
+        }
+
+        /**
+         * Previous unit in the token ring. For existing tokens this is prev,
+         * for candidates it's "split".
+         */
+        TokenInfo<Unit> prevInRing()
+        {
+            return null;
+        }
+    }
+
+    /**
+     * TokenInfo about existing tokens/vnodes.
+     */
+    static class TokenInfo<Unit> extends BaseTokenInfo<Unit, TokenInfo<Unit>>
+    {
+        public TokenInfo(Token token, UnitInfo<Unit> owningUnit)
+        {
+            super(token, owningUnit);
+        }
+
+        TokenInfo<Unit> prevInRing()
+        {
+            return prev;
+        }
+    }
+
+    static class Weighted<T> implements Comparable<Weighted<T>>
+    {
+        final double weight;
+        final T value;
+
+        public Weighted(double weight, T value)
+        {
+            this.weight = weight;
+            this.value = value;
+        }
+
+        @Override
+        public int compareTo(Weighted<T> o)
+        {
+            int cmp = Double.compare(o.weight, this.weight);
+            return cmp;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("%s<%s>", value, weight);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocatorBase.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocatorBase.java
@@ -18,9 +18,13 @@
 
 package org.apache.cassandra.dht.tokenallocator;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Random;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import org.apache.cassandra.dht.IPartitioner;
@@ -28,6 +32,9 @@ import org.apache.cassandra.dht.Token;
 
 public abstract class TokenAllocatorBase<Unit> implements TokenAllocator<Unit>
 {
+    static final double MIN_INITIAL_SPLITS_RATIO = 1.0 - 1.0 / Math.sqrt(5.0);
+    static final double MAX_INITIAL_SPLITS_RATIO = MIN_INITIAL_SPLITS_RATIO + 0.075;
+
     final NavigableMap<Token, Unit> sortedTokens;
     final ReplicationStrategy<Unit> strategy;
     final IPartitioner partitioner;
@@ -77,6 +84,59 @@ public abstract class TokenAllocatorBase<Unit> implements TokenAllocator<Unit>
         if (group == null)
             groupMap.put(groupClass, group = new GroupInfo(groupClass));
         return group;
+    }
+
+    Collection<Token> generateSplits(Unit newUnit, int numTokens)
+    {
+        return generateSplits(newUnit, numTokens, MIN_INITIAL_SPLITS_RATIO, MAX_INITIAL_SPLITS_RATIO);
+    }
+    /**
+     * Selects tokens by repeatedly splitting the largest range in the ring at the given ratio.
+     *
+     * This is used to choose tokens for the first nodes in the ring where the algorithm cannot be applied (e.g. when
+     * number of nodes < RF). It generates a reasonably chaotic initial token split, after which the algorithm behaves
+     * well for an unbounded number of nodes.
+     */
+    Collection<Token> generateSplits(Unit newUnit, int numTokens, double minRatio, double maxRatio)
+    {
+        Random random = new Random(sortedTokens.size());
+
+        double potentialRatioGrowth = maxRatio - minRatio;
+
+        List<Token> tokens = Lists.newArrayListWithExpectedSize(numTokens);
+
+        if (sortedTokens.isEmpty())
+        {
+            // Select a random start token. This has no effect on distribution, only on where the local ring is "centered".
+            // Using a random start decreases the chances of clash with the tokens of other datacenters in the ring.
+            Token t = partitioner.getRandomToken();
+            tokens.add(t);
+            sortedTokens.put(t, newUnit);
+        }
+
+        while (tokens.size() < numTokens)
+        {
+            // split max span using given ratio
+            Token prev = sortedTokens.lastKey();
+            double maxsz = 0;
+            Token t1 = null;
+            Token t2 = null;
+            for (Token curr : sortedTokens.keySet())
+            {
+                double sz = prev.size(curr);
+                if (sz > maxsz)
+                {
+                    maxsz = sz;
+                    t1 = prev; t2 = curr;
+                }
+                prev = curr;
+            }
+            assert t1 != null;
+            Token t = partitioner.split(t1, t2, minRatio + potentialRatioGrowth * random.nextDouble());
+            tokens.add(t);
+            sortedTokens.put(t, newUnit);
+        }
+        return tokens;
     }
 
     /**

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocatorFactory.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocatorFactory.java
@@ -15,13 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.cassandra.dht.tokenallocator;
 
-import java.util.Collection;
+import java.net.InetAddress;
+import java.util.NavigableMap;
 
+import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token;
 
-public interface TokenAllocator<Unit>
+public class TokenAllocatorFactory
 {
-    Collection<Token> addUnit(Unit newUnit, int numTokens);
+    public static TokenAllocator<InetAddress> createTokenAllocator(NavigableMap<Token, InetAddress> sortedTokens,
+                                                     ReplicationStrategy<InetAddress> strategy,
+                                                     IPartitioner partitioner)
+    {
+        if(strategy.replicas() == 1)
+            return new NoReplicationTokenAllocator<>(sortedTokens, strategy, partitioner);
+        return new ReplicationAwareTokenAllocator<>(sortedTokens, strategy, partitioner);
+    }
 }

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocatorFactory.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocatorFactory.java
@@ -21,17 +21,25 @@ package org.apache.cassandra.dht.tokenallocator;
 import java.net.InetAddress;
 import java.util.NavigableMap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token;
 
 public class TokenAllocatorFactory
 {
+    private static final Logger logger = LoggerFactory.getLogger(TokenAllocatorFactory.class);
     public static TokenAllocator<InetAddress> createTokenAllocator(NavigableMap<Token, InetAddress> sortedTokens,
                                                      ReplicationStrategy<InetAddress> strategy,
                                                      IPartitioner partitioner)
     {
-        if(strategy.replicas() == 1)
+        if(strategy.replicas() == 1 || strategy.replicas() == 0)
+        {
+            logger.info("Using NoReplicationTokenAllocator.");
             return new NoReplicationTokenAllocator<>(sortedTokens, strategy, partitioner);
+        }
+        logger.info("Using ReplicationAwareTokenAllocator.");
         return new ReplicationAwareTokenAllocator<>(sortedTokens, strategy, partitioner);
     }
 }

--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocatorFactory.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocatorFactory.java
@@ -34,7 +34,7 @@ public class TokenAllocatorFactory
                                                      ReplicationStrategy<InetAddress> strategy,
                                                      IPartitioner partitioner)
     {
-        if(strategy.replicas() == 1 || strategy.replicas() == 0)
+        if(strategy.replicas() == 1)
         {
             logger.info("Using NoReplicationTokenAllocator.");
             return new NoReplicationTokenAllocator<>(sortedTokens, strategy, partitioner);

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -667,7 +667,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
     private boolean sendGossip(MessageOut<GossipDigestSyn> message, Set<InetAddress> epSet)
     {
         List<InetAddress> liveEndpoints = ImmutableList.copyOf(epSet);
-        
+
         int size = liveEndpoints.size();
         if (size < 1)
             return false;
@@ -1251,7 +1251,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         for (Entry<ApplicationState, VersionedValue> remoteEntry : remoteStates)
             doOnChangeNotifications(addr, remoteEntry.getKey(), remoteEntry.getValue());
     }
-    
+
     // notify that a local application state is going to change (doesn't get triggered for remote changes)
     private void doBeforeChangeNotifications(InetAddress addr, EndpointState epState, ApplicationState apState, VersionedValue newValue)
     {
@@ -1651,5 +1651,59 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
     {
         stop();
         ExecutorUtils.shutdownAndWait(timeout, unit, executor);
+    }
+
+    public static void waitToSettle()
+    {
+        int forceAfter = Integer.getInteger("cassandra.skip_wait_for_gossip_to_settle", -1);
+        if (forceAfter == 0)
+        {
+            return;
+        }
+        final int GOSSIP_SETTLE_MIN_WAIT_MS = 5000;
+        final int GOSSIP_SETTLE_POLL_INTERVAL_MS = 1000;
+        final int GOSSIP_SETTLE_POLL_SUCCESSES_REQUIRED = 3;
+
+        logger.info("Waiting for gossip to settle before accepting client requests...");
+        Uninterruptibles.sleepUninterruptibly(GOSSIP_SETTLE_MIN_WAIT_MS, TimeUnit.MILLISECONDS);
+        int totalPolls = 0;
+        int numOkay = 0;
+        JMXEnabledThreadPoolExecutor gossipStage = (JMXEnabledThreadPoolExecutor)StageManager.getStage(Stage.GOSSIP);
+        while (numOkay < GOSSIP_SETTLE_POLL_SUCCESSES_REQUIRED)
+        {
+            Uninterruptibles.sleepUninterruptibly(GOSSIP_SETTLE_POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
+            long completed = gossipStage.metrics.completedTasks.getValue();
+            long active = gossipStage.metrics.activeTasks.getValue();
+            long pending = gossipStage.metrics.pendingTasks.getValue();
+            totalPolls++;
+            if (active == 0 && pending == 0)
+            {
+                logger.debug("Gossip looks settled. CompletedTasks: {}", SafeArg.of("completedTasks", completed));
+                numOkay++;
+            }
+            else
+            {
+                logger.info(
+                    "Gossip not settled after {} polls. Gossip Stage active/pending/completed: {}/{}/{}",
+                    SafeArg.of("totalPolls", totalPolls),
+                    SafeArg.of("active", active),
+                    SafeArg.of("pending", pending),
+                    SafeArg.of("completed", completed));
+                numOkay = 0;
+            }
+            if (forceAfter > 0 && totalPolls > forceAfter)
+            {
+                logger.warn("Gossip not settled but startup forced by cassandra.skip_wait_for_gossip_to_settle. Gossip Stage total/active/pending/completed: {}/{}/{}/{}",
+                            SafeArg.of("totalPolls", totalPolls),
+                            SafeArg.of("active", active),
+                            SafeArg.of("pending", pending),
+                            SafeArg.of("completed", completed));
+                break;
+            }
+        }
+        if (totalPolls > GOSSIP_SETTLE_POLL_SUCCESSES_REQUIRED)
+            logger.info("Gossip settled after {} extra polls; proceeding", SafeArg.of("extraPolls", totalPolls - GOSSIP_SETTLE_POLL_SUCCESSES_REQUIRED));
+        else
+            logger.info("No gossip backlog; proceeding");
     }
 }

--- a/src/java/org/apache/cassandra/locator/TokenMetadata.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadata.java
@@ -1031,7 +1031,8 @@ public class TokenMetadata
     {
         List tokens = sortedTokens();
         int index = Collections.binarySearch(tokens, token);
-        assert index >= 0 : token + " not found in " + StringUtils.join(tokenToEndpointMap.keySet(), ", ");
+//        assert index >= 0 : token + " not found in " + StringUtils.join(tokenToEndpointMap.keySet(), ", ");
+        if (index < 0) index = -index-1;
         return (Token) (index == 0 ? tokens.get(tokens.size() - 1) : tokens.get(index - 1));
     }
 
@@ -1039,7 +1040,8 @@ public class TokenMetadata
     {
         List tokens = sortedTokens();
         int index = Collections.binarySearch(tokens, token);
-        assert index >= 0 : token + " not found in " + StringUtils.join(tokenToEndpointMap.keySet(), ", ");
+//        assert index >= 0 : token + " not found in " + StringUtils.join(tokenToEndpointMap.keySet(), ", ");
+        if (index < 0) return (Token) tokens.get(-index-1);
         return (Token) ((index == (tokens.size() - 1)) ? tokens.get(0) : tokens.get(index + 1));
     }
 

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -78,6 +78,7 @@ import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.db.marshal.CounterColumnType;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.StartupException;
+import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.DefaultNameFactory;

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -57,13 +57,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.Uninterruptibles;
 
 import com.palantir.cassandra.concurrent.LocalReadRunnableTimeoutWatcher;
 import com.palantir.cassandra.db.BootstrappingSafetyException;
 import com.palantir.cassandra.settings.DisableClientInterfaceSetting;
 import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import org.apache.cassandra.config.ColumnDefinition;
@@ -405,7 +403,7 @@ public class CassandraDaemon
         new HiccupMeter().start();
 
         if (!FBUtilities.getBroadcastAddress().equals(InetAddress.getLoopbackAddress()))
-            waitForGossipToSettle();
+            Gossiper.waitToSettle();
 
         // schedule periodic background compaction task submission. this is simply a backstop against compactions stalling
         // due to scheduling errors or race conditions
@@ -752,61 +750,6 @@ public class CassandraDaemon
         if(!runManaged) {
             System.exit(0);
         }
-    }
-
-    @VisibleForTesting
-    public static void waitForGossipToSettle()
-    {
-        int forceAfter = Integer.getInteger("cassandra.skip_wait_for_gossip_to_settle", -1);
-        if (forceAfter == 0)
-        {
-            return;
-        }
-        final int GOSSIP_SETTLE_MIN_WAIT_MS = 5000;
-        final int GOSSIP_SETTLE_POLL_INTERVAL_MS = 1000;
-        final int GOSSIP_SETTLE_POLL_SUCCESSES_REQUIRED = 3;
-
-        logger.info("Waiting for gossip to settle before accepting client requests...");
-        Uninterruptibles.sleepUninterruptibly(GOSSIP_SETTLE_MIN_WAIT_MS, TimeUnit.MILLISECONDS);
-        int totalPolls = 0;
-        int numOkay = 0;
-        JMXEnabledThreadPoolExecutor gossipStage = (JMXEnabledThreadPoolExecutor)StageManager.getStage(Stage.GOSSIP);
-        while (numOkay < GOSSIP_SETTLE_POLL_SUCCESSES_REQUIRED)
-        {
-            Uninterruptibles.sleepUninterruptibly(GOSSIP_SETTLE_POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
-            long completed = gossipStage.metrics.completedTasks.getValue();
-            long active = gossipStage.metrics.activeTasks.getValue();
-            long pending = gossipStage.metrics.pendingTasks.getValue();
-            totalPolls++;
-            if (active == 0 && pending == 0)
-            {
-                logger.debug("Gossip looks settled. CompletedTasks: {}", SafeArg.of("completedTasks", completed));
-                numOkay++;
-            }
-            else
-            {
-                logger.info(
-                        "Gossip not settled after {} polls. Gossip Stage active/pending/completed: {}/{}/{}",
-                        SafeArg.of("totalPolls", totalPolls),
-                        SafeArg.of("active", active),
-                        SafeArg.of("pending", pending),
-                        SafeArg.of("completed", completed));
-                numOkay = 0;
-            }
-            if (forceAfter > 0 && totalPolls > forceAfter)
-            {
-                logger.warn("Gossip not settled but startup forced by cassandra.skip_wait_for_gossip_to_settle. Gossip Stage total/active/pending/completed: {}/{}/{}/{}",
-                            SafeArg.of("totalPolls", totalPolls),
-                            SafeArg.of("active", active),
-                            SafeArg.of("pending", pending),
-                            SafeArg.of("completed", completed));
-                break;
-            }
-        }
-        if (totalPolls > GOSSIP_SETTLE_POLL_SUCCESSES_REQUIRED)
-            logger.info("Gossip settled after {} extra polls; proceeding", SafeArg.of("extraPolls", totalPolls - GOSSIP_SETTLE_POLL_SUCCESSES_REQUIRED));
-        else
-            logger.info("No gossip backlog; proceeding");
     }
 
     public static void stop(String[] args) throws InterruptedException

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -834,7 +834,12 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     private boolean shouldBootstrap(boolean autoBootstrap)
     {
-        return autoBootstrap && !SystemKeyspace.bootstrapComplete() && !DatabaseDescriptor.getSeeds().contains(FBUtilities.getBroadcastAddress());
+        return autoBootstrap && !SystemKeyspace.bootstrapComplete() && !isSeed();
+    }
+
+    public static boolean isSeed()
+    {
+        return DatabaseDescriptor.getSeeds().contains(FBUtilities.getBroadcastAddress());
     }
 
     private void prepareToJoin() throws ConfigurationException
@@ -896,6 +901,27 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
     }
 
+    public void waitForSchema(int delay)
+    {
+        // first sleep the delay to make sure we see all our peers
+        Uninterruptibles.sleepUninterruptibly(delay, TimeUnit.MILLISECONDS);
+
+        // if our schema hasn't matched yet, keep sleeping until it does
+        // (post CASSANDRA-1391 we don't expect this to be necessary very often, but it doesn't hurt to be careful)
+        SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck();
+        List<InetAddress> ignoredEndpoints = replacing && !isReplacingSameAddress() ?
+                                             ImmutableList.of(DatabaseDescriptor.getReplaceAddress()) : ImmutableList.of();
+
+        while (!MigrationManager.isReadyForBootstrap() || !schemaAgreementCheck.isSchemaInAgreement(ignoredEndpoints))
+        {
+            setMode(Mode.JOINING, "waiting for schema information to complete", true);
+            logger.info(
+            "Local schema version {} is not consistent with peers, waiting for schema to become consistent",
+            SafeArg.of("localSchemaVersion", Schema.instance.getVersion().toString()));
+            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+        }
+    }
+
     private void joinTokenRing(int delay, boolean autoBootstrap, Collection<String> initialTokens)
     {
         joined = true;
@@ -952,23 +978,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                 setBootstrapState(SystemKeyspace.BootstrapState.IN_PROGRESS);
             }
             setMode(Mode.JOINING, "waiting for ring information", true);
-            // first sleep the delay to make sure we see all our peers
-            Uninterruptibles.sleepUninterruptibly(delay, TimeUnit.MILLISECONDS);
-
-            // if our schema hasn't matched yet, keep sleeping until it does
-            // (post CASSANDRA-1391 we don't expect this to be necessary very often, but it doesn't hurt to be careful)
-            SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck();
-            List<InetAddress> ignoredEndpoints = replacing && !isReplacingSameAddress() ?
-                                                 ImmutableList.of(DatabaseDescriptor.getReplaceAddress()) : ImmutableList.of();
-
-            while (!MigrationManager.isReadyForBootstrap() || !schemaAgreementCheck.isSchemaInAgreement(ignoredEndpoints))
-            {
-                setMode(Mode.JOINING, "waiting for schema information to complete", true);
-                logger.info(
-                    "Local schema version {} is not consistent with peers, waiting for schema to become consistent",
-                    SafeArg.of("localSchemaVersion", Schema.instance.getVersion().toString()));
-                Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
-            }
+            waitForSchema(delay);
             setMode(Mode.JOINING, "schema complete, ready to bootstrap", true);
             setMode(Mode.JOINING, "waiting for pending range calculation", true);
             PendingRangeCalculatorService.instance.blockUntilFinished();
@@ -995,7 +1005,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                     throw new UnsupportedOperationException(s);
                 }
                 setMode(Mode.JOINING, "getting bootstrap token", true);
-                bootstrapTokens = BootStrapper.getBootstrapTokens(tokenMetadata, FBUtilities.getBroadcastAddress());
+                bootstrapTokens = BootStrapper.getBootstrapTokens(tokenMetadata, FBUtilities.getBroadcastAddress(), delay, initialTokens);
             }
             else
             {
@@ -1072,22 +1082,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             bootstrapTokens = SystemKeyspace.getSavedTokens();
             if (bootstrapTokens.isEmpty())
             {
-                if (initialTokens.size() < 1)
-                {
-                    bootstrapTokens = BootStrapper.getRandomTokens(tokenMetadata, DatabaseDescriptor.getNumTokens());
-                    if (DatabaseDescriptor.getNumTokens() == 1)
-                        logger.warn("Generated random token {}. Random tokens will result in an unbalanced ring; see http://wiki.apache.org/cassandra/Operations",
-                                    SafeArg.of("token", bootstrapTokens));
-                    else
-                        logger.info("Generated random tokens. tokens are {}", SafeArg.of("tokens", bootstrapTokens));
-                }
-                else
-                {
-                    bootstrapTokens = new ArrayList<>(initialTokens.size());
-                    for (String token : initialTokens)
-                        bootstrapTokens.add(getPartitioner().getTokenFactory().fromString(token));
-                    logger.info("Saved tokens not found. Using configuration value: {}", SafeArg.of("tokens", bootstrapTokens));
-                }
+                bootstrapTokens = BootStrapper.getBootstrapTokens(tokenMetadata, FBUtilities.getBroadcastAddress(), delay, initialTokens);
             }
             else
             {
@@ -5323,7 +5318,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
         // Let's wait until gossip is finished before allowing requests
         instance.startGossiping();
-        CassandraDaemon.waitForGossipToSettle();
+        Gossiper.waitToSettle();
         instance.startTransports();
         instance.setOperationModeNormal();
     }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -960,7 +960,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck();
             List<InetAddress> ignoredEndpoints = replacing && !isReplacingSameAddress() ?
                                                  ImmutableList.of(DatabaseDescriptor.getReplaceAddress()) : ImmutableList.of();
-            
+
             while (!MigrationManager.isReadyForBootstrap() || !schemaAgreementCheck.isSchemaInAgreement(ignoredEndpoints))
             {
                 setMode(Mode.JOINING, "waiting for schema information to complete", true);
@@ -995,7 +995,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                     throw new UnsupportedOperationException(s);
                 }
                 setMode(Mode.JOINING, "getting bootstrap token", true);
-                bootstrapTokens = BootStrapper.getBootstrapTokens(tokenMetadata, initialTokens);
+                bootstrapTokens = BootStrapper.getBootstrapTokens(tokenMetadata, FBUtilities.getBroadcastAddress());
             }
             else
             {

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -55,7 +55,6 @@ import org.apache.cassandra.io.compress.CompressionParameters;
 import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.io.util.DataOutputBufferFixed;
 import org.apache.cassandra.io.util.FileUtils;
-import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.net.AsyncOneResponse;
 
 import com.fasterxml.jackson.core.JsonFactory;

--- a/src/java/org/apache/cassandra/utils/GuidGenerator.java
+++ b/src/java/org/apache/cassandra/utils/GuidGenerator.java
@@ -17,31 +17,39 @@
  */
 package org.apache.cassandra.utils;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.Random;
 
-public class GuidGenerator {
+public class GuidGenerator
+{
     private static final Random myRand;
     private static final SecureRandom mySecureRand;
     private static final String s_id;
 
-    static {
-        if (System.getProperty("java.security.egd") == null) {
+    static
+    {
+        if (System.getProperty("java.security.egd") == null)
+        {
             System.setProperty("java.security.egd", "file:/dev/urandom");
         }
         mySecureRand = new SecureRandom();
         long secureInitializer = mySecureRand.nextLong();
         myRand = new Random(secureInitializer);
-        try {
-            s_id = FBUtilities.getLocalAddress().toString();
+        try
+        {
+            s_id = InetAddress.getLocalHost().toString();
         }
-        catch (RuntimeException e) {
+        catch (UnknownHostException e)
+        {
             throw new AssertionError(e);
         }
     }
 
-    public static String guid() {
+    public static String guid()
+    {
         ByteBuffer array = guidAsBytes();
 
         StringBuilder sb = new StringBuilder();
@@ -58,7 +66,8 @@ public class GuidGenerator {
     public static String guidToString(byte[] bytes)
     {
         StringBuilder sb = new StringBuilder();
-        for (int j = 0; j < bytes.length; ++j) {
+        for (int j = 0; j < bytes.length; ++j)
+        {
             int b = bytes[j] & 0xFF;
             if (b < 0x10) sb.append('0');
             sb.append(Integer.toHexString(b));
@@ -67,11 +76,12 @@ public class GuidGenerator {
         return convertToStandardFormat( sb.toString() );
     }
 
-    public static ByteBuffer guidAsBytes(Random random, String hostId, long time)
+    public static ByteBuffer guidAsBytes(Random random, long time)
     {
         StringBuilder sbValueBeforeMD5 = new StringBuilder();
-        long rand = random.nextLong();
-        sbValueBeforeMD5.append(hostId)
+        long rand = 0;
+        rand = random.nextLong();
+        sbValueBeforeMD5.append(s_id)
                         .append(":")
                         .append(Long.toString(time))
                         .append(":")
@@ -83,7 +93,7 @@ public class GuidGenerator {
 
     public static ByteBuffer guidAsBytes()
     {
-        return guidAsBytes(myRand, s_id, System.currentTimeMillis());
+        return guidAsBytes(myRand, System.currentTimeMillis());
     }
 
     /*
@@ -91,7 +101,8 @@ public class GuidGenerator {
         * Example: C2FEEEAC-CFCD-11D1-8B05-00600806D9B6
     */
 
-    private static String convertToStandardFormat(String valueAfterMD5) {
+    private static String convertToStandardFormat(String valueAfterMD5)
+    {
         String raw = valueAfterMD5.toUpperCase();
         StringBuilder sb = new StringBuilder();
         sb.append(raw.substring(0, 8))

--- a/src/java/org/apache/cassandra/utils/GuidGenerator.java
+++ b/src/java/org/apache/cassandra/utils/GuidGenerator.java
@@ -67,13 +67,11 @@ public class GuidGenerator {
         return convertToStandardFormat( sb.toString() );
     }
 
-    public static ByteBuffer guidAsBytes()
+    public static ByteBuffer guidAsBytes(Random random, String hostId, long time)
     {
         StringBuilder sbValueBeforeMD5 = new StringBuilder();
-        long time = System.currentTimeMillis();
-        long rand = 0;
-        rand = myRand.nextLong();
-        sbValueBeforeMD5.append(s_id)
+        long rand = random.nextLong();
+        sbValueBeforeMD5.append(hostId)
                         .append(":")
                         .append(Long.toString(time))
                         .append(":")
@@ -81,6 +79,11 @@ public class GuidGenerator {
 
         String valueBeforeMD5 = sbValueBeforeMD5.toString();
         return ByteBuffer.wrap(FBUtilities.threadLocalMD5Digest().digest(valueBeforeMD5.getBytes()));
+    }
+
+    public static ByteBuffer guidAsBytes()
+    {
+        return guidAsBytes(myRand, s_id, System.currentTimeMillis());
     }
 
     /*

--- a/test/conf/logback-test.xml
+++ b/test/conf/logback-test.xml
@@ -66,7 +66,6 @@
 
   <root level="DEBUG">
     <appender-ref ref="ASYNCFILE" />
-    <appender-ref ref="STDERR" />
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/test/distributed/org/apache/cassandra/distributed/test/ResourceLeakTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ResourceLeakTest.java
@@ -37,7 +37,7 @@ import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.IInstanceConfig;
-import org.apache.cassandra.service.CassandraDaemon;
+import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.SigarLibrary;
 
@@ -148,7 +148,7 @@ public class ResourceLeakTest extends TestBaseImpl
             try (Cluster cluster = Cluster.build(numClusterNodes).withConfig(updater).start())
             {
                 if (cluster.get(1).config().has(GOSSIP)) // Wait for gossip to settle on the seed node
-                    cluster.get(1).runOnInstance(CassandraDaemon::waitForGossipToSettle);
+                    cluster.get(1).runOnInstance(Gossiper::waitToSettle);
 
                 init(cluster);
                 String tableName = "tbl" + loop;

--- a/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
+++ b/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
@@ -131,7 +131,7 @@ public class CommitLogStressTest
     ReplayPosition discardedPos;
 
     @BeforeClass
-    static public void initialize() throws IOException
+    public static void initialize() throws IOException
     {
         try (FileInputStream fis = new FileInputStream("CHANGES.txt"))
         {

--- a/test/long/org/apache/cassandra/dht/tokenallocator/AbstractReplicationAwareTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/AbstractReplicationAwareTokenAllocatorTest.java
@@ -523,12 +523,12 @@ abstract class AbstractReplicationAwareTokenAllocatorTest extends TokenAllocator
         SummaryStatistics unitStat = new SummaryStatistics();
         for (Map.Entry<Unit, Double> en : ownership.entrySet())
             unitStat.addValue(en.getValue() * inverseAverage / t.unitToTokens.get(en.getKey()).size());
-        su.update(unitStat);
+        su.update(unitStat, t.unitCount());
 
         SummaryStatistics tokenStat = new SummaryStatistics();
         for (Token tok : t.sortedTokens.keySet())
             tokenStat.addValue(replicatedTokenOwnership(tok, t.sortedTokens, t.strategy) * inverseAverage);
-        st.update(tokenStat);
+        st.update(tokenStat, t.unitCount());
 
         if (print)
         {

--- a/test/long/org/apache/cassandra/dht/tokenallocator/ByteOrderedReplicationAwareTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/ByteOrderedReplicationAwareTokenAllocatorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht.tokenallocator;
+
+import org.junit.Test;
+
+import org.apache.cassandra.Util;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
+
+public class ByteOrderedReplicationAwareTokenAllocatorTest extends AbstractReplicationAwareTokenAllocatorTest
+{
+    private static final int MAX_VNODE_COUNT = 64;
+
+    @Test
+    public void testExistingCluster()
+    {
+        super.testExistingCluster(new ByteOrderedPartitioner(), MAX_VNODE_COUNT);
+    }
+
+    @Test
+    public void testNewCluster()
+    {
+        Util.flakyTest(this::flakyTestNewCluster,
+                       2,
+                       "It tends to fail sometimes due to the random selection of the tokens in the first few nodes.");
+    }
+
+    private void flakyTestNewCluster()
+    {
+        testNewCluster(new ByteOrderedPartitioner(), MAX_VNODE_COUNT);
+    }
+}

--- a/test/long/org/apache/cassandra/dht/tokenallocator/Murmur3ReplicationAwareTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/Murmur3ReplicationAwareTokenAllocatorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht.tokenallocator;
+
+import org.junit.Test;
+
+import org.apache.cassandra.Util;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+
+public class Murmur3ReplicationAwareTokenAllocatorTest extends AbstractReplicationAwareTokenAllocatorTest
+{
+    private static final int MAX_VNODE_COUNT = 64;
+
+    @Test
+    public void testExistingCluster()
+    {
+        super.testExistingCluster(new Murmur3Partitioner(), MAX_VNODE_COUNT);
+    }
+
+    @Test
+    public void testNewCluster()
+    {
+        Util.flakyTest(this::flakyTestNewCluster,
+                       2,
+                       "It tends to fail sometimes due to the random selection of the tokens in the first few nodes.");
+    }
+
+    private void flakyTestNewCluster()
+    {
+        testNewCluster(new Murmur3Partitioner(), MAX_VNODE_COUNT);
+    }
+}

--- a/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht.tokenallocator;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.PriorityQueue;
+import java.util.Random;
+
+import com.google.common.collect.Maps;
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+import org.junit.Test;
+
+import junit.framework.Assert;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.RandomPartitioner;
+import org.apache.cassandra.dht.Token;
+
+public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
+{
+
+    @Test
+    public void testNewClusterWithMurmur3Partitioner()
+    {
+        testNewCluster(new Murmur3Partitioner());
+    }
+
+    @Test
+    public void testNewClusterWithRandomPartitioner()
+    {
+        testNewCluster(new RandomPartitioner());
+    }
+
+    private void testNewCluster(IPartitioner partitioner)
+    {
+        for (int perUnitCount = 1; perUnitCount <= MAX_VNODE_COUNT; perUnitCount *= 4)
+        {
+            testNewCluster(perUnitCount, fixedTokenCount, new NoReplicationStrategy(), partitioner);
+        }
+    }
+
+    public void testNewCluster(int perUnitCount, TokenCount tc, NoReplicationStrategy rs, IPartitioner partitioner)
+    {
+        System.out.println("Testing new cluster, target " + perUnitCount + " vnodes, replication " + rs);
+        final int targetClusterSize = TARGET_CLUSTER_SIZE;
+        NavigableMap<Token, Unit> tokenMap = Maps.newTreeMap();
+
+        NoReplicationTokenAllocator<Unit> t = new NoReplicationTokenAllocator<Unit>(tokenMap, rs, partitioner);
+        grow(t, targetClusterSize * 2 / 5, tc, perUnitCount, false);
+        grow(t, targetClusterSize, tc, perUnitCount, true);
+        System.out.println();
+    }
+
+    @Test
+    public void testExistingClusterWithMurmur3Partitioner()
+    {
+        testExistingCluster(new Murmur3Partitioner());
+    }
+
+    @Test
+    public void testExistingClusterWithRandomPartitioner()
+    {
+        testExistingCluster(new RandomPartitioner());
+    }
+
+    private void testExistingCluster(IPartitioner partitioner)
+    {
+        for (int perUnitCount = 1; perUnitCount <= MAX_VNODE_COUNT; perUnitCount *= 4)
+        {
+            testExistingCluster(perUnitCount, fixedTokenCount, new NoReplicationStrategy(), partitioner);
+        }
+    }
+
+    public NoReplicationTokenAllocator<Unit> randomWithTokenAllocator(NavigableMap<Token, Unit> map, NoReplicationStrategy rs,
+                                                                      int unitCount, TokenCount tc, int perUnitCount,
+                                                                      IPartitioner partitioner)
+    {
+        super.random(map, rs, unitCount, tc, perUnitCount, partitioner);
+        NoReplicationTokenAllocator<Unit> t = new NoReplicationTokenAllocator<Unit>(map, rs, partitioner);
+        t.createTokenInfos();
+        return t;
+    }
+
+    public void testExistingCluster(int perUnitCount, TokenCount tc, NoReplicationStrategy rs, IPartitioner partitioner)
+    {
+        System.out.println("Testing existing cluster, target " + perUnitCount + " vnodes, replication " + rs);
+        final int targetClusterSize = TARGET_CLUSTER_SIZE;
+        NavigableMap<Token, Unit> tokenMap = Maps.newTreeMap();
+        NoReplicationTokenAllocator<Unit> t = randomWithTokenAllocator(tokenMap, rs, targetClusterSize / 2, tc, perUnitCount, partitioner);
+        updateSummaryBeforeGrow(t);
+
+        grow(t, targetClusterSize * 9 / 10, tc, perUnitCount, false);
+        grow(t, targetClusterSize, tc, perUnitCount, true);
+        loseAndReplace(t, targetClusterSize / 10, tc, perUnitCount, partitioner);
+        System.out.println();
+    }
+
+    private void loseAndReplace(NoReplicationTokenAllocator<Unit> t, int howMany,
+                                TokenCount tc, int perUnitCount, IPartitioner partitioner)
+    {
+        int fullCount = t.sortedUnits.size();
+        System.out.format("Losing %d units. ", howMany);
+        for (int i = 0; i < howMany; ++i)
+        {
+            Unit u = t.unitFor(partitioner.getRandomToken(seededRand));
+            t.removeUnit(u);
+        }
+        // Grow half without verifying.
+        grow(t, (t.sortedUnits.size() + fullCount * 3) / 4, tc, perUnitCount, false);
+        // Metrics should be back to normal by now. Check that they remain so.
+        grow(t, fullCount, tc, perUnitCount, true);
+    }
+
+    private void updateSummaryBeforeGrow(NoReplicationTokenAllocator<Unit> t)
+    {
+        Summary su = new Summary();
+        Summary st = new Summary();
+        System.out.println("Before growing cluster: ");
+        updateSummary(t, su, st, true);
+    }
+
+    private void grow(NoReplicationTokenAllocator<Unit> t, int targetClusterSize, TokenCount tc, int perUnitCount, boolean verifyMetrics)
+    {
+        int size = t.sortedUnits.size();
+        Summary su = new Summary();
+        Summary st = new Summary();
+        Random rand = new Random(targetClusterSize + perUnitCount);
+        TestReplicationStrategy strategy = (TestReplicationStrategy) t.strategy;
+        if (size < targetClusterSize)
+        {
+            System.out.format("Adding %d unit(s) using %s...", targetClusterSize - size, t.toString());
+            long time = System.currentTimeMillis();
+
+            while (size < targetClusterSize)
+            {
+                int num_tokens = tc.tokenCount(perUnitCount, rand);
+                Unit unit = new Unit();
+                t.addUnit(unit, num_tokens);
+                ++size;
+                if (verifyMetrics)
+                    updateSummary(t, su, st, false);
+            }
+            System.out.format(" Done in %.3fs\n", (System.currentTimeMillis() - time) / 1000.0);
+
+            if (verifyMetrics)
+            {
+                updateSummary(t, su, st, true);
+                double maxExpected = 1.0 + tc.spreadExpectation() * strategy.spreadExpectation() / perUnitCount;
+                if (su.max > maxExpected)
+                {
+                    Assert.fail(String.format("Expected max unit size below %.4f, was %.4f", maxExpected, su.max));
+                }
+            }
+        }
+    }
+
+    private void updateSummary(NoReplicationTokenAllocator<Unit> t, Summary su, Summary st, boolean print)
+    {
+        int size = t.sortedTokens.size();
+
+        SummaryStatistics unitStat = new SummaryStatistics();
+        for (TokenAllocatorBase.Weighted<TokenAllocatorBase.UnitInfo> wu : t.sortedUnits)
+        {
+            unitStat.addValue(wu.weight * size / t.tokensInUnits.get(wu.value.unit).size());
+        }
+        su.update(unitStat);
+
+        SummaryStatistics tokenStat = new SummaryStatistics();
+        for (PriorityQueue<TokenAllocatorBase.Weighted<TokenAllocatorBase.TokenInfo>> tokens : t.tokensInUnits.values())
+        {
+            for (TokenAllocatorBase.Weighted<TokenAllocatorBase.TokenInfo> token : tokens)
+            {
+                tokenStat.addValue(token.weight);
+            }
+        }
+        st.update(tokenStat);
+
+        if (print)
+        {
+            System.out.format("Size %d(%d)   \tunit %s  token %s   %s\n",
+                              t.sortedUnits.size(), size,
+                              mms(unitStat),
+                              mms(tokenStat),
+                              t.strategy);
+            System.out.format("Worst intermediate unit\t%s  token %s\n", su, st);
+        }
+    }
+
+    static class NoReplicationStrategy implements TestReplicationStrategy
+    {
+        public List<Unit> getReplicas(Token token, NavigableMap<Token, Unit> sortedTokens)
+        {
+            return Collections.singletonList(sortedTokens.ceilingEntry(token).getValue());
+        }
+
+        public Token replicationStart(Token token, Unit unit, NavigableMap<Token, Unit> sortedTokens)
+        {
+            return sortedTokens.lowerKey(token);
+        }
+
+        public String toString()
+        {
+            return "No replication";
+        }
+
+        public void addUnit(Unit n)
+        {
+        }
+
+        public void removeUnit(Unit n)
+        {
+        }
+
+        public int replicas()
+        {
+            return 1;
+        }
+
+        public Object getGroup(Unit unit)
+        {
+            return unit;
+        }
+
+        public double spreadExpectation()
+        {
+            return 1;
+        }
+    }
+
+}

--- a/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
@@ -55,6 +55,7 @@ public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
         for (int perUnitCount = 1; perUnitCount <= MAX_VNODE_COUNT; perUnitCount *= 4)
         {
             testNewCluster(perUnitCount, fixedTokenCount, new NoReplicationStrategy(), partitioner);
+            testNewCluster(perUnitCount, fixedTokenCount, new ZeroReplicationStrategy(), partitioner);
         }
     }
 
@@ -87,6 +88,7 @@ public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
         for (int perUnitCount = 1; perUnitCount <= MAX_VNODE_COUNT; perUnitCount *= 4)
         {
             testExistingCluster(perUnitCount, fixedTokenCount, new NoReplicationStrategy(), partitioner);
+            testExistingCluster(perUnitCount, fixedTokenCount, new ZeroReplicationStrategy(), partitioner);
         }
     }
 
@@ -246,4 +248,11 @@ public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
         }
     }
 
+    static class ZeroReplicationStrategy extends NoReplicationStrategy
+    {
+        public int replicas()
+        {
+            return 0;
+        }
+    }
 }

--- a/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
@@ -184,7 +184,7 @@ public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
         {
             unitStat.addValue(wu.weight * size / t.tokensInUnits.get(wu.value.unit).size());
         }
-        su.update(unitStat);
+        su.update(unitStat, t.sortedUnits.size());
 
         SummaryStatistics tokenStat = new SummaryStatistics();
         for (PriorityQueue<TokenAllocatorBase.Weighted<TokenAllocatorBase.TokenInfo>> tokens : t.tokensInUnits.values())
@@ -194,7 +194,7 @@ public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
                 tokenStat.addValue(token.weight);
             }
         }
-        st.update(tokenStat);
+        st.update(tokenStat, t.sortedUnits.size());
 
         if (print)
         {

--- a/test/long/org/apache/cassandra/dht/tokenallocator/RandomReplicationAwareTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/RandomReplicationAwareTokenAllocatorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht.tokenallocator;
+
+import org.junit.Test;
+
+import org.apache.cassandra.Util;
+import org.apache.cassandra.dht.RandomPartitioner;
+
+public class RandomReplicationAwareTokenAllocatorTest extends AbstractReplicationAwareTokenAllocatorTest
+{
+    /** The maximum number of vnodes to use in the tests.
+     *  For RandomPartitioner we use a smaller number because
+     *  the tests take much longer and would otherwise timeout,
+     *  see CASSANDRA-12784.
+     * */
+    private static final int MAX_VNODE_COUNT = 16;
+
+    @Test
+    public void testExistingCluster()
+    {
+        testExistingCluster(new RandomPartitioner(), MAX_VNODE_COUNT);
+    }
+
+    @Test
+    public void testNewClusterr()
+    {
+        Util.flakyTest(this::flakyTestNewCluster,
+                       3,
+                       "It tends to fail sometimes due to the random selection of the tokens in the first few nodes.");
+    }
+
+    private void flakyTestNewCluster()
+    {
+        testNewCluster(new RandomPartitioner(), MAX_VNODE_COUNT);
+    }
+
+}

--- a/test/long/org/apache/cassandra/dht/tokenallocator/RandomReplicationAwareTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/RandomReplicationAwareTokenAllocatorTest.java
@@ -41,13 +41,6 @@ public class RandomReplicationAwareTokenAllocatorTest extends AbstractReplicatio
     @Test
     public void testNewClusterr()
     {
-        Util.flakyTest(this::flakyTestNewCluster,
-                       3,
-                       "It tends to fail sometimes due to the random selection of the tokens in the first few nodes.");
-    }
-
-    private void flakyTestNewCluster()
-    {
         testNewCluster(new RandomPartitioner(), MAX_VNODE_COUNT);
     }
 

--- a/test/long/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocatorTest.java
@@ -1,0 +1,700 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.dht.tokenallocator;
+
+import java.util.*;
+
+import junit.framework.Assert;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import org.apache.commons.math.stat.descriptive.SummaryStatistics;
+
+import org.junit.Test;
+
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Token;
+
+public class ReplicationAwareTokenAllocatorTest
+{
+    private static final int MAX_VNODE_COUNT = 64;
+
+    private static final int TARGET_CLUSTER_SIZE = 250;
+
+    interface TestReplicationStrategy extends ReplicationStrategy<Unit>
+    {
+        void addUnit(Unit n);
+
+        void removeUnit(Unit n);
+
+        /**
+         * Returns a list of all replica units for given token.
+         */
+        List<Unit> getReplicas(Token token, NavigableMap<Token, Unit> sortedTokens);
+
+        /**
+         * Returns the start of the token span that is replicated in this token.
+         * Note: Though this is not trivial to see, the replicated span is always contiguous. A token in the same
+         * group acts as a barrier; if one is not found the token replicates everything up to the replica'th distinct
+         * group seen in front of it.
+         */
+        Token replicationStart(Token token, Unit unit, NavigableMap<Token, Unit> sortedTokens);
+
+        /**
+         * Multiplier for the acceptable disbalance in the cluster. With some strategies it is harder to achieve good
+         * results.
+         */
+        public double spreadExpectation();
+    }
+
+    static class NoReplicationStrategy implements TestReplicationStrategy
+    {
+        public List<Unit> getReplicas(Token token, NavigableMap<Token, Unit> sortedTokens)
+        {
+            return Collections.singletonList(sortedTokens.ceilingEntry(token).getValue());
+        }
+
+        public Token replicationStart(Token token, Unit unit, NavigableMap<Token, Unit> sortedTokens)
+        {
+            return sortedTokens.lowerKey(token);
+        }
+
+        public String toString()
+        {
+            return "No replication";
+        }
+
+        public void addUnit(Unit n)
+        {
+        }
+
+        public void removeUnit(Unit n)
+        {
+        }
+
+        public int replicas()
+        {
+            return 1;
+        }
+
+        public boolean sameGroup(Unit n1, Unit n2)
+        {
+            return false;
+        }
+
+        public Object getGroup(Unit unit)
+        {
+            return unit;
+        }
+
+        public double spreadExpectation()
+        {
+            return 1;
+        }
+    }
+
+    static class SimpleReplicationStrategy implements TestReplicationStrategy
+    {
+        int replicas;
+
+        public SimpleReplicationStrategy(int replicas)
+        {
+            super();
+            this.replicas = replicas;
+        }
+
+        public List<Unit> getReplicas(Token token, NavigableMap<Token, Unit> sortedTokens)
+        {
+            List<Unit> endpoints = new ArrayList<Unit>(replicas);
+
+            token = sortedTokens.ceilingKey(token);
+            if (token == null)
+                token = sortedTokens.firstKey();
+            Iterator<Unit> iter = Iterables.concat(sortedTokens.tailMap(token, true).values(), sortedTokens.values()).iterator();
+            while (endpoints.size() < replicas)
+            {
+                if (!iter.hasNext())
+                    return endpoints;
+                Unit ep = iter.next();
+                if (!endpoints.contains(ep))
+                    endpoints.add(ep);
+            }
+            return endpoints;
+        }
+
+        public Token replicationStart(Token token, Unit unit, NavigableMap<Token, Unit> sortedTokens)
+        {
+            Set<Unit> seenUnits = Sets.newHashSet();
+            int unitsFound = 0;
+
+            for (Map.Entry<Token, Unit> en : Iterables.concat(
+                                                             sortedTokens.headMap(token, false).descendingMap().entrySet(),
+                                                             sortedTokens.descendingMap().entrySet()))
+            {
+                Unit n = en.getValue();
+                // Same group as investigated unit is a break; anything that could replicate in it replicates there.
+                if (n == unit)
+                    break;
+
+                if (seenUnits.add(n))
+                {
+                    if (++unitsFound == replicas)
+                        break;
+                }
+                token = en.getKey();
+            }
+            return token;
+        }
+
+        public void addUnit(Unit n)
+        {
+        }
+
+        public void removeUnit(Unit n)
+        {
+        }
+
+        public String toString()
+        {
+            return String.format("Simple %d replicas", replicas);
+        }
+
+        public int replicas()
+        {
+            return replicas;
+        }
+
+        public boolean sameGroup(Unit n1, Unit n2)
+        {
+            return false;
+        }
+
+        public Unit getGroup(Unit unit)
+        {
+            // The unit is the group.
+            return unit;
+        }
+
+        public double spreadExpectation()
+        {
+            return 1;
+        }
+    }
+
+    static abstract class GroupReplicationStrategy implements TestReplicationStrategy
+    {
+        final int replicas;
+        final Map<Unit, Integer> groupMap;
+
+        public GroupReplicationStrategy(int replicas)
+        {
+            this.replicas = replicas;
+            this.groupMap = Maps.newHashMap();
+        }
+
+        public List<Unit> getReplicas(Token token, NavigableMap<Token, Unit> sortedTokens)
+        {
+            List<Unit> endpoints = new ArrayList<Unit>(replicas);
+            BitSet usedGroups = new BitSet();
+
+            if (sortedTokens.isEmpty())
+                return endpoints;
+
+            token = sortedTokens.ceilingKey(token);
+            if (token == null)
+                token = sortedTokens.firstKey();
+            Iterator<Unit> iter = Iterables.concat(sortedTokens.tailMap(token, true).values(), sortedTokens.values()).iterator();
+            while (endpoints.size() < replicas)
+            {
+                // For simlicity assuming list can't be exhausted before finding all replicas.
+                Unit ep = iter.next();
+                int group = groupMap.get(ep);
+                if (!usedGroups.get(group))
+                {
+                    endpoints.add(ep);
+                    usedGroups.set(group);
+                }
+            }
+            return endpoints;
+        }
+
+        public Token lastReplicaToken(Token token, NavigableMap<Token, Unit> sortedTokens)
+        {
+            BitSet usedGroups = new BitSet();
+            int groupsFound = 0;
+
+            token = sortedTokens.ceilingKey(token);
+            if (token == null)
+                token = sortedTokens.firstKey();
+            for (Map.Entry<Token, Unit> en :
+            Iterables.concat(sortedTokens.tailMap(token, true).entrySet(),
+                             sortedTokens.entrySet()))
+            {
+                Unit ep = en.getValue();
+                int group = groupMap.get(ep);
+                if (!usedGroups.get(group))
+                {
+                    usedGroups.set(group);
+                    if (++groupsFound >= replicas)
+                        return en.getKey();
+                }
+            }
+            return token;
+        }
+
+        public Token replicationStart(Token token, Unit unit, NavigableMap<Token, Unit> sortedTokens)
+        {
+            // replicated ownership
+            int unitGroup = groupMap.get(unit);   // unit must be already added
+            BitSet seenGroups = new BitSet();
+            int groupsFound = 0;
+
+            for (Map.Entry<Token, Unit> en : Iterables.concat(
+                                                             sortedTokens.headMap(token, false).descendingMap().entrySet(),
+                                                             sortedTokens.descendingMap().entrySet()))
+            {
+                Unit n = en.getValue();
+                int ngroup = groupMap.get(n);
+                // Same group as investigated unit is a break; anything that could replicate in it replicates there.
+                if (ngroup == unitGroup)
+                    break;
+
+                if (!seenGroups.get(ngroup))
+                {
+                    if (++groupsFound == replicas)
+                        break;
+                    seenGroups.set(ngroup);
+                }
+                token = en.getKey();
+            }
+            return token;
+        }
+
+        public String toString()
+        {
+            Map<Integer, Integer> idToSize = instanceToCount(groupMap);
+            Map<Integer, Integer> sizeToCount = Maps.newTreeMap();
+            sizeToCount.putAll(instanceToCount(idToSize));
+            return String.format("%s strategy, %d replicas, group size to count %s", getClass().getSimpleName(), replicas, sizeToCount);
+        }
+
+        @Override
+        public int replicas()
+        {
+            return replicas;
+        }
+
+        public boolean sameGroup(Unit n1, Unit n2)
+        {
+            return groupMap.get(n1).equals(groupMap.get(n2));
+        }
+
+        public void removeUnit(Unit n)
+        {
+            groupMap.remove(n);
+        }
+
+        public Integer getGroup(Unit unit)
+        {
+            return groupMap.get(unit);
+        }
+
+        public double spreadExpectation()
+        {
+            return 1.5;   // Even balanced racks get disbalanced when they lose nodes.
+        }
+    }
+
+    private static <T> Map<T, Integer> instanceToCount(Map<?, T> map)
+    {
+        Map<T, Integer> idToCount = Maps.newHashMap();
+        for (Map.Entry<?, T> en : map.entrySet())
+        {
+            Integer old = idToCount.get(en.getValue());
+            idToCount.put(en.getValue(), old != null ? old + 1 : 1);
+        }
+        return idToCount;
+    }
+
+    /**
+     * Group strategy spreading units into a fixed number of groups.
+     */
+    static class FixedGroupCountReplicationStrategy extends GroupReplicationStrategy
+    {
+        int groupId;
+        int groupCount;
+
+        public FixedGroupCountReplicationStrategy(int replicas, int groupCount)
+        {
+            super(replicas);
+            assert groupCount >= replicas;
+            groupId = 0;
+            this.groupCount = groupCount;
+        }
+
+        public void addUnit(Unit n)
+        {
+            groupMap.put(n, groupId++ % groupCount);
+        }
+    }
+
+    /**
+     * Group strategy with a fixed number of units per group.
+     */
+    static class BalancedGroupReplicationStrategy extends GroupReplicationStrategy
+    {
+        int groupId;
+        int groupSize;
+
+        public BalancedGroupReplicationStrategy(int replicas, int groupSize)
+        {
+            super(replicas);
+            groupId = 0;
+            this.groupSize = groupSize;
+        }
+
+        public void addUnit(Unit n)
+        {
+            groupMap.put(n, groupId++ / groupSize);
+        }
+    }
+
+    static class UnbalancedGroupReplicationStrategy extends GroupReplicationStrategy
+    {
+        int groupId;
+        int nextSize;
+        int num;
+        int minGroupSize;
+        int maxGroupSize;
+        Random rand;
+
+        public UnbalancedGroupReplicationStrategy(int replicas, int minGroupSize, int maxGroupSize, Random rand)
+        {
+            super(replicas);
+            groupId = -1;
+            nextSize = 0;
+            num = 0;
+            this.maxGroupSize = maxGroupSize;
+            this.minGroupSize = minGroupSize;
+            this.rand = rand;
+        }
+
+        public void addUnit(Unit n)
+        {
+            if (++num > nextSize)
+            {
+                nextSize = minGroupSize + rand.nextInt(maxGroupSize - minGroupSize + 1);
+                ++groupId;
+                num = 0;
+            }
+            groupMap.put(n, groupId);
+        }
+
+        public double spreadExpectation()
+        {
+            return 2;
+        }
+    }
+
+    static Map<Unit, Double> evaluateReplicatedOwnership(ReplicationAwareTokenAllocator<Unit> t)
+    {
+        Map<Unit, Double> ownership = Maps.newHashMap();
+        Iterator<Token> it = t.sortedTokens.keySet().iterator();
+        if (!it.hasNext())
+            return ownership;
+
+        Token current = it.next();
+        while (it.hasNext())
+        {
+            Token next = it.next();
+            addOwnership(t, current, next, ownership);
+            current = next;
+        }
+        addOwnership(t, current, t.sortedTokens.firstKey(), ownership);
+
+        return ownership;
+    }
+
+    private static void addOwnership(ReplicationAwareTokenAllocator<Unit> t, Token current, Token next, Map<Unit, Double> ownership)
+    {
+        TestReplicationStrategy ts = (TestReplicationStrategy) t.strategy;
+        double size = current.size(next);
+        Token representative = t.partitioner.midpoint(current, next);
+        for (Unit n : ts.getReplicas(representative, t.sortedTokens))
+        {
+            Double v = ownership.get(n);
+            ownership.put(n, v != null ? v + size : size);
+        }
+    }
+
+    private static double replicatedTokenOwnership(Token token, NavigableMap<Token, Unit> sortedTokens, ReplicationStrategy<Unit> strategy)
+    {
+        TestReplicationStrategy ts = (TestReplicationStrategy) strategy;
+        Token next = sortedTokens.higherKey(token);
+        if (next == null)
+            next = sortedTokens.firstKey();
+        return ts.replicationStart(token, sortedTokens.get(token), sortedTokens).size(next);
+    }
+
+    static interface TokenCount
+    {
+        int tokenCount(int perUnitCount, Random rand);
+
+        double spreadExpectation();
+    }
+
+    static TokenCount fixedTokenCount = new TokenCount()
+    {
+        public int tokenCount(int perUnitCount, Random rand)
+        {
+            return perUnitCount;
+        }
+
+        public double spreadExpectation()
+        {
+            return 4;  // High tolerance to avoid flakiness.
+        }
+    };
+
+    static TokenCount varyingTokenCount = new TokenCount()
+    {
+        public int tokenCount(int perUnitCount, Random rand)
+        {
+            if (perUnitCount == 1) return 1;
+            // 25 to 175%
+            return rand.nextInt(perUnitCount * 3 / 2) + (perUnitCount + 3) / 4;
+        }
+
+        public double spreadExpectation()
+        {
+            return 8;  // High tolerance to avoid flakiness.
+        }
+    };
+
+    Murmur3Partitioner partitioner = new Murmur3Partitioner();
+    Random seededRand = new Random(2);
+
+    private void random(Map<Token, Unit> map, TestReplicationStrategy rs, int unitCount, TokenCount tc, int perUnitCount)
+    {
+        System.out.format("\nRandom generation of %d units with %d tokens each\n", unitCount, perUnitCount);
+        Random rand = seededRand;
+        for (int i = 0; i < unitCount; i++)
+        {
+            Unit unit = new Unit();
+            rs.addUnit(unit);
+            int tokens = tc.tokenCount(perUnitCount, rand);
+            for (int j = 0; j < tokens; j++)
+            {
+                map.put(partitioner.getRandomToken(rand), unit);
+            }
+        }
+    }
+
+    @Test
+    public void testExistingCluster()
+    {
+        for (int rf = 1; rf <= 5; ++rf)
+        {
+            for (int perUnitCount = 1; perUnitCount <= MAX_VNODE_COUNT; perUnitCount *= 4)
+            {
+                testExistingCluster(perUnitCount, fixedTokenCount, new SimpleReplicationStrategy(rf));
+                testExistingCluster(perUnitCount, varyingTokenCount, new SimpleReplicationStrategy(rf));
+                if (rf == 1) continue;  // Replication strategy doesn't matter for RF = 1.
+                for (int groupSize = 4; groupSize <= 64 && groupSize * rf * 4 < TARGET_CLUSTER_SIZE; groupSize *= 4)
+                {
+                    testExistingCluster(perUnitCount, fixedTokenCount, new BalancedGroupReplicationStrategy(rf, groupSize));
+                    testExistingCluster(perUnitCount, varyingTokenCount, new UnbalancedGroupReplicationStrategy(rf, groupSize / 2, groupSize * 2, seededRand));
+                }
+                testExistingCluster(perUnitCount, fixedTokenCount, new FixedGroupCountReplicationStrategy(rf, rf * 2));
+            }
+        }
+    }
+
+    public void testExistingCluster(int perUnitCount, TokenCount tc, TestReplicationStrategy rs)
+    {
+        System.out.println("Testing existing cluster, target " + perUnitCount + " vnodes, replication " + rs);
+        final int targetClusterSize = TARGET_CLUSTER_SIZE;
+        NavigableMap<Token, Unit> tokenMap = Maps.newTreeMap();
+
+        random(tokenMap, rs, targetClusterSize / 2, tc, perUnitCount);
+
+        ReplicationAwareTokenAllocator<Unit> t = new ReplicationAwareTokenAllocator<>(tokenMap, rs, partitioner);
+        grow(t, targetClusterSize * 9 / 10, tc, perUnitCount, false);
+        grow(t, targetClusterSize, tc, perUnitCount, true);
+        loseAndReplace(t, targetClusterSize / 10, tc, perUnitCount);
+        System.out.println();
+    }
+
+    @Test
+    public void testNewCluster()
+    {
+        for (int rf = 2; rf <= 5; ++rf)
+        {
+            for (int perUnitCount = 1; perUnitCount <= MAX_VNODE_COUNT; perUnitCount *= 4)
+            {
+                testNewCluster(perUnitCount, fixedTokenCount, new SimpleReplicationStrategy(rf));
+                testNewCluster(perUnitCount, varyingTokenCount, new SimpleReplicationStrategy(rf));
+                if (rf == 1) continue;  // Replication strategy doesn't matter for RF = 1.
+                for (int groupSize = 4; groupSize <= 64 && groupSize * rf * 8 < TARGET_CLUSTER_SIZE; groupSize *= 4)
+                {
+                    testNewCluster(perUnitCount, fixedTokenCount, new BalancedGroupReplicationStrategy(rf, groupSize));
+                    testNewCluster(perUnitCount, varyingTokenCount, new UnbalancedGroupReplicationStrategy(rf, groupSize / 2, groupSize * 2, seededRand));
+                }
+                testNewCluster(perUnitCount, fixedTokenCount, new FixedGroupCountReplicationStrategy(rf, rf * 2));
+            }
+        }
+    }
+
+    public void testNewCluster(int perUnitCount, TokenCount tc, TestReplicationStrategy rs)
+    {
+        System.out.println("Testing new cluster, target " + perUnitCount + " vnodes, replication " + rs);
+        final int targetClusterSize = TARGET_CLUSTER_SIZE;
+        NavigableMap<Token, Unit> tokenMap = Maps.newTreeMap();
+
+        ReplicationAwareTokenAllocator<Unit> t = new ReplicationAwareTokenAllocator<>(tokenMap, rs, partitioner);
+        grow(t, targetClusterSize * 2 / 5, tc, perUnitCount, false);
+        grow(t, targetClusterSize, tc, perUnitCount, true);
+        loseAndReplace(t, targetClusterSize / 5, tc, perUnitCount);
+        System.out.println();
+    }
+
+    private void loseAndReplace(ReplicationAwareTokenAllocator<Unit> t, int howMany, TokenCount tc, int perUnitCount)
+    {
+        int fullCount = t.unitCount();
+        System.out.format("Losing %d units. ", howMany);
+        for (int i = 0; i < howMany; ++i)
+        {
+            Unit u = t.unitFor(partitioner.getRandomToken(seededRand));
+            t.removeUnit(u);
+            ((TestReplicationStrategy) t.strategy).removeUnit(u);
+        }
+        // Grow half without verifying.
+        grow(t, (t.unitCount() + fullCount * 3) / 4, tc, perUnitCount, false);
+        // Metrics should be back to normal by now. Check that they remain so.
+        grow(t, fullCount, tc, perUnitCount, true);
+    }
+
+    static class Summary
+    {
+        double min = 1;
+        double max = 1;
+        double stddev = 0;
+
+        void update(SummaryStatistics stat)
+        {
+            min = Math.min(min, stat.getMin());
+            max = Math.max(max, stat.getMax());
+            stddev = Math.max(stddev, stat.getStandardDeviation());
+        }
+
+        public String toString()
+        {
+            return String.format("max %.2f min %.2f stddev %.4f", max, min, stddev);
+        }
+    }
+
+    public void grow(ReplicationAwareTokenAllocator<Unit> t, int targetClusterSize, TokenCount tc, int perUnitCount, boolean verifyMetrics)
+    {
+        int size = t.unitCount();
+        Summary su = new Summary();
+        Summary st = new Summary();
+        Random rand = new Random(targetClusterSize + perUnitCount);
+        TestReplicationStrategy strategy = (TestReplicationStrategy) t.strategy;
+        if (size < targetClusterSize)
+        {
+            System.out.format("Adding %d unit(s) using %s...", targetClusterSize - size, t.toString());
+            long time = System.currentTimeMillis();
+            while (size < targetClusterSize)
+            {
+                int tokens = tc.tokenCount(perUnitCount, rand);
+                Unit unit = new Unit();
+                strategy.addUnit(unit);
+                t.addUnit(unit, tokens);
+                ++size;
+                if (verifyMetrics)
+                    updateSummary(t, su, st, false);
+            }
+            System.out.format(" Done in %.3fs\n", (System.currentTimeMillis() - time) / 1000.0);
+            if (verifyMetrics)
+            {
+                updateSummary(t, su, st, true);
+                double maxExpected = 1.0 + tc.spreadExpectation() * strategy.spreadExpectation() / (perUnitCount * t.replicas);
+                if (su.max > maxExpected)
+                {
+                    Assert.fail(String.format("Expected max unit size below %.4f, was %.4f", maxExpected, su.max));
+                }
+                // We can't verify lower side range as small loads can't always be fixed.
+            }
+        }
+    }
+
+
+    private void updateSummary(ReplicationAwareTokenAllocator<Unit> t, Summary su, Summary st, boolean print)
+    {
+        int size = t.sortedTokens.size();
+        double inverseAverage = 1.0 * size / t.strategy.replicas();
+
+        Map<Unit, Double> ownership = evaluateReplicatedOwnership(t);
+        SummaryStatistics unitStat = new SummaryStatistics();
+        for (Map.Entry<Unit, Double> en : ownership.entrySet())
+            unitStat.addValue(en.getValue() * inverseAverage / t.unitToTokens.get(en.getKey()).size());
+        su.update(unitStat);
+
+        SummaryStatistics tokenStat = new SummaryStatistics();
+        for (Token tok : t.sortedTokens.keySet())
+            tokenStat.addValue(replicatedTokenOwnership(tok, t.sortedTokens, t.strategy) * inverseAverage);
+        st.update(tokenStat);
+
+        if (print)
+        {
+            System.out.format("Size %d(%d)   \tunit %s  token %s   %s\n",
+                              t.unitCount(), size,
+                              mms(unitStat),
+                              mms(tokenStat),
+                              t.strategy);
+            System.out.format("Worst intermediate unit\t%s  token %s\n", su, st);
+        }
+    }
+
+
+    private static String mms(SummaryStatistics s)
+    {
+        return String.format("max %.2f min %.2f stddev %.4f", s.getMax(), s.getMin(), s.getStandardDeviation());
+    }
+
+
+    int nextUnitId = 0;
+
+    final class Unit implements Comparable<Unit>
+    {
+        int unitId = nextUnitId++;
+
+        public String toString()
+        {
+            return Integer.toString(unitId);
+        }
+
+        @Override
+        public int compareTo(Unit o)
+        {
+            return Integer.compare(unitId, o.unitId);
+        }
+    }
+}

--- a/test/long/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocatorTest.java
@@ -29,6 +29,7 @@ import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
 import org.junit.Test;
 
+import org.apache.cassandra.Util;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.dht.Token;
 
@@ -545,6 +546,20 @@ public class ReplicationAwareTokenAllocatorTest
     @Test
     public void testNewCluster()
     {
+        Util.flakyTest(this::flakyTestNewCluster,
+                       5,
+                       "It tends to fail sometimes due to the random selection of the tokens in the first few nodes.");
+    }
+
+    public void flakyTestNewCluster()
+    {
+        // This test is flaky because the selection of the tokens for the first RF nodes (which is random, with an
+        // uncontrolled seed) can sometimes cause a pathological situation where the algorithm will find a (close to)
+        // ideal distribution of tokens for some number of nodes, which in turn will inevitably cause it to go into a
+        // bad (unacceptable to the test criteria) distribution after adding one more node.
+
+        // This should happen very rarely, unless something is broken in the token allocation code.
+
         for (int rf = 2; rf <= 5; ++rf)
         {
             for (int perUnitCount = 1; perUnitCount <= MAX_VNODE_COUNT; perUnitCount *= 4)

--- a/test/long/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocatorTest.java
@@ -25,7 +25,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-import org.apache.commons.math.stat.descriptive.SummaryStatistics;
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
 import org.junit.Test;
 

--- a/test/long/org/apache/cassandra/dht/tokenallocator/TokenAllocatorTestBase.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/TokenAllocatorTestBase.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht.tokenallocator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Random;
+
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Token;
+
+/**
+ * Base class for {@link NoReplicationTokenAllocatorTest} and {@link AbstractReplicationAwareTokenAllocatorTest},
+ */
+abstract class TokenAllocatorTestBase
+{
+    protected static final int TARGET_CLUSTER_SIZE = 250;
+    protected static final int MAX_VNODE_COUNT = 64;
+
+    interface TestReplicationStrategy extends ReplicationStrategy<Unit>
+    {
+        void addUnit(Unit n);
+
+        void removeUnit(Unit n);
+
+        /**
+         * Returns a list of all replica units for given token.
+         */
+        List<Unit> getReplicas(Token token, NavigableMap<Token, Unit> sortedTokens);
+
+        /**
+         * Returns the start of the token span that is replicated in this token.
+         * Note: Though this is not trivial to see, the replicated span is always contiguous. A token in the same
+         * group acts as a barrier; if one is not found the token replicates everything up to the replica'th distinct
+         * group seen in front of it.
+         */
+        Token replicationStart(Token token, Unit unit, NavigableMap<Token, Unit> sortedTokens);
+
+        /**
+         * Multiplier for the acceptable disbalance in the cluster. With some strategies it is harder to achieve good
+         * results.
+         */
+        double spreadExpectation();
+    }
+
+    interface TokenCount
+    {
+        int tokenCount(int perUnitCount, Random rand);
+
+        double spreadExpectation();
+    }
+
+    TokenCount fixedTokenCount = new TokenCount()
+    {
+        public int tokenCount(int perUnitCount, Random rand)
+        {
+            return perUnitCount;
+        }
+
+        public double spreadExpectation()
+        {
+            return 4;  // High tolerance to avoid flakiness.
+        }
+    };
+
+    TokenCount varyingTokenCount = new TokenCount()
+    {
+        public int tokenCount(int perUnitCount, Random rand)
+        {
+            if (perUnitCount == 1) return 1;
+            // 25 to 175%
+            return rand.nextInt(perUnitCount * 3 / 2) + (perUnitCount + 3) / 4;
+        }
+
+        public double spreadExpectation()
+        {
+            return 8;  // High tolerance to avoid flakiness.
+        }
+    };
+
+    Random seededRand = new Random(2);
+
+    public void random(Map<Token, Unit> map, TestReplicationStrategy rs,
+                              int unitCount, TokenCount tc, int perUnitCount, IPartitioner partitioner)
+    {
+        System.out.format("\nRandom generation of %d units with %d tokens each\n", unitCount, perUnitCount);
+        Random rand = seededRand;
+        for (int i = 0; i < unitCount; i++)
+        {
+            Unit unit = new Unit();
+            rs.addUnit(unit);
+            int tokens = tc.tokenCount(perUnitCount, rand);
+            for (int j = 0; j < tokens; j++)
+            {
+                map.put(partitioner.getRandomToken(rand), unit);
+            }
+        }
+    }
+
+    public String mms(SummaryStatistics s)
+    {
+        return String.format("max %.2f min %.2f stddev %.4f", s.getMax(), s.getMin(), s.getStandardDeviation());
+    }
+
+    class Summary
+    {
+        double min = 1;
+        double max = 1;
+        double stddev = 0;
+
+        void update(SummaryStatistics stat)
+        {
+            min = Math.min(min, stat.getMin());
+            max = Math.max(max, stat.getMax());
+            stddev = Math.max(stddev, stat.getStandardDeviation());
+        }
+
+        public String toString()
+        {
+            return String.format("max %.2f min %.2f stddev %.4f", max, min, stddev);
+        }
+    }
+
+    int nextUnitId = 0;
+
+    final class Unit implements Comparable<Unit>
+    {
+        int unitId = nextUnitId++;
+
+        public String toString()
+        {
+            return Integer.toString(unitId);
+        }
+
+        @Override
+        public int compareTo(Unit o)
+        {
+            return Integer.compare(unitId, o.unitId);
+        }
+    }
+}

--- a/test/long/org/apache/cassandra/dht/tokenallocator/TokenAllocatorTestBase.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/TokenAllocatorTestBase.java
@@ -124,19 +124,34 @@ abstract class TokenAllocatorTestBase
     class Summary
     {
         double min = 1;
+        int minAt = -1;
         double max = 1;
+        int maxAt = - 1;
         double stddev = 0;
+        int stddevAt = -1;
 
-        void update(SummaryStatistics stat)
+        void update(SummaryStatistics stat, int point)
         {
-            min = Math.min(min, stat.getMin());
-            max = Math.max(max, stat.getMax());
-            stddev = Math.max(stddev, stat.getStandardDeviation());
+            if (stat.getMin() <= min)
+            {
+                min = Math.min(min, stat.getMin());
+                minAt = point;
+            }
+            if (stat.getMax() >= max)
+            {
+                max = Math.max(max, stat.getMax());
+                maxAt = point;
+            }
+            if (stat.getStandardDeviation() >= stddev)
+            {
+                stddev = Math.max(stddev, stat.getStandardDeviation());
+                stddevAt = point;
+            }
         }
 
         public String toString()
         {
-            return String.format("max %.2f min %.2f stddev %.4f", max, min, stddev);
+            return String.format("max %.4f @%d min %.4f @%d stddev %.4f @%d", max, maxAt, min, minAt, stddev, stddevAt);
         }
     }
 

--- a/test/long/org/apache/cassandra/io/compress/CompressorPerformance.java
+++ b/test/long/org/apache/cassandra/io/compress/CompressorPerformance.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ThreadLocalRandom;
 public class CompressorPerformance
 {
 
-    static public void testPerformances() throws IOException
+    public static void testPerformances() throws IOException
     {
         for (ICompressor compressor: new ICompressor[] {
                 SnappyCompressor.instance,  // warm up
@@ -61,7 +61,7 @@ public class CompressorPerformance
     static ByteBuffer dataSource;
     static int bufLen;
 
-    static private void testPerformance(ICompressor compressor, BufferType in, BufferType out) throws IOException
+    private static void testPerformance(ICompressor compressor, BufferType in, BufferType out) throws IOException
     {
         int len = dataSource.capacity();
         int bufLen = compressor.initialCompressedBufferLength(len);

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -30,6 +30,13 @@ import java.util.concurrent.Future;
 
 import com.google.common.base.Supplier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.config.ColumnDefinition;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.composites.*;
 import org.apache.cassandra.db.compaction.AbstractCompactionTask;
@@ -56,7 +63,9 @@ import static org.junit.Assert.assertTrue;
 
 public class Util
 {
-    private static List<UUID> hostIdPool = new ArrayList<UUID>();
+    private static final Logger logger = LoggerFactory.getLogger(Util.class);
+
+    private static List<UUID> hostIdPool = new ArrayList<>();
 
     public static DecoratedKey dk(String key)
     {
@@ -416,10 +425,9 @@ public class Util
         AssertionError e = runCatchingAssertionError(test);
         if (e == null)
             return;     // success
-        System.err.format("Test failed. %s%n"
-                          + "Re-running %d times to verify it isn't failing more often than it should.%n"
-                          + "Failure was: %s%n", message, rerunsOnFailure, e);
-        e.printStackTrace();
+
+        logger.info("Test failed. {}", message, e);
+        logger.info("Re-running {} times to verify it isn't failing more often than it should.", rerunsOnFailure);
 
         int rerunsFailed = 0;
         for (int i = 0; i < rerunsOnFailure; ++i)
@@ -429,14 +437,16 @@ public class Util
             {
                 ++rerunsFailed;
                 e.addSuppressed(t);
+
+                logger.debug("Test failed again, total num failures: {}", rerunsFailed, t);
             }
         }
         if (rerunsFailed > 0)
         {
-            System.err.format("Test failed in %d of the %d reruns.%n", rerunsFailed, rerunsOnFailure);
+            logger.error("Test failed in {} of the {} reruns.", rerunsFailed, rerunsOnFailure);
             throw e;
         }
 
-        System.err.println("All reruns succeeded. Failure treated as flake.");
+        logger.info("All reruns succeeded. Failure treated as flake.");
     }
 }

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -383,4 +383,60 @@ public class Util
     {
         thread.join(10000);
     }
+
+    public static AssertionError runCatchingAssertionError(Runnable test)
+    {
+        try
+        {
+            test.run();
+            return null;
+        }
+        catch (AssertionError e)
+        {
+            return e;
+        }
+    }
+
+    /**
+     * Wrapper function used to run a test that can sometimes flake for uncontrollable reasons.
+     *
+     * If the given test fails on the first run, it is executed the given number of times again, expecting all secondary
+     * runs to succeed. If they do, the failure is understood as a flake and the test is treated as passing.
+     *
+     * Do not use this if the test is deterministic and its success is not influenced by external factors (such as time,
+     * selection of random seed, network failures, etc.). If the test can be made independent of such factors, it is
+     * probably preferable to do so rather than use this method.
+     *
+     * @param test The test to run.
+     * @param rerunsOnFailure How many times to re-run it if it fails. All reruns must pass.
+     * @param message Message to send to System.err on initial failure.
+     */
+    public static void flakyTest(Runnable test, int rerunsOnFailure, String message)
+    {
+        AssertionError e = runCatchingAssertionError(test);
+        if (e == null)
+            return;     // success
+        System.err.format("Test failed. %s%n"
+                          + "Re-running %d times to verify it isn't failing more often than it should.%n"
+                          + "Failure was: %s%n", message, rerunsOnFailure, e);
+        e.printStackTrace();
+
+        int rerunsFailed = 0;
+        for (int i = 0; i < rerunsOnFailure; ++i)
+        {
+            AssertionError t = runCatchingAssertionError(test);
+            if (t != null)
+            {
+                ++rerunsFailed;
+                e.addSuppressed(t);
+            }
+        }
+        if (rerunsFailed > 0)
+        {
+            System.err.format("Test failed in %d of the %d reruns.%n", rerunsFailed, rerunsOnFailure);
+            throw e;
+        }
+
+        System.err.println("All reruns succeeded. Failure treated as flake.");
+    }
 }

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogTestReplayer.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogTestReplayer.java
@@ -36,7 +36,7 @@ import org.apache.cassandra.io.util.FastByteArrayInputStream;
  */
 public class CommitLogTestReplayer extends CommitLogReplayer
 {
-    static public void examineCommitLog(Predicate<Mutation> processor) throws IOException
+    public static void examineCommitLog(Predicate<Mutation> processor) throws IOException
     {
         CommitLog.instance.sync(true);
 

--- a/test/unit/org/apache/cassandra/dht/AllocatablePartitionerTestCase.java
+++ b/test/unit/org/apache/cassandra/dht/AllocatablePartitionerTestCase.java
@@ -22,12 +22,11 @@ package org.apache.cassandra.dht;
 
 import org.junit.Test;
 
-public class Murmur3PartitionerTest extends PartitionerTestCase
+public abstract class AllocatablePartitionerTestCase extends PartitionerTestCase
 {
-    public void initPartitioner()
-    {
-        partitioner = Murmur3Partitioner.instance;
-    }
+    public abstract void initPartitioner();
+
+    public abstract Token almostMax();
 
     @Override
     protected void midpointMinimumTestCase()
@@ -57,7 +56,7 @@ public class Murmur3PartitionerTest extends PartitionerTestCase
     @Test
     public void testSplitExceedMaximumCase()
     {
-        Murmur3Partitioner.LongToken left = new Murmur3Partitioner.LongToken(Long.MAX_VALUE - 100);
+        Token left = almostMax();
         assertSplit(left, tok("a"), 16);
     }
 }

--- a/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
+++ b/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
@@ -18,13 +18,22 @@
 */
 package org.apache.cassandra.dht;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import com.google.common.collect.Lists;
+
+import org.apache.commons.math.stat.descriptive.SummaryStatistics;
+
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,23 +43,33 @@ import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.dht.tokenallocator.TokenAllocation;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.gms.IFailureDetectionEventListener;
 import org.apache.cassandra.gms.IFailureDetector;
 import org.apache.cassandra.locator.TokenMetadata;
 import org.apache.cassandra.service.StorageService;
-
-import static org.junit.Assert.*;
+import org.apache.cassandra.utils.FBUtilities;
 
 @RunWith(OrderedJUnit4ClassRunner.class)
 public class BootStrapperTest
 {
+    static IPartitioner oldPartitioner;
+
     @BeforeClass
     public static void setup() throws ConfigurationException
     {
+        oldPartitioner = DatabaseDescriptor.getPartitioner();
+        DatabaseDescriptor.setPartitioner(Murmur3Partitioner.instance);
         SchemaLoader.startGossiper();
         SchemaLoader.prepareServer();
         SchemaLoader.schemaDefinition("BootStrapperTest");
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        DatabaseDescriptor.setPartitioner(oldPartitioner);
     }
 
     @Test
@@ -112,14 +131,81 @@ public class BootStrapperTest
 
     private void generateFakeEndpoints(int numOldNodes) throws UnknownHostException
     {
-        TokenMetadata tmd = StorageService.instance.getTokenMetadata();
+        generateFakeEndpoints(StorageService.instance.getTokenMetadata(), numOldNodes, 1);
+    }
+
+    private void generateFakeEndpoints(TokenMetadata tmd, int numOldNodes, int numVNodes) throws UnknownHostException
+    {
         tmd.clearUnsafe();
         IPartitioner p = StorageService.getPartitioner();
 
         for (int i = 1; i <= numOldNodes; i++)
         {
             // leave .1 for myEndpoint
-            tmd.updateNormalToken(p.getRandomToken(), InetAddress.getByName("127.0.0." + (i + 1)));
+            InetAddress addr = InetAddress.getByName("127.0.0." + (i + 1));
+            List<Token> tokens = Lists.newArrayListWithCapacity(numVNodes);
+            for (int j = 0; j < numVNodes; ++j)
+                tokens.add(p.getRandomToken());
+            
+            tmd.updateNormalTokens(tokens, addr);
         }
+    }
+    
+    @Test
+    public void testAllocateTokens() throws UnknownHostException
+    {
+        int vn = 16;
+        String ks = "BootStrapperTestKeyspace3";
+        TokenMetadata tm = new TokenMetadata();
+        generateFakeEndpoints(tm, 10, vn);
+        InetAddress addr = FBUtilities.getBroadcastAddress();
+        allocateTokensForNode(vn, ks, tm, addr);
+    }
+
+    private void allocateTokensForNode(int vn, String ks, TokenMetadata tm, InetAddress addr)
+    {
+        SummaryStatistics os = TokenAllocation.replicatedOwnershipStats(tm, Keyspace.open(ks).getReplicationStrategy(), addr);
+        Collection<Token> tokens = BootStrapper.allocateTokens(tm, addr, ks, vn);
+        assertEquals(vn, tokens.size());
+        tm.updateNormalTokens(tokens, addr);
+        SummaryStatistics ns = TokenAllocation.replicatedOwnershipStats(tm, Keyspace.open(ks).getReplicationStrategy(), addr);
+        verifyImprovement(os, ns);
+    }
+
+    private void verifyImprovement(SummaryStatistics os, SummaryStatistics ns)
+    {
+        if (ns.getStandardDeviation() > os.getStandardDeviation())
+        {
+            fail(String.format("Token allocation unexpectedly increased standard deviation.\nStats before:\n%s\nStats after:\n%s", os, ns));
+        }
+    }
+
+    
+    @Test
+    public void testAllocateTokensMultipleKeyspaces() throws UnknownHostException
+    {
+        // TODO: This scenario isn't supported very well. Investigate a multi-keyspace version of the algorithm.
+        int vn = 16;
+        String ks3 = "BootStrapperTestKeyspace4"; // RF = 3
+        String ks2 = "BootStrapperTestKeyspace5"; // RF = 2
+
+        TokenMetadata tm = new TokenMetadata();
+        generateFakeEndpoints(tm, 10, vn);
+        
+        InetAddress dcaddr = FBUtilities.getBroadcastAddress();
+        SummaryStatistics os3 = TokenAllocation.replicatedOwnershipStats(tm, Keyspace.open(ks3).getReplicationStrategy(), dcaddr);
+        SummaryStatistics os2 = TokenAllocation.replicatedOwnershipStats(tm, Keyspace.open(ks2).getReplicationStrategy(), dcaddr);
+        String cks = ks3;
+        String nks = ks2;
+        for (int i=11; i<=20; ++i)
+        {
+            allocateTokensForNode(vn, cks, tm, InetAddress.getByName("127.0.0." + (i + 1)));
+            String t = cks; cks = nks; nks = t;
+        }
+        
+        SummaryStatistics ns3 = TokenAllocation.replicatedOwnershipStats(tm, Keyspace.open(ks3).getReplicationStrategy(), dcaddr);
+        SummaryStatistics ns2 = TokenAllocation.replicatedOwnershipStats(tm, Keyspace.open(ks2).getReplicationStrategy(), dcaddr);
+        verifyImprovement(os3, ns3);
+        verifyImprovement(os2, ns2);
     }
 }

--- a/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
+++ b/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 import com.google.common.collect.Lists;
 
-import org.apache.commons.math.stat.descriptive.SummaryStatistics;
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
+++ b/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
@@ -226,7 +226,7 @@ public class BootStrapperTest
     private void allocateTokensForNode(int vn, String ks, TokenMetadata tm, InetAddress addr)
     {
         SummaryStatistics os = TokenAllocation.replicatedOwnershipStats(tm.cloneOnlyTokenMap(), Keyspace.open(ks).getReplicationStrategy(), addr);
-        Collection<Token> tokens = BootStrapper.allocateTokens(tm, addr, ks, vn);
+        Collection<Token> tokens = BootStrapper.allocateTokens(tm, addr, ks, vn, 0);
         assertEquals(vn, tokens.size());
         tm.updateNormalTokens(tokens, addr);
         SummaryStatistics ns = TokenAllocation.replicatedOwnershipStats(tm.cloneOnlyTokenMap(), Keyspace.open(ks).getReplicationStrategy(), addr);

--- a/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
+++ b/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
@@ -196,7 +196,7 @@ public class BootStrapperTest
             int vn = 16;
             String ks = "BootStrapperTestNTSKeyspace" + rackCount + replicas;
             String dc = "1";
-            SchemaLoader.createKeyspace(ks, NetworkTopologyStrategy.class, ImmutableMap.of(dc, "15"), SchemaLoader.standardCFMD(ks, "Standard1"));
+            SchemaLoader.createKeyspace(ks, NetworkTopologyStrategy.class, ImmutableMap.of(dc, String.valueOf(replicas)), SchemaLoader.standardCFMD(ks, "Standard1"));
             TokenMetadata tm = StorageService.instance.getTokenMetadata();
             tm.clearUnsafe();
             for (int i = 0; i < rackCount; ++i)

--- a/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
+++ b/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.dht;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import org.junit.Assert;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -27,7 +28,9 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -144,6 +147,8 @@ public class BootStrapperTest
         generateFakeEndpoints(tmd, numOldNodes, numVNodes, "0", "0");
     }
 
+    Random rand = new Random(1);
+
     private void generateFakeEndpoints(TokenMetadata tmd, int numOldNodes, int numVNodes, String dc, String rack) throws UnknownHostException
     {
         IPartitioner p = StorageService.getPartitioner();
@@ -154,7 +159,7 @@ public class BootStrapperTest
             InetAddress addr = InetAddress.getByName("127." + dc + "." + rack + "." + (i + 1));
             List<Token> tokens = Lists.newArrayListWithCapacity(numVNodes);
             for (int j = 0; j < numVNodes; ++j)
-                tokens.add(p.getRandomToken());
+                tokens.add(p.getRandomToken(rand));
             
             tmd.updateNormalTokens(tokens, addr);
         }
@@ -260,7 +265,54 @@ public class BootStrapperTest
         }
     }
 
-    
+    @Test
+    public void testAllocateTokensRfEqRacks() throws UnknownHostException
+    {
+        IEndpointSnitch oldSnitch = DatabaseDescriptor.getEndpointSnitch();
+        try
+        {
+            DatabaseDescriptor.setEndpointSnitch(new RackInferringSnitch());
+            int vn = 8;
+            int replicas = 3;
+            int rackCount = replicas;
+            String ks = "BootStrapperTestNTSKeyspaceRfEqRacks";
+            String dc = "1";
+
+            TokenMetadata metadata = StorageService.instance.getTokenMetadata();
+            metadata.clearUnsafe();
+            metadata.updateHostId(UUID.randomUUID(), InetAddress.getByName("127.1.0.99"));
+            metadata.updateHostId(UUID.randomUUID(), InetAddress.getByName("127.15.0.99"));
+
+            SchemaLoader.createKeyspace(ks, NetworkTopologyStrategy.class, ImmutableMap.of(dc, "15"), SchemaLoader.standardCFMD(ks, "Standard1"));
+            int base = 5;
+            for (int i = 0; i < rackCount; ++i)
+                generateFakeEndpoints(metadata, base << i, vn, dc, Integer.toString(i));     // unbalanced racks
+
+            int cnt = 5;
+            for (int i = 0; i < cnt; ++i)
+                allocateTokensForNode(vn, ks, metadata, InetAddress.getByName("127." + dc + ".0." + (99 + i)));
+
+            double target = 1.0 / (base + cnt);
+            double permittedOver = 1.0 / (2 * vn + 1) + 0.01;
+
+            Map<InetAddress, Float> ownership = StorageService.instance.effectiveOwnership(ks);
+            boolean failed = false;
+            for (Map.Entry<InetAddress, Float> o : ownership.entrySet())
+            {
+                int rack = o.getKey().getAddress()[2];
+                if (rack != 0)
+                    continue;
+
+                System.out.format("Node %s owns %f ratio to optimal %.2f\n", o.getKey(), o.getValue(), o.getValue() / target);
+                if (o.getValue()/target > 1 + permittedOver)
+                    failed = true;
+            }
+            Assert.assertFalse(String.format("One of the nodes in the rack has over %.2f%% overutilization.", permittedOver * 100), failed);
+        } finally {
+            DatabaseDescriptor.setEndpointSnitch(oldSnitch);
+        }
+    }
+
     @Test
     public void testAllocateTokensMultipleKeyspaces() throws UnknownHostException
     {

--- a/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
+++ b/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
@@ -47,6 +48,9 @@ import org.apache.cassandra.dht.tokenallocator.TokenAllocation;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.gms.IFailureDetectionEventListener;
 import org.apache.cassandra.gms.IFailureDetector;
+import org.apache.cassandra.locator.IEndpointSnitch;
+import org.apache.cassandra.locator.NetworkTopologyStrategy;
+import org.apache.cassandra.locator.RackInferringSnitch;
 import org.apache.cassandra.locator.TokenMetadata;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
@@ -137,12 +141,17 @@ public class BootStrapperTest
     private void generateFakeEndpoints(TokenMetadata tmd, int numOldNodes, int numVNodes) throws UnknownHostException
     {
         tmd.clearUnsafe();
+        generateFakeEndpoints(tmd, numOldNodes, numVNodes, "0", "0");
+    }
+
+    private void generateFakeEndpoints(TokenMetadata tmd, int numOldNodes, int numVNodes, String dc, String rack) throws UnknownHostException
+    {
         IPartitioner p = StorageService.getPartitioner();
 
         for (int i = 1; i <= numOldNodes; i++)
         {
             // leave .1 for myEndpoint
-            InetAddress addr = InetAddress.getByName("127.0.0." + (i + 1));
+            InetAddress addr = InetAddress.getByName("127." + dc + "." + rack + "." + (i + 1));
             List<Token> tokens = Lists.newArrayListWithCapacity(numVNodes);
             for (int j = 0; j < numVNodes; ++j)
                 tokens.add(p.getRandomToken());
@@ -160,6 +169,58 @@ public class BootStrapperTest
         generateFakeEndpoints(tm, 10, vn);
         InetAddress addr = FBUtilities.getBroadcastAddress();
         allocateTokensForNode(vn, ks, tm, addr);
+    }
+
+    public void testAllocateTokensNetworkStrategy(int rackCount, int replicas) throws UnknownHostException
+    {
+        IEndpointSnitch oldSnitch = DatabaseDescriptor.getEndpointSnitch();
+        try
+        {
+            DatabaseDescriptor.setEndpointSnitch(new RackInferringSnitch());
+            int vn = 16;
+            String ks = "BootStrapperTestNTSKeyspace" + rackCount + replicas;
+            String dc = "1";
+            SchemaLoader.createKeyspace(ks, NetworkTopologyStrategy.class, ImmutableMap.of(dc, "15"), SchemaLoader.standardCFMD(ks, "Standard1"));
+            TokenMetadata tm = new TokenMetadata();
+            tm.clearUnsafe();
+            for (int i = 0; i < rackCount; ++i)
+                generateFakeEndpoints(tm, 10, vn, dc, Integer.toString(i));
+            InetAddress addr = InetAddress.getByName("127." + dc + ".0.99");
+            allocateTokensForNode(vn, ks, tm, addr);
+            // Note: Not matching replication factor in second datacentre, but this should not affect us.
+        } finally {
+            DatabaseDescriptor.setEndpointSnitch(oldSnitch);
+        }
+    }
+
+    @Test
+    public void testAllocateTokensNetworkStrategyOneRack() throws UnknownHostException
+    {
+        testAllocateTokensNetworkStrategy(1, 3);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void testAllocateTokensNetworkStrategyTwoRacks() throws UnknownHostException
+    {
+        testAllocateTokensNetworkStrategy(2, 3);
+    }
+
+    @Test
+    public void testAllocateTokensNetworkStrategyThreeRacks() throws UnknownHostException
+    {
+        testAllocateTokensNetworkStrategy(3, 3);
+    }
+
+    @Test
+    public void testAllocateTokensNetworkStrategyFiveRacks() throws UnknownHostException
+    {
+        testAllocateTokensNetworkStrategy(5, 3);
+    }
+
+    @Test
+    public void testAllocateTokensNetworkStrategyOneRackOneReplica() throws UnknownHostException
+    {
+        testAllocateTokensNetworkStrategy(1, 1);
     }
 
     private void allocateTokensForNode(int vn, String ks, TokenMetadata tm, InetAddress addr)

--- a/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
+++ b/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
@@ -283,7 +283,7 @@ public class BootStrapperTest
             metadata.updateHostId(UUID.randomUUID(), InetAddress.getByName("127.1.0.99"));
             metadata.updateHostId(UUID.randomUUID(), InetAddress.getByName("127.15.0.99"));
 
-            SchemaLoader.createKeyspace(ks, NetworkTopologyStrategy.class, ImmutableMap.of(dc, "15"), SchemaLoader.standardCFMD(ks, "Standard1"));
+            SchemaLoader.createKeyspace(ks, NetworkTopologyStrategy.class, ImmutableMap.of(dc, String.valueOf(replicas)), SchemaLoader.standardCFMD(ks, "Standard1"));
             int base = 5;
             for (int i = 0; i < rackCount; ++i)
                 generateFakeEndpoints(metadata, base << i, vn, dc, Integer.toString(i));     // unbalanced racks

--- a/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
+++ b/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
@@ -181,7 +181,7 @@ public class BootStrapperTest
             String ks = "BootStrapperTestNTSKeyspace" + rackCount + replicas;
             String dc = "1";
             SchemaLoader.createKeyspace(ks, NetworkTopologyStrategy.class, ImmutableMap.of(dc, "15"), SchemaLoader.standardCFMD(ks, "Standard1"));
-            TokenMetadata tm = new TokenMetadata();
+            TokenMetadata tm = StorageService.instance.getTokenMetadata();
             tm.clearUnsafe();
             for (int i = 0; i < rackCount; ++i)
                 generateFakeEndpoints(tm, 10, vn, dc, Integer.toString(i));
@@ -225,11 +225,11 @@ public class BootStrapperTest
 
     private void allocateTokensForNode(int vn, String ks, TokenMetadata tm, InetAddress addr)
     {
-        SummaryStatistics os = TokenAllocation.replicatedOwnershipStats(tm, Keyspace.open(ks).getReplicationStrategy(), addr);
+        SummaryStatistics os = TokenAllocation.replicatedOwnershipStats(tm.cloneOnlyTokenMap(), Keyspace.open(ks).getReplicationStrategy(), addr);
         Collection<Token> tokens = BootStrapper.allocateTokens(tm, addr, ks, vn);
         assertEquals(vn, tokens.size());
         tm.updateNormalTokens(tokens, addr);
-        SummaryStatistics ns = TokenAllocation.replicatedOwnershipStats(tm, Keyspace.open(ks).getReplicationStrategy(), addr);
+        SummaryStatistics ns = TokenAllocation.replicatedOwnershipStats(tm.cloneOnlyTokenMap(), Keyspace.open(ks).getReplicationStrategy(), addr);
         verifyImprovement(os, ns);
     }
 

--- a/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
+++ b/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
@@ -171,6 +171,17 @@ public class BootStrapperTest
         allocateTokensForNode(vn, ks, tm, addr);
     }
 
+    @Test
+    public void testAllocateTokensLocalRf() throws UnknownHostException
+    {
+        int vn = 16;
+        int allocateTokensForLocalRf = 3;
+        TokenMetadata tm = new TokenMetadata();
+        generateFakeEndpoints(tm, 10, vn);
+        InetAddress addr = FBUtilities.getBroadcastAddress();
+        allocateTokensForNode(vn, allocateTokensForLocalRf, tm, addr);
+    }
+
     public void testAllocateTokensNetworkStrategy(int rackCount, int replicas) throws UnknownHostException
     {
         IEndpointSnitch oldSnitch = DatabaseDescriptor.getEndpointSnitch();
@@ -231,6 +242,14 @@ public class BootStrapperTest
         tm.updateNormalTokens(tokens, addr);
         SummaryStatistics ns = TokenAllocation.replicatedOwnershipStats(tm.cloneOnlyTokenMap(), Keyspace.open(ks).getReplicationStrategy(), addr);
         verifyImprovement(os, ns);
+    }
+
+    private void allocateTokensForNode(int vn, int rf, TokenMetadata tm, InetAddress addr)
+    {
+        Collection<Token> tokens = BootStrapper.allocateTokens(tm, addr, rf, vn, 0);
+        assertEquals(vn, tokens.size());
+        tm.updateNormalTokens(tokens, addr);
+        // SummaryStatistics is not implemented for `allocate_tokens_for_local_replication_factor` so can't be verified
     }
 
     private void verifyImprovement(SummaryStatistics os, SummaryStatistics ns)

--- a/test/unit/org/apache/cassandra/dht/ByteOrderedPartitionerTestCase.java
+++ b/test/unit/org/apache/cassandra/dht/ByteOrderedPartitionerTestCase.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ByteOrderedPartitionerTestCase extends AllocatablePartitionerTestCase
+{
+    public void initPartitioner()
+    {
+        partitioner = ByteOrderedPartitioner.instance;
+    }
+
+    public Token almostMax()
+    {
+        byte[] arr = Arrays.copyOf(ByteOrderedPartitioner.MAXIMUM.token, 16);
+        arr[15] = 0x00;
+        return new ByteOrderedPartitioner.BytesToken(arr);
+    }
+
+    @Test
+    public void testIncrement()
+    {
+        ByteOrderedPartitioner.BytesToken token = new ByteOrderedPartitioner.BytesToken(new byte[]{ 0x00 });
+        ByteOrderedPartitioner.BytesToken expected = new ByteOrderedPartitioner.BytesToken(new byte[]{ 0x00, 0x00 });
+        assertEquals(expected, token.increaseSlightly());
+    }
+
+    @Test
+    public void testIncrementFullLength()
+    {
+        byte[] tokenArr = new byte[16];
+        byte[] expectedArr = new byte[16];
+        Arrays.fill(tokenArr, (byte) 0x00);
+        Arrays.fill(expectedArr, (byte) 0x00);
+        expectedArr[15] = 0x01;
+        ByteOrderedPartitioner.BytesToken token = new ByteOrderedPartitioner.BytesToken(tokenArr);
+        ByteOrderedPartitioner.BytesToken expected = new ByteOrderedPartitioner.BytesToken(expectedArr);
+        assertEquals(expected, token.increaseSlightly());
+    }
+
+    @Test
+    public void testIncrementWrapAround()
+    {
+        ByteOrderedPartitioner.BytesToken token = ByteOrderedPartitioner.MAXIMUM;
+        ByteOrderedPartitioner.BytesToken expected = ByteOrderedPartitioner.MINIMUM;
+        assertEquals(expected, token.increaseSlightly());
+    }
+
+    @Test
+    public void testSize()
+    {
+        ByteOrderedPartitioner.BytesToken start = new ByteOrderedPartitioner.BytesToken(new byte[]{ 0x00 });
+        ByteOrderedPartitioner.BytesToken end = new ByteOrderedPartitioner.BytesToken(new byte[]{ 0x01 });
+        double actual = start.size(end);
+        assertEquals(1.0/256, actual, 0);
+    }
+
+    @Test
+    public void testSize2()
+    {
+        ByteOrderedPartitioner.BytesToken start = new ByteOrderedPartitioner.BytesToken(new byte[]{ 0x00, 0x00 });
+        ByteOrderedPartitioner.BytesToken end = new ByteOrderedPartitioner.BytesToken(new byte[]{ 0x00, 0x01 });
+        double actual = start.size(end);
+        assertEquals(1.0/256/256, actual, 0);
+    }
+}

--- a/test/unit/org/apache/cassandra/dht/KeyCollisionTest.java
+++ b/test/unit/org/apache/cassandra/dht/KeyCollisionTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.dht;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -160,7 +161,12 @@ public class KeyCollisionTest
 
         public BigIntegerToken getRandomToken()
         {
-            return new BigIntegerToken(BigInteger.valueOf(new Random().nextInt(15)));
+            return getRandomToken(ThreadLocalRandom.current());
+        }
+
+        public BigIntegerToken getRandomToken(Random random)
+        {
+            return new BigIntegerToken(BigInteger.valueOf(random.nextInt(15)));
         }
 
         private final Token.TokenFactory tokenFactory = new Token.TokenFactory() {

--- a/test/unit/org/apache/cassandra/dht/KeyCollisionTest.java
+++ b/test/unit/org/apache/cassandra/dht/KeyCollisionTest.java
@@ -19,9 +19,7 @@
 package org.apache.cassandra.dht;
 
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.util.*;
-import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -30,12 +28,9 @@ import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.columniterator.IdentityQueryFilter;
-import org.apache.cassandra.db.marshal.AbstractType;
-import org.apache.cassandra.db.marshal.IntegerType;
 import org.apache.cassandra.config.*;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.locator.SimpleStrategy;
-import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.*;
 
 import static org.apache.cassandra.Util.dk;
@@ -129,129 +124,6 @@ public class KeyCollisionTest
         public long getHeapSize()
         {
             return 0;
-        }
-    }
-
-    public static class LengthPartitioner implements IPartitioner
-    {
-        public static final BigInteger ZERO = new BigInteger("0");
-        public static final BigIntegerToken MINIMUM = new BigIntegerToken("-1");
-
-        public static LengthPartitioner instance = new LengthPartitioner();
-
-        public DecoratedKey decorateKey(ByteBuffer key)
-        {
-            return new BufferDecoratedKey(getToken(key), key);
-        }
-
-        public BigIntegerToken midpoint(Token ltoken, Token rtoken)
-        {
-            // the symbolic MINIMUM token should act as ZERO: the empty bit array
-            BigInteger left = ltoken.equals(MINIMUM) ? ZERO : ((BigIntegerToken)ltoken).token;
-            BigInteger right = rtoken.equals(MINIMUM) ? ZERO : ((BigIntegerToken)rtoken).token;
-            Pair<BigInteger,Boolean> midpair = FBUtilities.midpoint(left, right, 127);
-            // discard the remainder
-            return new BigIntegerToken(midpair.left);
-        }
-
-        public BigIntegerToken getMinimumToken()
-        {
-            return MINIMUM;
-        }
-
-        public BigIntegerToken getRandomToken()
-        {
-            return getRandomToken(ThreadLocalRandom.current());
-        }
-
-        public BigIntegerToken getRandomToken(Random random)
-        {
-            return new BigIntegerToken(BigInteger.valueOf(random.nextInt(15)));
-        }
-
-        private final Token.TokenFactory tokenFactory = new Token.TokenFactory() {
-            public ByteBuffer toByteArray(Token token)
-            {
-                BigIntegerToken bigIntegerToken = (BigIntegerToken) token;
-                return ByteBuffer.wrap(bigIntegerToken.token.toByteArray());
-            }
-
-            public Token fromByteArray(ByteBuffer bytes)
-            {
-                return new BigIntegerToken(new BigInteger(ByteBufferUtil.getArray(bytes)));
-            }
-
-            public String toString(Token token)
-            {
-                BigIntegerToken bigIntegerToken = (BigIntegerToken) token;
-                return bigIntegerToken.token.toString();
-            }
-
-            public Token fromString(String string)
-            {
-                return new BigIntegerToken(new BigInteger(string));
-            }
-
-            public void validate(String token) {}
-        };
-
-        public Token.TokenFactory getTokenFactory()
-        {
-            return tokenFactory;
-        }
-
-        public boolean preservesOrder()
-        {
-            return false;
-        }
-
-        public BigIntegerToken getToken(ByteBuffer key)
-        {
-            if (key.remaining() == 0)
-                return MINIMUM;
-            return new BigIntegerToken(BigInteger.valueOf(key.remaining()));
-        }
-
-        public Map<Token, Float> describeOwnership(List<Token> sortedTokens)
-        {
-            // allTokens will contain the count and be returned, sorted_ranges is shorthand for token<->token math.
-            Map<Token, Float> allTokens = new HashMap<Token, Float>();
-            List<Range<Token>> sortedRanges = new ArrayList<Range<Token>>();
-
-            // this initializes the counts to 0 and calcs the ranges in order.
-            Token lastToken = sortedTokens.get(sortedTokens.size() - 1);
-            for (Token node : sortedTokens)
-            {
-                allTokens.put(node, new Float(0.0));
-                sortedRanges.add(new Range<Token>(lastToken, node));
-                lastToken = node;
-            }
-
-            for (String ks : Schema.instance.getKeyspaces())
-            {
-                for (CFMetaData cfmd : Schema.instance.getKSMetaData(ks).cfMetaData().values())
-                {
-                    for (Range<Token> r : sortedRanges)
-                    {
-                        // Looping over every KS:CF:Range, get the splits size and add it to the count
-                        allTokens.put(r.right, allTokens.get(r.right) + StorageService.instance.getSplits(ks, cfmd.cfName, r, 1).size());
-                    }
-                }
-            }
-
-            // Sum every count up and divide count/total for the fractional ownership.
-            Float total = new Float(0.0);
-            for (Float f : allTokens.values())
-                total += f;
-            for (Map.Entry<Token, Float> row : allTokens.entrySet())
-                allTokens.put(row.getKey(), row.getValue() / total);
-
-            return allTokens;
-        }
-
-        public AbstractType<?> getTokenValidator()
-        {
-            return IntegerType.instance;
         }
     }
 }

--- a/test/unit/org/apache/cassandra/dht/LengthPartitioner.java
+++ b/test/unit/org/apache/cassandra/dht/LengthPartitioner.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.dht;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.config.Schema;
+import org.apache.cassandra.db.BufferDecoratedKey;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.IntegerType;
+import org.apache.cassandra.dht.KeyCollisionTest.BigIntegerToken;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Pair;
+
+public class LengthPartitioner implements IPartitioner
+{
+    public static final BigInteger ZERO = new BigInteger("0");
+    public static final BigIntegerToken MINIMUM = new BigIntegerToken("-1");
+
+    public static LengthPartitioner instance = new LengthPartitioner();
+
+    public DecoratedKey decorateKey(ByteBuffer key)
+    {
+        return new BufferDecoratedKey(getToken(key), key);
+    }
+
+    public BigIntegerToken midpoint(Token ltoken, Token rtoken)
+    {
+        // the symbolic MINIMUM token should act as ZERO: the empty bit array
+        BigInteger left = ltoken.equals(MINIMUM) ? ZERO : ((BigIntegerToken)ltoken).token;
+        BigInteger right = rtoken.equals(MINIMUM) ? ZERO : ((BigIntegerToken)rtoken).token;
+        Pair<BigInteger,Boolean> midpair = FBUtilities.midpoint(left, right, 127);
+        // discard the remainder
+        return new BigIntegerToken(midpair.left);
+    }
+
+    public Token split(Token left, Token right, double ratioToLeft)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    public BigIntegerToken getMinimumToken()
+    {
+        return MINIMUM;
+    }
+
+    public BigIntegerToken getRandomToken()
+    {
+        return getRandomToken(ThreadLocalRandom.current());
+    }
+
+    public BigIntegerToken getRandomToken(Random random)
+    {
+        return new BigIntegerToken(BigInteger.valueOf(random.nextInt(15)));
+    }
+
+    private final Token.TokenFactory tokenFactory = new Token.TokenFactory() {
+        public ByteBuffer toByteArray(Token token)
+        {
+            BigIntegerToken bigIntegerToken = (BigIntegerToken) token;
+            return ByteBuffer.wrap(bigIntegerToken.token.toByteArray());
+        }
+
+        public Token fromByteArray(ByteBuffer bytes)
+        {
+            return new BigIntegerToken(new BigInteger(ByteBufferUtil.getArray(bytes)));
+        }
+
+        public String toString(Token token)
+        {
+            BigIntegerToken bigIntegerToken = (BigIntegerToken) token;
+            return bigIntegerToken.token.toString();
+        }
+
+        public Token fromString(String string)
+        {
+            return new BigIntegerToken(new BigInteger(string));
+        }
+
+        public void validate(String token) {}
+    };
+
+    public Token.TokenFactory getTokenFactory()
+    {
+        return tokenFactory;
+    }
+
+    public boolean preservesOrder()
+    {
+        return false;
+    }
+
+    public BigIntegerToken getToken(ByteBuffer key)
+    {
+        if (key.remaining() == 0)
+            return MINIMUM;
+        return new BigIntegerToken(BigInteger.valueOf(key.remaining()));
+    }
+
+    public Map<Token, Float> describeOwnership(List<Token> sortedTokens)
+    {
+        // allTokens will contain the count and be returned, sorted_ranges is shorthand for token<->token math.
+        Map<Token, Float> allTokens = new HashMap<Token, Float>();
+        List<Range<Token>> sortedRanges = new ArrayList<Range<Token>>();
+
+        // this initializes the counts to 0 and calcs the ranges in order.
+        Token lastToken = sortedTokens.get(sortedTokens.size() - 1);
+        for (Token node : sortedTokens)
+        {
+            allTokens.put(node, new Float(0.0));
+            sortedRanges.add(new Range<Token>(lastToken, node));
+            lastToken = node;
+        }
+
+        for (String ks : Schema.instance.getKeyspaces())
+        {
+            for (CFMetaData cfmd : Schema.instance.getKSMetaData(ks).cfMetaData().values())
+            {
+                for (Range<Token> r : sortedRanges)
+                {
+                    // Looping over every KS:CF:Range, get the splits size and add it to the count
+                    allTokens.put(r.right, allTokens.get(r.right) + StorageService.instance.getSplits(ks, cfmd.cfName, r, 1).size());
+                }
+            }
+        }
+
+        // Sum every count up and divide count/total for the fractional ownership.
+        Float total = new Float(0.0);
+        for (Float f : allTokens.values())
+            total += f;
+        for (Map.Entry<Token, Float> row : allTokens.entrySet())
+            allTokens.put(row.getKey(), row.getValue() / total);
+
+        return allTokens;
+    }
+
+    public AbstractType<?> getTokenValidator()
+    {
+        return IntegerType.instance;
+    }
+}

--- a/test/unit/org/apache/cassandra/dht/Murmur3PartitionerTest.java
+++ b/test/unit/org/apache/cassandra/dht/Murmur3PartitionerTest.java
@@ -20,6 +20,8 @@
  */
 package org.apache.cassandra.dht;
 
+import org.junit.Test;
+
 public class Murmur3PartitionerTest extends PartitionerTestCase
 {
     public void initPartitioner()
@@ -36,6 +38,27 @@ public class Murmur3PartitionerTest extends PartitionerTestCase
         assertMidpoint(mintoken, tok("aaa"), 16);
         assertMidpoint(mintoken, mintoken, 62);
         assertMidpoint(tok("a"), mintoken, 16);
+    }
+
+    @Test
+    public void testSplit()
+    {
+        assertSplit(tok("a"), tok("b"), 16);
+        assertSplit(tok("a"), tok("bbb"), 16);
+    }
+
+    @Test
+    public void testSplitWrapping()
+    {
+        assertSplit(tok("b"), tok("a"), 16);
+        assertSplit(tok("bbb"), tok("a"), 16);
+    }
+
+    @Test
+    public void testSplitExceedMaximumCase()
+    {
+        Murmur3Partitioner.LongToken left = new Murmur3Partitioner.LongToken(Long.MAX_VALUE - 100);
+        assertSplit(left, tok("a"), 16);
     }
 }
 

--- a/test/unit/org/apache/cassandra/dht/Murmur3PartitionerTestCase.java
+++ b/test/unit/org/apache/cassandra/dht/Murmur3PartitionerTestCase.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht;
+
+public class Murmur3PartitionerTestCase extends AllocatablePartitionerTestCase
+{
+    public void initPartitioner()
+    {
+        partitioner = Murmur3Partitioner.instance;
+    }
+
+    public Token almostMax()
+    {
+        return new Murmur3Partitioner.LongToken(Long.MAX_VALUE - 100);
+    }
+}

--- a/test/unit/org/apache/cassandra/dht/PartitionerTestCase.java
+++ b/test/unit/org/apache/cassandra/dht/PartitionerTestCase.java
@@ -106,6 +106,38 @@ public abstract class PartitionerTestCase
         assertMidpoint(tok("bbb"), tok("a"), 16);
     }
 
+    /**
+     * Test split token ranges
+     */
+    public void assertSplit(Token left, Token right, int depth)
+    {
+        Random rand = new Random();
+        for (int i = 0; i < 1000; i++)
+        {
+            assertSplit(left, right ,rand, depth);
+        }
+    }
+
+    private void assertSplit(Token left, Token right, Random rand, int depth)
+    {
+        double ratio = rand.nextDouble();
+        Token newToken = partitioner.split(left, right, ratio);
+
+        assert new Range<Token>(left, right).contains(newToken)
+                : "For " + left + "," + right + ": range did not contain new token:" + newToken;
+
+        assertEquals("For " + left + "," + right + ", new token: " + newToken,
+                     ratio, left.size(newToken) / left.size(right), 0.1);
+
+        if (depth < 1)
+            return;
+
+        if (rand.nextBoolean())
+            assertSplit(left, newToken, rand, depth-1);
+        else
+            assertSplit(newToken, right, rand, depth-1);
+    }
+
     @Test
     public void testTokenFactoryBytes()
     {

--- a/test/unit/org/apache/cassandra/dht/RandomPartitionerTest.java
+++ b/test/unit/org/apache/cassandra/dht/RandomPartitionerTest.java
@@ -20,10 +20,36 @@ package org.apache.cassandra.dht;
  *
  */
 
+import java.math.BigInteger;
+
+import org.junit.Test;
+
 public class RandomPartitionerTest extends PartitionerTestCase
 {
     public void initPartitioner()
     {
         partitioner = RandomPartitioner.instance;
+    }
+
+    @Test
+    public void testSplit()
+    {
+        assertSplit(tok("a"), tok("b"), 16);
+        assertSplit(tok("a"), tok("bbb"), 16);
+    }
+
+    @Test
+    public void testSplitWrapping()
+    {
+        assertSplit(tok("b"), tok("a"), 16);
+        assertSplit(tok("bbb"), tok("a"), 16);
+    }
+
+    @Test
+    public void testSplitExceedMaximumCase()
+    {
+        RandomPartitioner.BigIntegerToken left = new RandomPartitioner.BigIntegerToken(RandomPartitioner.MAXIMUM.subtract(BigInteger.valueOf(10)));
+
+        assertSplit(left, tok("a"), 16);
     }
 }


### PR DESCRIPTION
This PR backports a chain of commits related to the intelligent token allocator first introduced in Cassandra 3.0 with [CASSANDRA-7032](https://issues.apache.org/jira/browse/CASSANDRA-7032)

See [this Quip](https://palantir.quip.com/rTzpAfGfHPeZ) for more details