### PR TITLE
Schema agreement check also ignores removed nodes

### DIFF
--- a/src/java/com/palantir/cassandra/utils/SchemaAgreementCheck.java
+++ b/src/java/com/palantir/cassandra/utils/SchemaAgreementCheck.java
@@ -68,7 +68,7 @@ public class SchemaAgreementCheck
             UUID localSchemaVersion = localSchemaVersionSupplier.get();
             return endpointStatesSupplier.get().stream()
                                          .filter(endpoint -> !ignoredEndpoints.contains(endpoint.getKey()))
-                                         .filter(endpointStates -> !isLeft(endpointStates.getValue()))
+                                         .filter(endpointStates -> !isLeftOrRemoved(endpointStates.getValue()))
                                          .allMatch(endpointStates -> schemaIsEqualToLocalVersion(localSchemaVersion, endpointStates.getKey(), endpointStates.getValue()));
         }
         catch (Exception e)
@@ -78,9 +78,10 @@ public class SchemaAgreementCheck
         }
     }
 
-    private boolean isLeft(EndpointState endpointState)
+    private boolean isLeftOrRemoved(EndpointState endpointState)
     {
-        return VersionedValue.STATUS_LEFT.equals(endpointState.getStatus());
+        return VersionedValue.STATUS_LEFT.equals(endpointState.getStatus())
+               || VersionedValue.REMOVED_TOKEN.equals(endpointState.getStatus());
     }
 
     private boolean schemaIsEqualToLocalVersion(UUID localSchemaVersion, InetAddress address, EndpointState endpointState)

--- a/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
+++ b/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
@@ -172,7 +172,6 @@ public class SchemaAgreementCheckTest
     private static EndpointState createRemoved(UUID schema)
     {
         EndpointState state = EndpointStateFactory.create();
-        List<Token> tokens = Collections.singletonList(DatabaseDescriptor.getPartitioner().getRandomToken());
         state.addApplicationState(ApplicationState.STATUS, valueFactory.removedNonlocal(UUID.randomUUID(), 259200 * 1000));
         state.addApplicationState(ApplicationState.SCHEMA, valueFactory.schema(schema));
         return state;

--- a/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
+++ b/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.gms.ApplicationState;
 import org.apache.cassandra.gms.EndpointState;
 import org.apache.cassandra.gms.EndpointStateFactory;
+import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.gms.VersionedValue;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -172,7 +173,7 @@ public class SchemaAgreementCheckTest
     private static EndpointState createRemoved(UUID schema)
     {
         EndpointState state = EndpointStateFactory.create();
-        state.addApplicationState(ApplicationState.STATUS, valueFactory.removedNonlocal(UUID.randomUUID(), 259200 * 1000));
+        state.addApplicationState(ApplicationState.STATUS, valueFactory.removedNonlocal(UUID.randomUUID(), Gossiper.aVeryLongTime));
         state.addApplicationState(ApplicationState.SCHEMA, valueFactory.schema(schema));
         return state;
     }

--- a/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
+++ b/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
@@ -101,6 +101,21 @@ public class SchemaAgreementCheckTest
     }
 
     @Test
+    public void checkSchemaAgreement_ignoresRemovedNode()
+    {
+        UUID schema1 = UUID.randomUUID();
+        UUID schema2 = UUID.randomUUID();
+        EndpointState state1 = createNormal(schema1);
+        EndpointState state2 = createRemoved(schema2);
+
+        SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(() -> schema1,
+                                                                             () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state1,
+                                                                                                   InetAddresses.forString("127.0.0.2"), state1,
+                                                                                                   InetAddresses.forString("127.0.0.3"), state2).entrySet());
+        assertThat(schemaAgreementCheck.isSchemaInAgreement()).isTrue();
+    }
+
+    @Test
     public void checkSchemaAgreement_ignoresProvidedIgnorableNode()
     {
         UUID schema1 = UUID.randomUUID();
@@ -149,6 +164,16 @@ public class SchemaAgreementCheckTest
         EndpointState state = EndpointStateFactory.create();
         List<Token> tokens = Collections.singletonList(DatabaseDescriptor.getPartitioner().getRandomToken());
         state.addApplicationState(ApplicationState.STATUS, valueFactory.left(tokens, 1000));
+        state.addApplicationState(ApplicationState.SCHEMA, valueFactory.schema(schema));
+        state.addApplicationState(ApplicationState.TOKENS, valueFactory.tokens(tokens));
+        return state;
+    }
+
+    private static EndpointState createRemoved(UUID schema)
+    {
+        EndpointState state = EndpointStateFactory.create();
+        List<Token> tokens = Collections.singletonList(DatabaseDescriptor.getPartitioner().getRandomToken());
+        state.addApplicationState(ApplicationState.STATUS, valueFactory.removedNonlocal(UUID.randomUUID(), 259200 * 1000));
         state.addApplicationState(ApplicationState.SCHEMA, valueFactory.schema(schema));
         state.addApplicationState(ApplicationState.TOKENS, valueFactory.tokens(tokens));
         return state;

--- a/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
+++ b/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
@@ -175,7 +175,6 @@ public class SchemaAgreementCheckTest
         List<Token> tokens = Collections.singletonList(DatabaseDescriptor.getPartitioner().getRandomToken());
         state.addApplicationState(ApplicationState.STATUS, valueFactory.removedNonlocal(UUID.randomUUID(), 259200 * 1000));
         state.addApplicationState(ApplicationState.SCHEMA, valueFactory.schema(schema));
-        state.addApplicationState(ApplicationState.TOKENS, valueFactory.tokens(tokens));
         return state;
     }
 }


### PR DESCRIPTION
Removed nodes lingering in gossip should not be considered for schema agreement check