### PR TITLE
Support Intelligent Token Allocation with the ByteOrderedPartitioner

### DIFF
--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -187,7 +187,7 @@ public class ByteOrderedPartitioner implements IPartitioner
         BigInteger right = bigForBytes(rToken.token, sigbytes);
 
         Pair<BigInteger,Boolean> midpair = FBUtilities.midpoint(left, right, 8*sigbytes);
-        return new BytesToken(bytesForBig(midpair.left, sigbytes, false));
+        return new BytesToken(bytesForBig(midpair.left, sigbytes, midpair.right));
     }
 
     public Token split(Token left, Token right, double ratioToLeft)
@@ -239,7 +239,7 @@ public class ByteOrderedPartitioner implements IPartitioner
         if (sigbytes != bytes.length)
         {
             b = new byte[sigbytes];
-            System.arraycopy(bytes, 0, b, 0, bytes.length);
+            System.arraycopy(bytes, 0, b, 0, Math.min(bytes.length, b.length));
         } else
             b = bytes;
         return new BigInteger(1, b);

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -47,12 +47,13 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class ByteOrderedPartitioner implements IPartitioner
 {
+    private static final int GENERATED_TOKEN_LENGTH = 16;
     public static final BytesToken MINIMUM = new BytesToken(ArrayUtils.EMPTY_BYTE_ARRAY);
-    public static final BytesToken MAXIMUM = new BytesToken(new byte[16]);
+    public static final BytesToken MAXIMUM = new BytesToken(new byte[GENERATED_TOKEN_LENGTH]);
     public static final BigDecimal MAX_TOKEN_MAGNITUDE;
     static {
         Arrays.fill(MAXIMUM.token, (byte) 0xFF);
-        MAX_TOKEN_MAGNITUDE = new BigDecimal(bigForBytes(MAXIMUM.token, 16));
+        MAX_TOKEN_MAGNITUDE = new BigDecimal(bigForBytes(MAXIMUM.token, GENERATED_TOKEN_LENGTH));
     }
 
     public static final BigInteger BYTE_MASK = new BigInteger("255");
@@ -130,7 +131,7 @@ public class ByteOrderedPartitioner implements IPartitioner
         public double size(Token next)
         {
             BytesToken n = (BytesToken) next;
-            BigDecimal size = new BigDecimal(bigForBytes(n.token, 16).subtract(bigForBytes(token, 16)));
+            BigDecimal size = new BigDecimal(bigForBytes(n.token, GENERATED_TOKEN_LENGTH).subtract(bigForBytes(token, GENERATED_TOKEN_LENGTH)));
             BigDecimal d = size.divide(MAX_TOKEN_MAGNITUDE, MathContext.DECIMAL64); // Scale so that the full range is 1.
             return (d.compareTo(BigDecimal.ZERO) > 0 ? d : d.add(BigDecimal.ONE)).doubleValue(); // Adjust for signed long, also making sure t.size(t) == 1.
         }
@@ -138,7 +139,7 @@ public class ByteOrderedPartitioner implements IPartitioner
         @Override
         public Token increaseSlightly()
         {
-            if (token.length < 16)
+            if (token.length < GENERATED_TOKEN_LENGTH)
             {
                 byte[] newToken = Arrays.copyOf(token, token.length + 1);
                 newToken[token.length] = 0;
@@ -150,9 +151,9 @@ public class ByteOrderedPartitioner implements IPartitioner
             }
             else
             {
-                byte[] result = new byte[16];
-                System.arraycopy(token, 0, result, 0, 16);
-                for (int i = 15; i >= 0; i--) {
+                byte[] result = new byte[GENERATED_TOKEN_LENGTH];
+                System.arraycopy(token, 0, result, 0, GENERATED_TOKEN_LENGTH);
+                for (int i = GENERATED_TOKEN_LENGTH-1; i >= 0; i--) {
                     if (result[i] != (byte) 0xFF) {
                         result[i]++;
                         break;
@@ -195,9 +196,9 @@ public class ByteOrderedPartitioner implements IPartitioner
         BytesToken lToken = (BytesToken) left;
         BytesToken rToken = (BytesToken) right;
 
-        int sigbytes = 16;
-        BigDecimal l = new BigDecimal(bigForBytes(lToken.token, 16)),
-                   r = new BigDecimal(bigForBytes(rToken.token, 16)),
+        int sigbytes = GENERATED_TOKEN_LENGTH;
+        BigDecimal l = new BigDecimal(bigForBytes(lToken.token, sigbytes)),
+                   r = new BigDecimal(bigForBytes(rToken.token, sigbytes)),
                    ratio = BigDecimal.valueOf(ratioToLeft);
         byte[] newToken;
 

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -50,10 +50,11 @@ public class ByteOrderedPartitioner implements IPartitioner
     private static final int GENERATED_TOKEN_LENGTH = 16;
     public static final BytesToken MINIMUM = new BytesToken(ArrayUtils.EMPTY_BYTE_ARRAY);
     public static final BytesToken MAXIMUM = new BytesToken(new byte[GENERATED_TOKEN_LENGTH]);
+    public static final BigDecimal MIN_TOKEN_MAGNITUDE = new BigDecimal(bigForBytes(MINIMUM.token, MINIMUM.token.length));
     public static final BigDecimal MAX_TOKEN_MAGNITUDE;
     static {
         Arrays.fill(MAXIMUM.token, (byte) 0xFF);
-        MAX_TOKEN_MAGNITUDE = new BigDecimal(bigForBytes(MAXIMUM.token, GENERATED_TOKEN_LENGTH));
+        MAX_TOKEN_MAGNITUDE = new BigDecimal(bigForBytes(MAXIMUM.token, MAXIMUM.token.length));
     }
 
     public static final BigInteger BYTE_MASK = new BigInteger("255");
@@ -210,21 +211,22 @@ public class ByteOrderedPartitioner implements IPartitioner
         {
             // wrapping case
             // L + ((R - min) + (max - L)) * pct
-            BigInteger maxTokenInt = bigForBytes(MAXIMUM.token, MAXIMUM.token.length);
-            BigInteger minTokenInt = bigForBytes(MINIMUM.token, MINIMUM.token.length);
-            BigDecimal max = new BigDecimal(maxTokenInt);
-            BigDecimal min = new BigDecimal(minTokenInt);
+            BigDecimal max = MAX_TOKEN_MAGNITUDE;
+            BigDecimal min = MIN_TOKEN_MAGNITUDE;
 
             BigInteger token = max.subtract(min).add(r).subtract(l).multiply(ratio).add(l).toBigInteger();
 
-            if (token.compareTo(maxTokenInt) <= 0)
+            BigInteger maxToken = MAX_TOKEN_MAGNITUDE.toBigInteger();
+
+            if (token.compareTo(maxToken) <= 0)
             {
                 newToken = bytesForBig(token, sigbytes, false);
             }
             else
             {
                 // if the value is above maximum
-                newToken = bytesForBig(minTokenInt.add(token.subtract(maxTokenInt)), sigbytes, false);
+                BigInteger minToken = min.toBigInteger();
+                newToken = bytesForBig(minToken.add(token.subtract(maxToken)), sigbytes, false);
             }
         }
         return new BytesToken(newToken);

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -33,7 +33,9 @@ import org.apache.cassandra.utils.Pair;
 
 import org.apache.commons.lang3.ArrayUtils;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.MathContext;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,6 +48,12 @@ import java.util.concurrent.ThreadLocalRandom;
 public class ByteOrderedPartitioner implements IPartitioner
 {
     public static final BytesToken MINIMUM = new BytesToken(ArrayUtils.EMPTY_BYTE_ARRAY);
+    public static final BytesToken MAXIMUM = new BytesToken(new byte[16]);
+    public static final BigDecimal MAX_TOKEN_MAGNITUDE;
+    static {
+        Arrays.fill(MAXIMUM.token, (byte) 0xFF);
+        MAX_TOKEN_MAGNITUDE = new BigDecimal(bigForBytes(MAXIMUM.token, 16));
+    }
 
     public static final BigInteger BYTE_MASK = new BigInteger("255");
 
@@ -121,15 +129,39 @@ public class ByteOrderedPartitioner implements IPartitioner
         @Override
         public double size(Token next)
         {
-            throw new UnsupportedOperationException(String.format("Token type %s does not support token allocation.",
-                                                                  getClass().getSimpleName()));
+            BytesToken n = (BytesToken) next;
+            BigDecimal size = new BigDecimal(bigForBytes(n.token, 16).subtract(bigForBytes(token, 16)));
+            BigDecimal d = size.divide(MAX_TOKEN_MAGNITUDE, MathContext.DECIMAL64); // Scale so that the full range is 1.
+            return (d.compareTo(BigDecimal.ZERO) > 0 ? d : d.add(BigDecimal.ONE)).doubleValue(); // Adjust for signed long, also making sure t.size(t) == 1.
         }
 
         @Override
         public Token increaseSlightly()
         {
-            throw new UnsupportedOperationException(String.format("Token type %s does not support token allocation.",
-                                                                  getClass().getSimpleName()));
+            if (token.length < 16)
+            {
+                byte[] newToken = Arrays.copyOf(token, token.length + 1);
+                newToken[token.length] = 0;
+                return new BytesToken(newToken);
+            }
+            else if (Arrays.equals(token, MAXIMUM.token))
+            {
+                return MINIMUM;
+            }
+            else
+            {
+                byte[] result = new byte[16];
+                System.arraycopy(token, 0, result, 0, 16);
+                for (int i = 15; i >= 0; i--) {
+                    if (result[i] != (byte) 0xFF) {
+                        result[i]++;
+                        break;
+                    } else {
+                        result[i] = 0;
+                    }
+                }
+                return new BytesToken(result);
+            }
         }
     }
 
@@ -147,12 +179,12 @@ public class ByteOrderedPartitioner implements IPartitioner
 
     public BytesToken midpoint(Token lt, Token rt)
     {
-        BytesToken ltoken = (BytesToken) lt;
-        BytesToken rtoken = (BytesToken) rt;
+        BytesToken lToken = (BytesToken) lt;
+        BytesToken rToken = (BytesToken) rt;
 
-        int sigbytes = Math.max(ltoken.token.length, rtoken.token.length);
-        BigInteger left = bigForBytes(ltoken.token, sigbytes);
-        BigInteger right = bigForBytes(rtoken.token, sigbytes);
+        int sigbytes = Math.max(lToken.token.length, rToken.token.length);
+        BigInteger left = bigForBytes(lToken.token, sigbytes);
+        BigInteger right = bigForBytes(rToken.token, sigbytes);
 
         Pair<BigInteger,Boolean> midpair = FBUtilities.midpoint(left, right, 8*sigbytes);
         return new BytesToken(bytesForBig(midpair.left, sigbytes, midpair.right));
@@ -160,14 +192,48 @@ public class ByteOrderedPartitioner implements IPartitioner
 
     public Token split(Token left, Token right, double ratioToLeft)
     {
-        throw new UnsupportedOperationException();
+        BytesToken lToken = (BytesToken) left;
+        BytesToken rToken = (BytesToken) right;
+
+        int sigbytes = 16;
+        BigDecimal l = new BigDecimal(bigForBytes(lToken.token, 16)),
+                   r = new BigDecimal(bigForBytes(rToken.token, 16)),
+                   ratio = BigDecimal.valueOf(ratioToLeft);
+        byte[] newToken;
+
+        if (l.compareTo(r) < 0)
+        {
+            newToken = bytesForBig(r.subtract(l).multiply(ratio).add(l).toBigInteger(), sigbytes, false);
+        }
+        else
+        {
+            // wrapping case
+            // L + ((R - min) + (max - L)) * pct
+            BigInteger maxTokenInt = bigForBytes(MAXIMUM.token, MAXIMUM.token.length);
+            BigInteger minTokenInt = bigForBytes(MINIMUM.token, MINIMUM.token.length);
+            BigDecimal max = new BigDecimal(maxTokenInt);
+            BigDecimal min = new BigDecimal(minTokenInt);
+
+            BigInteger token = max.subtract(min).add(r).subtract(l).multiply(ratio).add(l).toBigInteger();
+
+            if (token.compareTo(maxTokenInt) <= 0)
+            {
+                newToken = bytesForBig(token, sigbytes, false);
+            }
+            else
+            {
+                // if the value is above maximum
+                newToken = bytesForBig(minTokenInt.add(token.subtract(maxTokenInt)), sigbytes, false);
+            }
+        }
+        return new BytesToken(newToken);
     }
 
     /**
      * Convert a byte array containing the most significant of 'sigbytes' bytes
      * representing a big-endian magnitude into a BigInteger.
      */
-    protected BigInteger bigForBytes(byte[] bytes, int sigbytes)
+    protected static BigInteger bigForBytes(byte[] bytes, int sigbytes)
     {
         byte[] b;
         if (sigbytes != bytes.length)
@@ -184,7 +250,7 @@ public class ByteOrderedPartitioner implements IPartitioner
      * If remainder is true, an additional byte with the high order bit enabled
      * will be added to the end of the array
      */
-    protected byte[] bytesForBig(BigInteger big, int sigbytes, boolean remainder)
+    protected static byte[] bytesForBig(BigInteger big, int sigbytes, boolean remainder)
     {
         byte[] bytes = new byte[sigbytes + (remainder ? 1 : 0)];
         if (remainder)

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -187,7 +187,7 @@ public class ByteOrderedPartitioner implements IPartitioner
         BigInteger right = bigForBytes(rToken.token, sigbytes);
 
         Pair<BigInteger,Boolean> midpair = FBUtilities.midpoint(left, right, 8*sigbytes);
-        return new BytesToken(bytesForBig(midpair.left, sigbytes, midpair.right));
+        return new BytesToken(bytesForBig(midpair.left, sigbytes, false));
     }
 
     public Token split(Token left, Token right, double ratioToLeft)

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -179,12 +179,12 @@ public class ByteOrderedPartitioner implements IPartitioner
 
     public BytesToken midpoint(Token lt, Token rt)
     {
-        BytesToken lToken = (BytesToken) lt;
-        BytesToken rToken = (BytesToken) rt;
+        BytesToken ltoken = (BytesToken) lt;
+        BytesToken rtoken = (BytesToken) rt;
 
-        int sigbytes = Math.max(lToken.token.length, rToken.token.length);
-        BigInteger left = bigForBytes(lToken.token, sigbytes);
-        BigInteger right = bigForBytes(rToken.token, sigbytes);
+        int sigbytes = Math.max(ltoken.token.length, rtoken.token.length);
+        BigInteger left = bigForBytes(ltoken.token, sigbytes);
+        BigInteger right = bigForBytes(rtoken.token, sigbytes);
 
         Pair<BigInteger,Boolean> midpair = FBUtilities.midpoint(left, right, 8*sigbytes);
         return new BytesToken(bytesForBig(midpair.left, sigbytes, midpair.right));

--- a/test/long/org/apache/cassandra/dht/tokenallocator/ByteOrderedReplicationAwareTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/ByteOrderedReplicationAwareTokenAllocatorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht.tokenallocator;
+
+import org.junit.Test;
+
+import org.apache.cassandra.Util;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
+
+public class ByteOrderedReplicationAwareTokenAllocatorTest extends AbstractReplicationAwareTokenAllocatorTest
+{
+    private static final int MAX_VNODE_COUNT = 64;
+
+    @Test
+    public void testExistingCluster()
+    {
+        super.testExistingCluster(new ByteOrderedPartitioner(), MAX_VNODE_COUNT);
+    }
+
+    @Test
+    public void testNewCluster()
+    {
+        Util.flakyTest(this::flakyTestNewCluster,
+                       2,
+                       "It tends to fail sometimes due to the random selection of the tokens in the first few nodes.");
+    }
+
+    private void flakyTestNewCluster()
+    {
+        testNewCluster(new ByteOrderedPartitioner(), MAX_VNODE_COUNT);
+    }
+}

--- a/test/unit/org/apache/cassandra/dht/AllocatablePartitionerTestCase.java
+++ b/test/unit/org/apache/cassandra/dht/AllocatablePartitionerTestCase.java
@@ -22,12 +22,11 @@ package org.apache.cassandra.dht;
 
 import org.junit.Test;
 
-public class Murmur3PartitionerTest extends PartitionerTestCase
+public abstract class AllocatablePartitionerTestCase extends PartitionerTestCase
 {
-    public void initPartitioner()
-    {
-        partitioner = Murmur3Partitioner.instance;
-    }
+    public abstract void initPartitioner();
+
+    public abstract Token almostMax();
 
     @Override
     protected void midpointMinimumTestCase()
@@ -57,7 +56,7 @@ public class Murmur3PartitionerTest extends PartitionerTestCase
     @Test
     public void testSplitExceedMaximumCase()
     {
-        Murmur3Partitioner.LongToken left = new Murmur3Partitioner.LongToken(Long.MAX_VALUE - 100);
+        Token left = almostMax();
         assertSplit(left, tok("a"), 16);
     }
 }

--- a/test/unit/org/apache/cassandra/dht/ByteOrderedPartitionerTestCase.java
+++ b/test/unit/org/apache/cassandra/dht/ByteOrderedPartitionerTestCase.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ByteOrderedPartitionerTestCase extends AllocatablePartitionerTestCase
+{
+    public void initPartitioner()
+    {
+        partitioner = ByteOrderedPartitioner.instance;
+    }
+
+    public Token almostMax()
+    {
+        byte[] arr = Arrays.copyOf(ByteOrderedPartitioner.MAXIMUM.token, 16);
+        arr[15] = 0x00;
+        return new ByteOrderedPartitioner.BytesToken(arr);
+    }
+
+    @Test
+    public void testIncrement()
+    {
+        ByteOrderedPartitioner.BytesToken token = new ByteOrderedPartitioner.BytesToken(new byte[]{ 0x00 });
+        ByteOrderedPartitioner.BytesToken expected = new ByteOrderedPartitioner.BytesToken(new byte[]{ 0x00, 0x00 });
+        assertEquals(expected, token.increaseSlightly());
+    }
+
+    @Test
+    public void testIncrementFullLength()
+    {
+        byte[] tokenArr = new byte[16];
+        byte[] expectedArr = new byte[16];
+        Arrays.fill(tokenArr, (byte) 0x00);
+        Arrays.fill(expectedArr, (byte) 0x00);
+        expectedArr[15] = 0x01;
+        ByteOrderedPartitioner.BytesToken token = new ByteOrderedPartitioner.BytesToken(tokenArr);
+        ByteOrderedPartitioner.BytesToken expected = new ByteOrderedPartitioner.BytesToken(expectedArr);
+        assertEquals(expected, token.increaseSlightly());
+    }
+
+    @Test
+    public void testIncrementWrapAround()
+    {
+        ByteOrderedPartitioner.BytesToken token = ByteOrderedPartitioner.MAXIMUM;
+        ByteOrderedPartitioner.BytesToken expected = ByteOrderedPartitioner.MINIMUM;
+        assertEquals(expected, token.increaseSlightly());
+    }
+
+    @Test
+    public void testSize()
+    {
+        ByteOrderedPartitioner.BytesToken start = new ByteOrderedPartitioner.BytesToken(new byte[]{ 0x00 });
+        ByteOrderedPartitioner.BytesToken end = new ByteOrderedPartitioner.BytesToken(new byte[]{ 0x01 });
+        double actual = start.size(end);
+        assertEquals(1.0/256, actual, 0);
+    }
+
+    @Test
+    public void testSize2()
+    {
+        ByteOrderedPartitioner.BytesToken start = new ByteOrderedPartitioner.BytesToken(new byte[]{ 0x00, 0x00 });
+        ByteOrderedPartitioner.BytesToken end = new ByteOrderedPartitioner.BytesToken(new byte[]{ 0x00, 0x01 });
+        double actual = start.size(end);
+        assertEquals(1.0/256/256, actual, 0);
+    }
+}

--- a/test/unit/org/apache/cassandra/dht/Murmur3PartitionerTestCase.java
+++ b/test/unit/org/apache/cassandra/dht/Murmur3PartitionerTestCase.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht;
+
+public class Murmur3PartitionerTestCase extends AllocatablePartitionerTestCase
+{
+    public void initPartitioner()
+    {
+        partitioner = Murmur3Partitioner.instance;
+    }
+
+    public Token almostMax()
+    {
+        return new Murmur3Partitioner.LongToken(Long.MAX_VALUE - 100);
+    }
+}


### PR DESCRIPTION
Follows #623

Implements `size`, `increaseSlightly`, and `split` on the `ByteOrderedPartitioner` to support intelligent token allocation.

Also extends the existing test cases to run on the `ByteOrderedPartitioner`, with some additions.