### PR TITLE
require peer endpoint state in SchemaAgreementCheck

### DIFF
--- a/src/java/com/palantir/cassandra/utils/SchemaAgreementCheck.java
+++ b/src/java/com/palantir/cassandra/utils/SchemaAgreementCheck.java
@@ -37,24 +37,28 @@ import org.apache.cassandra.gms.ApplicationState;
 import org.apache.cassandra.gms.EndpointState;
 import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.gms.VersionedValue;
+import org.apache.cassandra.locator.TokenMetadata;
 import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.utils.FBUtilities;
 
 public class SchemaAgreementCheck
 {
     private static final Logger logger = LoggerFactory.getLogger(SchemaAgreementCheck.class);
     private final Supplier<UUID> localSchemaVersionSupplier;
     private final Supplier<Set<Map.Entry<InetAddress, EndpointState>>> endpointStatesSupplier;
+    private final InetAddress localAddress;
 
     public SchemaAgreementCheck()
     {
-        this(Schema.instance::getVersion, Gossiper.instance::getEndpointStates);
+        this(Schema.instance::getVersion, Gossiper.instance::getEndpointStates, FBUtilities.getBroadcastAddress());
     }
 
     @VisibleForTesting
-    SchemaAgreementCheck(Supplier<UUID> localSchemaVersionSupplier, Supplier<Set<Map.Entry<InetAddress, EndpointState>>> endpointStatesSupplier)
+    SchemaAgreementCheck(Supplier<UUID> localSchemaVersionSupplier, Supplier<Set<Map.Entry<InetAddress, EndpointState>>> endpointStatesSupplier, InetAddress localAddress)
     {
         this.localSchemaVersionSupplier = localSchemaVersionSupplier;
         this.endpointStatesSupplier = endpointStatesSupplier;
+        this.localAddress = localAddress;
     }
 
     public boolean isSchemaInAgreement() {
@@ -66,10 +70,15 @@ public class SchemaAgreementCheck
         try
         {
             UUID localSchemaVersion = localSchemaVersionSupplier.get();
-            return endpointStatesSupplier.get().stream()
-                                         .filter(endpoint -> !ignoredEndpoints.contains(endpoint.getKey()))
-                                         .filter(endpointStates -> !isLeftOrRemoved(endpointStates.getValue()))
-                                         .allMatch(endpointStates -> schemaIsEqualToLocalVersion(localSchemaVersion, endpointStates.getKey(), endpointStates.getValue()));
+            Set<Map.Entry<InetAddress, EndpointState>> endpointStates = endpointStatesSupplier.get();
+
+            boolean peerEndpointsExist = endpointStates.stream()
+                          .anyMatch(endpointState -> !localAddress.equals(endpointState.getKey()));
+            boolean schemaIsInAgreeement = endpointStates.stream()
+                          .filter(endpointState -> !ignoredEndpoints.contains(endpointState.getKey()))
+                          .filter(endpointState -> !isLeftOrRemoved(endpointState.getValue()))
+                          .allMatch(endpointState -> schemaIsEqualToLocalVersion(localSchemaVersion, endpointState.getKey(), endpointState.getValue()));
+            return peerEndpointsExist && schemaIsInAgreeement;
         }
         catch (Exception e)
         {
@@ -89,8 +98,10 @@ public class SchemaAgreementCheck
         VersionedValue schema = endpointState.getApplicationState(ApplicationState.SCHEMA);
         boolean match = schema != null && localSchemaVersion.equals(UUID.fromString(schema.value));
         if(!match) {
-            logger.warn("Schema agreement check failure", SafeArg.of("localSchemaVersion", localSchemaVersion),
-                        SafeArg.of("endpoint", address), SafeArg.of("remoteSchemaVersion", schema.value));
+            logger.warn("Schema agreement check failure",
+                        SafeArg.of("localSchemaVersion", localSchemaVersion),
+                        SafeArg.of("endpoint", address),
+                        SafeArg.of("remoteSchemaVersion", schema));
         }
         return match;
     }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4181,7 +4181,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             throw new UnsupportedOperationException("Node in " + operationMode + " state; wait for status to become normal or restart");
 
         SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck();
-        if(!schemaAgreementCheck.isSchemaInAgreement(ImmutableList.of())) {
+        if(!schemaAgreementCheck.isSchemaInAgreement()) {
             throw new UnsupportedOperationException("The cluster does not agree on schema; wait for agreement before triggering a decommission");
         }
 

--- a/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
+++ b/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
@@ -50,7 +50,8 @@ public class SchemaAgreementCheckTest
         SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(() -> schema,
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state,
                                                                                                    InetAddresses.forString("127.0.0.2"), state,
-                                                                                                   InetAddresses.forString("127.0.0.3"), state).entrySet());
+                                                                                                   InetAddresses.forString("127.0.0.3"), state).entrySet(),
+                                                                             InetAddresses.forString("127.0.0.1"));
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isTrue();
     }
 
@@ -68,7 +69,8 @@ public class SchemaAgreementCheckTest
         SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(() -> schema,
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state1,
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
-                                                                                                   InetAddresses.forString("127.0.0.3"), state2).entrySet());
+                                                                                                   InetAddresses.forString("127.0.0.3"), state2).entrySet(),
+                                                                             InetAddresses.forString("127.0.0.1"));
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isFalse();
     }
 
@@ -82,7 +84,8 @@ public class SchemaAgreementCheckTest
         SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(() -> schema1,
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state1,
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
-                                                                                                   InetAddresses.forString("127.0.0.3"), state2).entrySet());
+                                                                                                   InetAddresses.forString("127.0.0.3"), state2).entrySet(),
+                                                                             InetAddresses.forString("127.0.0.1"));
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isFalse();
     }
 
@@ -97,7 +100,8 @@ public class SchemaAgreementCheckTest
         SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(() -> schema1,
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state1,
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
-                                                                                                   InetAddresses.forString("127.0.0.3"), state2).entrySet());
+                                                                                                   InetAddresses.forString("127.0.0.3"), state2).entrySet(),
+                                                                             InetAddresses.forString("127.0.0.1"));
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isTrue();
     }
 
@@ -112,7 +116,8 @@ public class SchemaAgreementCheckTest
         SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(() -> schema1,
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state1,
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
-                                                                                                   InetAddresses.forString("127.0.0.3"), state2).entrySet());
+                                                                                                   InetAddresses.forString("127.0.0.3"), state2).entrySet(),
+                                                                             InetAddresses.forString("127.0.0.1"));
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isTrue();
     }
 
@@ -127,7 +132,8 @@ public class SchemaAgreementCheckTest
         SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(() -> schema1,
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state1,
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
-                                                                                                   InetAddresses.forString("127.0.0.3"), state2).entrySet());
+                                                                                                   InetAddresses.forString("127.0.0.3"), state2).entrySet(),
+                                                                             InetAddresses.forString("127.0.0.1"));
         assertThat(schemaAgreementCheck.isSchemaInAgreement(ImmutableList.of(InetAddresses.forString("127.0.0.3")))).isTrue();
     }
 
@@ -146,7 +152,20 @@ public class SchemaAgreementCheckTest
         SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(() -> schema1,
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state1,
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
-                                                                                                   InetAddresses.forString("127.0.0.3"), state2).entrySet());
+                                                                                                   InetAddresses.forString("127.0.0.3"), state2).entrySet(),
+                                                                             InetAddresses.forString("127.0.0.1"));
+        assertThat(schemaAgreementCheck.isSchemaInAgreement()).isFalse();
+    }
+
+    @Test
+    public void checkSchemaAgreement_failsIfEndpointsAreMissing()
+    {
+        UUID schema = UUID.randomUUID();
+        EndpointState state = createNormal(schema);
+
+        SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(() -> schema,
+                                                                             () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state).entrySet(),
+                                                                             InetAddresses.forString("127.0.0.1"));
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isFalse();
     }
 


### PR DESCRIPTION
This PR updates the SchemaAgreementCheck to require the EndpointStateMap to contain at least one other endpoint.

This will cause the check to fail if the local node has no state about other peers.

This check only runs when nodes bootstrap, so this will not impact new clusters, as seeds do not bootstrap.