### PR TITLE
Expose endpoint shadow state map

### DIFF
--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -879,6 +879,11 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         return endpointStateMap.entrySet();
     }
 
+    public Map<InetAddress, EndpointState> getEndpointShadowStateMap()
+    {
+        return endpointShadowStateMap;
+    }
+
     public UUID getHostId(InetAddress endpoint)
     {
         return getHostId(endpoint, endpointStateMap);

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -881,7 +881,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
 
     public Map<InetAddress, EndpointState> getEndpointShadowStateMap()
     {
-        return endpointShadowStateMap;
+        return ImmutableMap.copyOf(endpointShadowStateMap);
     }
 
     public UUID getHostId(InetAddress endpoint)


### PR DESCRIPTION
Used internally within Palantir wrapper. I considered re-using `Gossiper#useShadowRound`, but that changes the existing steady-state behavior.