### PR TITLE
Add metric for tables with throttled compactions due to high disk usage

### DIFF
--- a/src/java/com/palantir/cassandra/db/compaction/CompactionThroughputThrottler.java
+++ b/src/java/com/palantir/cassandra/db/compaction/CompactionThroughputThrottler.java
@@ -3,6 +3,7 @@ package com.palantir.cassandra.db.compaction;
 import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.logsafe.SafeArg;
 
+import org.apache.cassandra.config.CFMetaData;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.compaction.CompactionManager;
@@ -11,14 +12,38 @@ import org.apache.cassandra.utils.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
 /**
  * Backpressure mechanism to reduce compaction throughput for large tables as disk fills up
  */
-public class CompactionThroughputThrottler
+public final class CompactionThroughputThrottler
 {
     private static final boolean ENABLE_COMPACTION_THROUGHPUT_THROTTLING = Boolean.getBoolean("palantir_cassandra.enable_compaction_throughput_throttling");
     private static final long THROTTLER_TABLE_SIZE_BYTES = Long.getLong("palantir_cassandra.throttler_table_size_gb", 10L) * 1024L * 1024L * 1024L;
     private static final Logger logger = LoggerFactory.getLogger(CompactionThroughputThrottler.class);
+
+    public static final CompactionThroughputThrottler instance = new CompactionThroughputThrottler();
+    private final Set<UUID> throttledCfs = new HashSet<>();
+
+    private CompactionThroughputThrottler() {}
+
+    public int throttledTableCount()
+    {
+        return throttledCfs.size();
+    }
+
+    public void maybeRemoveThrottledCompaction(CFMetaData cfMetaData)
+    {
+        if (throttledCfs.remove(cfMetaData.cfId) && logger.isDebugEnabled())
+        {
+            logger.debug("Completed throttled compaction for {}/{}.",
+                         SafeArg.of("keyspace", cfMetaData.ksName),
+                         SafeArg.of("table", cfMetaData.cfName));
+        }
+    }
 
     public static RateLimiter getRateLimiter(Pair<String, String> ksCf)
     {
@@ -30,8 +55,9 @@ public class CompactionThroughputThrottler
             return defaultRateLimit;
         }
 
+        ColumnFamilyStore cfs = ColumnFamilyStore.getIfExists(ksCf.left, ksCf.right);
         double diskUsage = Directories.getMaxPathToUtilization().getValue();
-        long liveSpaceUsedBytes = ColumnFamilyStore.getIfExists(keyspace, columnFamily).metric.liveDiskSpaceUsed.getCount();
+        long liveSpaceUsedBytes = cfs.metric.liveDiskSpaceUsed.getCount();
 
         if (liveSpaceUsedBytes < THROTTLER_TABLE_SIZE_BYTES || diskUsage < 0.80d)
         {
@@ -59,6 +85,11 @@ public class CompactionThroughputThrottler
         else if (diskUsage >= 0.80d)
         {
             recommendedRateLimit = RateLimiter.create(Math.min(defaultRateLimit.getRate() / 2, defaultRateLimit.getRate()));
+        }
+
+        if (recommendedRateLimit.getRate() < defaultRateLimit.getRate())
+        {
+            instance.throttledCfs.add(cfs.metadata.cfId);
         }
 
         if (logger.isDebugEnabled())

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
 import com.palantir.cassandra.db.ColumnFamilyStoreManager;
+import com.palantir.cassandra.db.compaction.CompactionThroughputThrottler;
 import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
@@ -285,6 +286,7 @@ public class CompactionTask extends AbstractCompactionTask
             // update the metrics
             cfs.metric.compactionBytesWritten.inc(endsize);
             cfs.metric.compactionsCompleted.inc();
+            CompactionThroughputThrottler.instance.maybeRemoveThrottledCompaction(cfs.metadata);
         }
     }
 

--- a/src/java/org/apache/cassandra/metrics/CompactionMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CompactionMetrics.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
+import com.palantir.cassandra.db.compaction.CompactionThroughputThrottler;
 
 import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -50,6 +51,8 @@ public class CompactionMetrics implements CompactionManager.CompactionExecutorSt
     public final Meter totalCompactionsCompleted;
     /** Total number of bytes compacted since server [re]start */
     public final Counter bytesCompacted;
+    /** Number of throttled CFs due to disk pressure */
+    public final Gauge<Integer> totalThrottledTables;
 
     public CompactionMetrics(final ThreadPoolExecutor... collectors)
     {
@@ -80,6 +83,7 @@ public class CompactionMetrics implements CompactionManager.CompactionExecutorSt
         });
         totalCompactionsCompleted = Metrics.meter(factory.createMetricName("TotalCompactionsCompleted"));
         bytesCompacted = Metrics.counter(factory.createMetricName("BytesCompacted"));
+        totalThrottledTables = Metrics.register(factory.createMetricName("TotalThrottledTables"), CompactionThroughputThrottler.instance::throttledTableCount);
     }
 
     public void beginCompaction(CompactionInfo.Holder ci)


### PR DESCRIPTION
Adds CF metric showing  number of tables being throttled when compacting as a follow up to:
- #508

The metric tracks the tables that were throttled due to high disk usage. Compactions are removed from the throttle list once the compaction completes.