### PR TITLE
Added shutdown hook to notify user of keyspace repair interruption

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/Repair.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Repair.java
@@ -84,6 +84,10 @@ public class Repair extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.println("Repair interrupted. Only the current keyspace will be repaired.");
+        }));
+
         List<String> keyspaces = parseOptionalKeyspace(args, probe);
         String[] cfnames = parseOptionalColumnFamilies(args);
 


### PR DESCRIPTION
This is to notify operator of keyspace repair interruption only repairing the current keyspace: https://github.com/palantir/cassandra/issues/298