### PR TITLE
[DNM] do not purge tombstones on any cfs being repaired

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionController.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionController.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.db.compaction;
 
 import java.util.*;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 
@@ -51,7 +52,7 @@ public class CompactionController implements AutoCloseable
 
     public final ColumnFamilyStore cfs;
     // note that overlapIterator and overlappingSSTables will be null if NEVER_PURGE_TOMBSTONES is set - this is a
-    // good thing so that noone starts using them and thinks that if overlappingSSTables is empty, there
+    // good thing so that no one starts using them and thinks that if overlappingSSTables is empty, there
     // is no overlap.
     private Refs<SSTableReader> overlappingSSTables;
     private OverlapIterator<RowPosition, SSTableReader> overlapIterator;
@@ -140,7 +141,7 @@ public class CompactionController implements AutoCloseable
             return Collections.<SSTableReader>emptySet();
 
         if (doNotPurgeTombstones(cfStore)) {
-            logger.debug("not looking for droppable sstables - doNotPurgeTombstones returned true for keyspace {}", cfStore.keyspace.getName());
+            logger.debug("Not looking for droppable sstables - doNotPurgeTombstones returned true for keyspace {}", cfStore.keyspace.getName());
             return Collections.<SSTableReader>emptySet();
         }
 
@@ -268,7 +269,8 @@ public class CompactionController implements AutoCloseable
     /**
      * @param cfs
      * @return true if this node may be streaming data for this keyspace, or if cassandra.never_purge_tombstones is set
-     * If we are streaming, tombstones should not be purged so that we don't pre-maturely purge those that exceed gc_grace_seconds.
+     * If the node is streaming, tombstones should not be purged. If we pre-maturely purge a tombstone that was written
+     * at time T+1, and the node started streaming at time T, we may end up with resurrected keys.
      * <p>
      * Note that this node may receive data without streaming, e.g. during a repair.
      */

--- a/src/java/org/apache/cassandra/db/compaction/CompactionController.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionController.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Memtable;
 import org.apache.cassandra.db.RowPosition;
+import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.AlwaysPresentFilter;
 
@@ -76,7 +77,7 @@ public class CompactionController implements AutoCloseable
 
     void maybeRefreshOverlaps()
     {
-        if (doNotPurgeTombstones(cfs.keyspace.getName()))
+        if (doNotPurgeTombstones(cfs))
         {
             logger.debug("not refreshing overlaps - doNotPurgeTombstones returned true for keyspace {}", cfs.keyspace.getName());
             return;
@@ -94,7 +95,7 @@ public class CompactionController implements AutoCloseable
 
     private void refreshOverlaps()
     {
-        if (doNotPurgeTombstones(cfs.keyspace.getName()))
+        if (doNotPurgeTombstones(cfs))
         {
             logger.debug("not refreshing overlaps - doNotPurgeTombstones returned true for keyspace {}", cfs.keyspace.getName());
             return;
@@ -138,7 +139,7 @@ public class CompactionController implements AutoCloseable
         if (compacting == null)
             return Collections.<SSTableReader>emptySet();
 
-        if (doNotPurgeTombstones(cfStore.keyspace.getName())) {
+        if (doNotPurgeTombstones(cfStore)) {
             logger.debug("not looking for droppable sstables - doNotPurgeTombstones returned true for keyspace {}", cfStore.keyspace.getName());
             return Collections.<SSTableReader>emptySet();
         }
@@ -207,7 +208,7 @@ public class CompactionController implements AutoCloseable
      */
     public Predicate<Long> getPurgeEvaluator(DecoratedKey key)
     {
-        if (doNotPurgeTombstones(getKeyspace()))
+        if (doNotPurgeTombstones(cfs))
         {
             logger.debug("Purge evaluator always returning false - doNotPurgeTombstones returned true for keyspace {}", getKeyspace());
             return Predicates.alwaysFalse();
@@ -265,17 +266,18 @@ public class CompactionController implements AutoCloseable
     }
 
     /**
-     * @param keyspace
+     * @param cfs
      * @return true if this node may be streaming data for this keyspace, or if cassandra.never_purge_tombstones is set
      * If we are streaming, tombstones should not be purged so that we don't pre-maturely purge those that exceed gc_grace_seconds.
      * <p>
      * Note that this node may receive data without streaming, e.g. during a repair.
      */
-    private static boolean doNotPurgeTombstones(String keyspace)
+    private static boolean doNotPurgeTombstones(ColumnFamilyStore cfs)
     {
         return NEVER_PURGE_TOMBSTONES
                 || StorageService.instance.isRebuilding()
-                || pendingRangesExistForKeyspace(keyspace);
+                || pendingRangesExistForKeyspace(cfs.keyspace.getName())
+                || ActiveRepairService.instance.isRepairing(cfs.metadata.cfId);
     }
 
     /**

--- a/src/java/org/apache/cassandra/service/ActiveRepairService.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairService.java
@@ -499,6 +499,18 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
         }
     }
 
+    public boolean isRepairing(UUID cfId)
+    {
+        for (ParentRepairSession session : parentRepairSessions.values())
+        {
+            if (session.isRepairing(cfId))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * We keep a ParentRepairSession around for the duration of the entire repair, for example, on a 256 token vnode rf=3 cluster
      * we would have 768 RepairSession but only one ParentRepairSession. We use the PRS to avoid anticompacting the sstables
@@ -628,6 +640,18 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
                 if (snapshotGenerations.contains(sstable.descriptor.generation))
                     activeSSTables.add(sstable);
             return activeSSTables;
+        }
+
+        synchronized boolean isRepairing(UUID cfId)
+        {
+            for (ColumnFamilyStore cfs : columnFamilyStores.values())
+            {
+                if (cfs.metadata.cfId.equals(cfId))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public synchronized void maybeSnapshot(UUID cfId, UUID parentSessionId)

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
@@ -19,8 +19,11 @@
 package org.apache.cassandra.db.compaction;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Sets;
@@ -38,6 +41,7 @@ import org.apache.cassandra.db.composites.CellName;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.locator.SimpleStrategy;
+import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
@@ -53,6 +57,7 @@ public class CompactionControllerTest extends SchemaLoader
     private static final String KEYSPACE = "CompactionControllerTest";
     private static final String CF1 = "Standard1";
     private static final String CF2 = "Standard2";
+    private static final String CF3 = "Standard3";
 
     @BeforeClass
     public static void defineSchema() throws ConfigurationException
@@ -62,7 +67,8 @@ public class CompactionControllerTest extends SchemaLoader
                                     SimpleStrategy.class,
                                     KSMetaData.optsWithRF(1),
                                     SchemaLoader.standardCFMD(KEYSPACE, CF1),
-                                    SchemaLoader.standardCFMD(KEYSPACE, CF2));
+                                    SchemaLoader.standardCFMD(KEYSPACE, CF2),
+                                    SchemaLoader.standardCFMD(KEYSPACE, CF3));
     }
 
     @Test
@@ -209,6 +215,44 @@ public class CompactionControllerTest extends SchemaLoader
         } finally {
             StorageService.instance.unsafeSetRebuilding(false);
         }
+    }
+
+
+    @Test
+    public void testTombstonesNotPurgedWhenRepairing()
+    {
+        Keyspace keyspace = Keyspace.open(KEYSPACE);
+        ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF3);
+        cfs.truncateBlocking();
+
+        ByteBuffer rowKey = ByteBufferUtil.bytes("key");
+
+        long timestamp1 = FBUtilities.timestampMicros();
+        long timestamp2 = timestamp1 - 5;
+
+        // create sstable with tombstone that should be expired in no older timestamps
+        applyDeleteMutation(CF3, rowKey, timestamp2);
+        cfs.forceBlockingFlush();
+
+        // first sstable with tombstone is compacting
+        Set<SSTableReader> compacting = Sets.newHashSet(cfs.getSSTables());
+
+        applyMutation(CF3, rowKey, timestamp1);
+        cfs.forceBlockingFlush();
+
+        // second sstable is overlapping
+        Set<SSTableReader> overlapping = Sets.difference(Sets.newHashSet(cfs.getSSTables()), compacting);
+
+        // the first sstable should be expired because the overlapping sstable is newer and the gc period is later
+        int gcBefore = (int) (System.currentTimeMillis() / 1000) + 5;
+
+        UUID repairUuid = UUID.randomUUID();
+        ActiveRepairService.instance.registerParentRepairSession(
+            repairUuid, FBUtilities.getLocalAddress(), Collections.singletonList(cfs), Collections.emptySet(), false, false);
+
+        assertEquals(CompactionController.getFullyExpiredSSTables(cfs, compacting, overlapping, gcBefore), Collections.emptySet());
+        ActiveRepairService.instance.removeParentRepairSession(repairUuid);
+        assertEquals(CompactionController.getFullyExpiredSSTables(cfs, compacting, overlapping, gcBefore), compacting);
     }
 
     private void applyMutation(String cf, ByteBuffer rowKey, long timestamp)


### PR DESCRIPTION
Based on #630 

This PR disables the purging of tombstones for any ColumnFamilies that are being repaired.

We assume that our internal cassandra-manager is used, where each repair command only targets a single keyspace+columnFamily. This means that each `ParentRepairSession` only tracks a single `ColumnFamilyStore`, so it is cheap to iterate over `columnFamilyStores.values()`.