### PR TITLE
Add Logging for Compactions Over 5GiB

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -128,8 +128,12 @@ public class CompactionTask extends AbstractCompactionTask
 
         final long expectedWriteSize = checkAvailableDiskSpaceAndGetWriteSize(checkAvailableDiskSpaceFunction);
 
-        if (expectedWriteSize > 5 * 1024 * 1024 * 1024) {
-            logger.info(String.format("Compaction for ks/cf %s/%s exceeds 5GiB with total size of %d", cfs.keyspace, cfs.name, expectedWriteSize));
+        if (expectedWriteSize > 5 * 1024 * 1024 * 1024)
+        {
+            logger.info("Compaction for ks/cf {}/{} exceeds 5GiB with total size of {}",
+                    SafeArg.of("keyspace", cfs.keyspace),
+                    SafeArg.of("columnFamily", cfs.name),
+                    SafeArg.of("size", expectedWriteSize));
         }
 
         // sanity check: all sstables must belong to the same cfs

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -128,8 +128,8 @@ public class CompactionTask extends AbstractCompactionTask
 
         final long expectedWriteSize = checkAvailableDiskSpaceAndGetWriteSize(checkAvailableDiskSpaceFunction);
 
-        if (expectedWriteSize > 200 * 1024 * 1024 * 1024) {
-            logger.info(String.format("Compaction for ks/cf %s/%s exceeds 200GiB with total size of %d", cfs.keyspace, cfs.name, expectedWriteSize));
+        if (expectedWriteSize > 5 * 1024 * 1024 * 1024) {
+            logger.info(String.format("Compaction for ks/cf %s/%s exceeds 5GiB with total size of %d", cfs.keyspace, cfs.name, expectedWriteSize));
         }
 
         // sanity check: all sstables must belong to the same cfs

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -128,6 +128,10 @@ public class CompactionTask extends AbstractCompactionTask
 
         final long expectedWriteSize = checkAvailableDiskSpaceAndGetWriteSize(checkAvailableDiskSpaceFunction);
 
+        if (expectedWriteSize > 250 * 1024 * 1024 * 1024) {
+            logger.info(String.format("Compaction for ks/cf %s/%s exceeds 250G with total size of %d", cfs.keyspace, cfs.name, expectedWriteSize));
+        }
+
         // sanity check: all sstables must belong to the same cfs
         assert !Iterables.any(transaction.originals(), new Predicate<SSTableReader>()
         {

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -128,8 +128,8 @@ public class CompactionTask extends AbstractCompactionTask
 
         final long expectedWriteSize = checkAvailableDiskSpaceAndGetWriteSize(checkAvailableDiskSpaceFunction);
 
-        if (expectedWriteSize > 250 * 1024 * 1024 * 1024) {
-            logger.info(String.format("Compaction for ks/cf %s/%s exceeds 250G with total size of %d", cfs.keyspace, cfs.name, expectedWriteSize));
+        if (expectedWriteSize > 5 * 1024 * 1024 * 1024) {
+            logger.info(String.format("Compaction for ks/cf %s/%s exceeds 5GiB with total size of %d", cfs.keyspace, cfs.name, expectedWriteSize));
         }
 
         // sanity check: all sstables must belong to the same cfs

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -128,8 +128,8 @@ public class CompactionTask extends AbstractCompactionTask
 
         final long expectedWriteSize = checkAvailableDiskSpaceAndGetWriteSize(checkAvailableDiskSpaceFunction);
 
-        if (expectedWriteSize > 5 * 1024 * 1024 * 1024) {
-            logger.info(String.format("Compaction for ks/cf %s/%s exceeds 5GiB with total size of %d", cfs.keyspace, cfs.name, expectedWriteSize));
+        if (expectedWriteSize > 200 * 1024 * 1024 * 1024) {
+            logger.info(String.format("Compaction for ks/cf %s/%s exceeds 200GiB with total size of %d", cfs.keyspace, cfs.name, expectedWriteSize));
         }
 
         // sanity check: all sstables must belong to the same cfs


### PR DESCRIPTION
Add logging for compactions where the table is over 5GiB in size. This will be used to help inform operational steps and reduce the need to run `nodetool compactionstats`.