### PR TITLE
[DNM] Flags for disabling read repairs

### DIFF
--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -315,6 +315,8 @@ public class Config
     public int otc_coalescing_enough_coalesced_messages = 8;
 
     public volatile boolean coerce_read_consistency_all = false;
+    public volatile boolean disable_read_repair_mutation = false;
+    public volatile boolean disable_block_on_read_repair = false;
 
     public int windows_timer_interval = 0;
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2106,4 +2106,24 @@ public class DatabaseDescriptor
     {
         conf.coerce_read_consistency_all = value;
     }
+
+    public static boolean getDisableReadRepairMutation()
+    {
+        return conf.disable_read_repair_mutation;
+    }
+
+    public static void setDisableReadRepairMutation(boolean value)
+    {
+        conf.disable_read_repair_mutation = value;
+    }
+
+    public static boolean getDisableBlockOnReadRepair()
+    {
+        return conf.disable_block_on_read_repair;
+    }
+
+    public static void setDisableBlockOnReadRepair(boolean value)
+    {
+        conf.disable_block_on_read_repair = value;
+    }
 }

--- a/src/java/org/apache/cassandra/db/ReadVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/ReadVerbHandler.java
@@ -49,6 +49,16 @@ public class ReadVerbHandler implements IVerbHandler<ReadCommand>
         MessageOut<ReadResponse> reply = new MessageOut<ReadResponse>(MessagingService.Verb.REQUEST_RESPONSE,
                                                                       getResponse(command, row),
                                                                       ReadResponse.serializer);
+
+        if (command.isDigestQuery())
+        {
+            Keyspace.open(command.ksName).getColumnFamilyStore(command.cfName).metric.digestReads.mark();
+        }
+        else
+        {
+            Keyspace.open(command.ksName).getColumnFamilyStore(command.cfName).metric.dataReads.mark();
+        }
+
         Tracing.trace("Enqueuing response to {}", message.from);
         MessagingService.instance().sendReply(reply, id, message.from);
     }

--- a/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
@@ -190,9 +190,13 @@ public class ColumnFamilyMetrics
     public final Map<ConsistencyLevel, LatencyMetrics> coordinatorScanLatencyByCL;
 
     public final LatencyMetrics blockingReadRepairLatency;
+    public final Meter avoidedReadRepairs;
     public final Meter blockingReadRepairs;
     public final Meter attemptedReadRepairs;
     public final Meter backgroundReadRepairs;
+
+    public final Meter digestReads;
+    public final Meter dataReads;
 
     public final Counter largePartitionsCompacted;
 
@@ -426,9 +430,12 @@ public class ColumnFamilyMetrics
         coordinatorScanLatencyByCL = MetricUtils.byConsistencyLevel(cl -> new LatencyMetrics(factory, "CoordinatorScan", ",consistency=" + cl, coordinatorScanLatency));
 
         blockingReadRepairLatency = new LatencyMetrics(factory, "BlockingReadRepair", new LatencyMetrics(globalNameFactory, "BlockingReadRepair"));
+        avoidedReadRepairs = Metrics.meter(factory.createMetricName("AvoidedReadRepairs"));
         blockingReadRepairs = Metrics.meter(factory.createMetricName("BlockingReadRepairs"));
         backgroundReadRepairs = Metrics.meter(factory.createMetricName("BackgroundReadRepairs"));
         attemptedReadRepairs = Metrics.meter(factory.createMetricName("AttemptedReadRepairs"));
+        digestReads = Metrics.meter(factory.createMetricName("DigestReads"));
+        dataReads = Metrics.meter(factory.createMetricName("DataReads"));
         largePartitionsCompacted = Metrics.counter("LargePartitionsCompacted");
         pendingFlushes = createColumnFamilyCounter("PendingFlushes");
         bytesFlushed = createColumnFamilyCounter("BytesFlushed");

--- a/src/java/org/apache/cassandra/service/RowDataResolver.java
+++ b/src/java/org/apache/cassandra/service/RowDataResolver.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Iterables;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.columniterator.IdentityQueryFilter;
 import org.apache.cassandra.db.filter.IDiskAtomFilter;
@@ -109,6 +110,11 @@ public class RowDataResolver extends AbstractRowResolver
      */
     public static List<AsyncOneResponse> scheduleRepairs(ColumnFamily resolved, String keyspaceName, DecoratedKey key, List<ColumnFamily> versions, List<InetAddress> endpoints)
     {
+        if (DatabaseDescriptor.getDisableReadRepairMutation())
+        {
+            return Collections.emptyList();
+        }
+
         List<AsyncOneResponse> results = new ArrayList<AsyncOneResponse>(versions.size());
 
         for (int i = 0; i < versions.size(); i++)

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -1556,9 +1556,12 @@ public class StorageProxy implements StorageProxyMBean
                         RowDataResolver resolver = (RowDataResolver)handler.resolver;
                         try
                         {
-                            // wait for the repair writes to be acknowledged, to minimize impact on any replica that's
-                            // behind on writes in case the out-of-sync row is read multiple times in quick succession
-                            FBUtilities.waitOnFutures(resolver.repairResults, DatabaseDescriptor.getWriteRpcTimeout());
+                            if (!DatabaseDescriptor.getDisableBlockOnReadRepair())
+                            {
+                                // wait for the repair writes to be acknowledged, to minimize impact on any replica that's
+                                // behind on writes in case the out-of-sync row is read multiple times in quick succession
+                                FBUtilities.waitOnFutures(resolver.repairResults, DatabaseDescriptor.getWriteRpcTimeout());
+                            }
                         }
                         catch (TimeoutException e)
                         {

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -1967,7 +1967,10 @@ public class StorageProxy implements StorageProxyMBean
 
                 try
                 {
-                    FBUtilities.waitOnFutures(repairResponses, DatabaseDescriptor.getWriteRpcTimeout());
+                    if (!DatabaseDescriptor.getDisableBlockOnReadRepair())
+                    {
+                        FBUtilities.waitOnFutures(repairResponses, DatabaseDescriptor.getWriteRpcTimeout());
+                    }
                 }
                 catch (TimeoutException ex)
                 {

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -1450,6 +1450,7 @@ public class StorageProxy implements StorageProxyMBean
                 try
                 {
                     Row row = exec.get();
+                    Keyspace.open(exec.command.ksName).getColumnFamilyStore(exec.command.cfName).metric.avoidedReadRepairs.mark();
                     if (row != null)
                     {
                         row = exec.command.maybeTrim(row);

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5528,14 +5528,36 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         logger.info("Updated write_delay_in_s to {}", SafeArg.of("value", writeDelay));
     }
 
+    public boolean getCoerceReadConsistencyAll()
+    {
+        return DatabaseDescriptor.getCoerceReadConsistencyAll();
+    }
+
     public void setCoerceReadConsistencyAll(boolean value)
     {
         DatabaseDescriptor.setCoerceReadConsistencyAll(value);
         logger.info("Updated coerce_read_consistency_level to {}", SafeArg.of("value", value));
     }
 
-    public boolean getCoerceReadConsistencyAll()
+    public boolean getDisableReadRepairMutation()
     {
-        return DatabaseDescriptor.getCoerceReadConsistencyAll();
+        return DatabaseDescriptor.getDisableReadRepairMutation();
+    }
+
+    public void setDisableReadRepairMutation(boolean value)
+    {
+        DatabaseDescriptor.setDisableReadRepairMutation(value);
+        logger.info("Updated disable_read_repair_mutation to {}", SafeArg.of("value", value));
+    }
+
+    public boolean getDisableBlockOnReadRepair()
+    {
+        return DatabaseDescriptor.getDisableBlockOnReadRepair();
+    }
+
+    public void setDisableBlockOnReadRepair(boolean value)
+    {
+        DatabaseDescriptor.setDisableBlockOnReadRepair(value);
+        logger.info("Updated disable_block_on_read_repair to {}", SafeArg.of("value", value));
     }
 }

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -936,4 +936,12 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
     public boolean getCoerceReadConsistencyAll();
 
     public void setCoerceReadConsistencyAll(boolean value);
+
+    public boolean getDisableReadRepairMutation();
+
+    public void setDisableReadRepairMutation(boolean value);
+
+    public boolean getDisableBlockOnReadRepair();
+
+    public void setDisableBlockOnReadRepair(boolean value);
 }

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1194,6 +1194,26 @@ public class NodeProbe implements AutoCloseable
         ssProxy.setCoerceReadConsistencyAll(value);
     }
 
+    public boolean getDisableReadRepairMutation()
+    {
+        return ssProxy.getDisableReadRepairMutation();
+    }
+
+    public void setDisableReadRepairMutation(boolean value)
+    {
+        ssProxy.setDisableReadRepairMutation(value);
+    }
+
+    public boolean getDisableBlockOnReadRepair()
+    {
+        return ssProxy.getDisableBlockOnReadRepair();
+    }
+
+    public void setDisableBlockOnReadRepair(boolean value)
+    {
+        ssProxy.setDisableBlockOnReadRepair(value);
+    }
+
     // JMX getters for the o.a.c.metrics API below.
     /**
      * Retrieve cache metrics based on the cache type (KeyCache, RowCache, or CounterCache)

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -165,7 +165,11 @@ public class NodeTool
                 SetWriteDelay.class,
                 SetRangeScanTokenRangesWarnThreshold.class,
                 GetCoerceReadConsistencyAll.class,
-                SetCoerceReadConsistencyAll.class
+                SetCoerceReadConsistencyAll.class,
+                GetDisableReadRepairMutation.class,
+                SetDisableReadRepairMutation.class,
+                GetDisableBlockOnReadRepair.class,
+                SetDisableBlockOnReadRepair.class
         );
 
         Cli.CliBuilder<NodeToolCmdRunnable> builder = Cli.builder("nodetool");

--- a/src/java/org/apache/cassandra/tools/nodetool/GetDisableBlockOnReadRepair.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetDisableBlockOnReadRepair.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import io.airlift.command.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool;
+
+@Command(name = "getdisableblockonreadrepair", description = "Check if blocking on read repair is disabled")
+public class GetDisableBlockOnReadRepair extends NodeTool.NodeToolCmd
+{
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        probe.output().out.println(probe.getDisableBlockOnReadRepair());
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/GetDisableReadRepairMutation.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetDisableReadRepairMutation.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import io.airlift.command.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool;
+
+@Command(name = "getdisablereadrepairmutation", description = "Check if read repair mutations are disabled")
+public class GetDisableReadRepairMutation extends NodeTool.NodeToolCmd
+{
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        probe.output().out.println(probe.getDisableReadRepairMutation());
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/SetDisableBlockOnReadRepair.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/SetDisableBlockOnReadRepair.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import io.airlift.command.Arguments;
+import io.airlift.command.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool;
+
+@Command(name = "setdisableblockonreadrepair", description = "Disable block on read repair")
+public class SetDisableBlockOnReadRepair extends NodeTool.NodeToolCmd
+{
+    @Arguments(title = "flag", description = "true, or false (default)", required = true)
+    private String flag;
+
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        probe.setDisableBlockOnReadRepair(Boolean.parseBoolean(flag));
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/SetDisableReadRepairMutation.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/SetDisableReadRepairMutation.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import io.airlift.command.Arguments;
+import io.airlift.command.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool;
+
+@Command(name = "setdisablereadrepairmutation", description = "Disable read repair mutations")
+public class SetDisableReadRepairMutation extends NodeTool.NodeToolCmd
+{
+    @Arguments(title = "flag", description = "true, or false (default)", required = true)
+    private String flag;
+
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        probe.setDisableReadRepairMutation(Boolean.parseBoolean(flag));
+    }
+}


### PR DESCRIPTION
Based on #634 and #630 

This PR adds two new config options to `cassandra.yaml`, and their respective `nodetool` commands for checking/setting at runtime.

- `disable_block_on_read_repair` - this coordinator will read-repair as normal, but will not block on ACKs for `READ_REPAIR` verbs before returning to the client. The intention is to reduce the latency of read-repairs, at the cost of read-repairing multiple times if the same cell is read repeatedly.
- `disable_read_repair_mutation`- this coordinator will still resolve a full read in the case of digest mismatches, but will not send `READ_REPAIR` mutation verbs to any replicas. The intention is to reduce the write load on replicas.
