### PR TITLE
Add partition header when empty columns from stream

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnIndex.java
+++ b/src/java/org/apache/cassandra/db/ColumnIndex.java
@@ -221,7 +221,7 @@ public class ColumnIndex
 
         public void maybeWriteRowHeader() throws IOException
         {
-            if (lastColumn == null)
+            if (noAddedColumns())
             {
                 ByteBufferUtil.writeWithShortLength(key, output);
                 DeletionTime.serializer.serialize(deletionInfo.getTopLevelDeletion(), output);
@@ -235,11 +235,19 @@ public class ColumnIndex
             blockSize += size;
         }
 
+        public boolean noAddedColumns() {
+            return lastColumn == null;
+        }
+
+        public boolean isLive() {
+            return deletionInfo.isLive();
+        }
+
         public ColumnIndex build()
         {
             assert !tombstoneTracker.hasUnwrittenTombstones();  // finishAddingAtoms must be called before building.
             // all columns were GC'd after all
-            if (lastColumn == null)
+            if (noAddedColumns())
                 return ColumnIndex.EMPTY;
 
             // the last column may have fallen on an index boundary already.  if not, index it explicitly.
@@ -256,7 +264,7 @@ public class ColumnIndex
 
         public void maybeWriteEmptyRowHeader() throws IOException
         {
-            if (!deletionInfo.isLive())
+            if (!isLive())
                 maybeWriteRowHeader();
         }
     }

--- a/src/java/org/apache/cassandra/db/ColumnIndex.java
+++ b/src/java/org/apache/cassandra/db/ColumnIndex.java
@@ -219,7 +219,7 @@ public class ColumnIndex
             }
         }
 
-        private void maybeWriteRowHeader() throws IOException
+        public void maybeWriteRowHeader() throws IOException
         {
             if (lastColumn == null)
             {

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -273,8 +273,7 @@ public class BigTableWriter extends SSTableWriter
                 logger.warn("No cells written for key {} in appendFromStream for keyspace {} and cf {}",
                             UnsafeArg.of("key", key),
                             SafeArg.of("keyspace", metadata.ksName),
-                            SafeArg.of("cf", metadata.cfName),
-                            SafeArg.of(""));
+                            SafeArg.of("cf", metadata.cfName));
             }
             // Adds row header if no cells was written for this key
             columnIndexer.maybeWriteRowHeader();

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -264,9 +264,9 @@ public class BigTableWriter extends SSTableWriter
 
                 columnIndexer.add(atom); // This write the atom on disk too
             }
-            columnIndexer.finishAddingAtoms();
+            columnIndexer.maybeWriteRowHeader();
 
-            columnIndexer.maybeWriteEmptyRowHeader();
+            columnIndexer.finishAddingAtoms();
             dataFile.stream.writeShort(END_OF_ROW);
         }
         catch (IOException e)

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.io.sstable.*;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -46,6 +48,7 @@ import org.apache.cassandra.io.util.*;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.FilterFactory;
+import org.apache.cassandra.utils.Hex;
 import org.apache.cassandra.utils.IFilter;
 import org.apache.cassandra.utils.StreamingHistogram;
 import org.apache.cassandra.utils.concurrent.Transactional;
@@ -263,6 +266,13 @@ public class BigTableWriter extends SSTableWriter
                 maxDeletionTimeTracker.update(atom.getLocalDeletionTime());
 
                 columnIndexer.add(atom); // This write the atom on disk too
+            }
+            if(dataFile.getFilePointer() - currentPosition == 0)
+            {
+                logger.warn("No column cells written for key {} in appendFromStream for keyspace {} and cf {}",
+                            UnsafeArg.of("key", key),
+                            SafeArg.of("keyspace", metadata.ksName),
+                            SafeArg.of("cf", metadata.cfName));
             }
             columnIndexer.maybeWriteRowHeader();
 

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -268,7 +268,7 @@ public class BigTableWriter extends SSTableWriter
                 columnIndexer.add(atom); // This write the atom on disk too
             }
 
-            if (dataFile.getFilePointer() - currentPosition == 0)
+            if (columnIndexer.isLive() && columnIndexer.noAddedColumns())
             {
                 logger.warn("No cells written for key {} in appendFromStream for keyspace {} and cf {}",
                             UnsafeArg.of("key", key),

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -267,13 +267,16 @@ public class BigTableWriter extends SSTableWriter
 
                 columnIndexer.add(atom); // This write the atom on disk too
             }
-            if(dataFile.getFilePointer() - currentPosition == 0)
+
+            if (dataFile.getFilePointer() - currentPosition == 0)
             {
-                logger.warn("No column cells written for key {} in appendFromStream for keyspace {} and cf {}",
+                logger.warn("No cells written for key {} in appendFromStream for keyspace {} and cf {}",
                             UnsafeArg.of("key", key),
                             SafeArg.of("keyspace", metadata.ksName),
-                            SafeArg.of("cf", metadata.cfName));
+                            SafeArg.of("cf", metadata.cfName),
+                            SafeArg.of(""));
             }
+            // Adds row header if no cells was written for this key
             columnIndexer.maybeWriteRowHeader();
 
             columnIndexer.finishAddingAtoms();


### PR DESCRIPTION
### Summary
If a stream receives a sstable with a partition key and an empty set of column, eg:
```
{"key": "18668d64625541fd31808201",
 "cells": []},
```
the `appendFromStream` function will result in a corrupted sstable with the Data.db file solely containing an end of row `END_OF_ROW = 0x0000` for that key, while the index file will still refer its position. This PR ensures the resulting sstable is at parity with the input, in case we don't find a better solution to handle this on the sending side.

### Details of the issue
The appendFromStream function takes a key and an input stream and writes the content of the stream to a new sstable, deserializing each component of the row one after the other:
https://github.com/palantir/cassandra/blob/ee8619e8f2d5739e450a3928b06f2ed696765a0e/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java#L268
When the key has no cells but the row itself is not deleted (deletion info is default), `iter.next()` will return null right away: 
https://github.com/palantir/cassandra/blob/ee8619e8f2d5739e450a3928b06f2ed696765a0e/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java#L249
The function will then move on to adding the end of row flag, without adding any key header: https://github.com/palantir/cassandra/blob/ee8619e8f2d5739e450a3928b06f2ed696765a0e/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java#L280 and the key will be added to the index file.

On the next compaction, the reader will see the key in the index file but fail to deserialize ` 0x0000` because it expects a header. Example result:
```
./service/bin/sstable2json lb-1-big-Data.db

[
{"key": "X",
 "metadata": {"deletionInfo": {"markedForDeleteAt":5138089516213600898,"localDeletionTime":829355}},
 "cells": [Exception in thread "main" org.apache.cassandra.io.sstable.CorruptSSTableException: Corrupted: table-e7e3b4385c1d3ddc9f1df12add9e5c8c/lb-1-big-Data.db
    at org.apache.cassandra.io.sstable.SSTableIdentityIterator.hasNext(SSTableIdentityIterator.java:178)
```

### Fix
The fix calls `maybeWriteRowHeader` in all cases once we have finished adding the atoms:
https://github.com/palantir/cassandra/blob/e2e1cb89e7cfb82ba021320becacd1da61f2cd6e/src/java/org/apache/cassandra/db/ColumnIndex.java#L222

The previous code would only do this if the row was entirely deleted
https://github.com/palantir/cassandra/blob/e2e1cb89e7cfb82ba021320becacd1da61f2cd6e/src/java/org/apache/cassandra/db/ColumnIndex.java#L257

which makes sense since we don't actually expect to see any keys with empty cells in practice (root cause for this is still TBD but it seems reads and compactions can handle this state)

`maybeWriteRowHeader` checks if `lastColumn` is null before adding the header. `lastColumn` is updated whenever we add a cell to the output so this function should only write the header if no cells were ever written.

Alternative would be to move the header write fully out of the `ColumnIndex::add` function:
https://github.com/palantir/cassandra/blob/e2e1cb89e7cfb82ba021320becacd1da61f2cd6e/src/java/org/apache/cassandra/db/ColumnIndex.java#L184 
but this is called in a lot of other places so this feels less invasive