### PR TITLE
Fix compaction logging conditional

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -129,10 +129,10 @@ public class CompactionTask extends AbstractCompactionTask
 
         final long expectedWriteSize = checkAvailableDiskSpaceAndGetWriteSize(checkAvailableDiskSpaceFunction);
 
-        if (expectedWriteSize > 5 * 1024 * 1024 * 1024)
+        if (expectedWriteSize > 5 * 1024 * 1024 * 1024L)
         {
             logger.info("Compaction for ks/cf {}/{} exceeds 5GiB with total size of {}",
-                    SafeArg.of("keyspace", cfs.keyspace),
+                    SafeArg.of("keyspace", cfs.keyspace.getName()),
                     SafeArg.of("columnFamily", cfs.name),
                     SafeArg.of("size", expectedWriteSize));
         }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -61,7 +61,7 @@ public class CompactionTask extends AbstractCompactionTask
     protected static long totalBytesCompacted = 0;
     private CompactionExecutorStatsCollector collector;
     private static final boolean CONSIDER_CONCURRENT_COMPACTIONS = Boolean.getBoolean("palantir_cassandra.consider_concurrent_compactions");
-    private static final fiveGibibytesInBytes = 5 * 1024 * 1024 * 1024L;
+    private static final long fiveGibibytesInBytes = 5 * 1024 * 1024 * 1024L;
 
     public CompactionTask(ColumnFamilyStore cfs, LifecycleTransaction txn, int gcBefore, boolean offline)
     {

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -61,6 +61,7 @@ public class CompactionTask extends AbstractCompactionTask
     protected static long totalBytesCompacted = 0;
     private CompactionExecutorStatsCollector collector;
     private static final boolean CONSIDER_CONCURRENT_COMPACTIONS = Boolean.getBoolean("palantir_cassandra.consider_concurrent_compactions");
+    private static final fiveGibibytesInBytes = 5 * 1024 * 1024 * 1024L;
 
     public CompactionTask(ColumnFamilyStore cfs, LifecycleTransaction txn, int gcBefore, boolean offline)
     {
@@ -129,7 +130,7 @@ public class CompactionTask extends AbstractCompactionTask
 
         final long expectedWriteSize = checkAvailableDiskSpaceAndGetWriteSize(checkAvailableDiskSpaceFunction);
 
-        if (expectedWriteSize > 5 * 1024 * 1024 * 1024L)
+        if (expectedWriteSize > fiveGibibytesInBytes)
         {
             logger.info("Compaction for ks/cf {}/{} exceeds 5GiB with total size of {}",
                     SafeArg.of("keyspace", cfs.keyspace.getName()),

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -61,7 +61,7 @@ public class CompactionTask extends AbstractCompactionTask
     protected static long totalBytesCompacted = 0;
     private CompactionExecutorStatsCollector collector;
     private static final boolean CONSIDER_CONCURRENT_COMPACTIONS = Boolean.getBoolean("palantir_cassandra.consider_concurrent_compactions");
-    private static final long fiveGibibytesInBytes = 5 * 1024 * 1024 * 1024L;
+    private static final long FIVE_GIBIBYTES_IN_BYTES = 5 * 1024 * 1024 * 1024L;
 
     public CompactionTask(ColumnFamilyStore cfs, LifecycleTransaction txn, int gcBefore, boolean offline)
     {
@@ -130,7 +130,7 @@ public class CompactionTask extends AbstractCompactionTask
 
         final long expectedWriteSize = checkAvailableDiskSpaceAndGetWriteSize(checkAvailableDiskSpaceFunction);
 
-        if (expectedWriteSize > fiveGibibytesInBytes)
+        if (expectedWriteSize > FIVE_GIBIBYTES_IN_BYTES)
         {
             logger.info("Compaction for ks/cf {}/{} exceeds 5GiB with total size of {}",
                     SafeArg.of("keyspace", cfs.keyspace.getName()),


### PR DESCRIPTION
Fix compaction logging conditional as the current version overflows integers and will log compactions exceeding ~1.2GB in size, rather than the expected 5. 

Also, get the keyspace name for formatting, rather than keyspaces currently being appended with `Keyspace(name=`