### PR TITLE
Fix schema agreement for token allocator

### DIFF
--- a/src/java/com/palantir/cassandra/utils/SchemaAgreementCheck.java
+++ b/src/java/com/palantir/cassandra/utils/SchemaAgreementCheck.java
@@ -45,26 +45,26 @@ public class SchemaAgreementCheck
     private final Supplier<UUID> localSchemaVersionSupplier;
     private final Supplier<Set<Map.Entry<InetAddress, EndpointState>>> endpointStatesSupplier;
     private final InetAddress localAddress;
-    private final boolean isNewCluster;
+    private final boolean requirePeers;
 
-    public SchemaAgreementCheck()
+    public SchemaAgreementCheck(boolean requirePeers)
     {
         this(Schema.instance::getVersion,
              Gossiper.instance::getEndpointStates,
              FBUtilities.getBroadcastAddress(),
-             Boolean.getBoolean("palantir_cassandra.is_new_cluster"));
+             requirePeers);
     }
 
     @VisibleForTesting
     SchemaAgreementCheck(Supplier<UUID> localSchemaVersionSupplier,
                          Supplier<Set<Map.Entry<InetAddress, EndpointState>>> endpointStatesSupplier,
                          InetAddress localAddress,
-                         boolean isNewCluster)
+                         boolean requirePeers)
     {
         this.localSchemaVersionSupplier = localSchemaVersionSupplier;
         this.endpointStatesSupplier = endpointStatesSupplier;
         this.localAddress = localAddress;
-        this.isNewCluster = isNewCluster;
+        this.requirePeers = requirePeers;
     }
 
     public boolean isSchemaInAgreement() {
@@ -84,7 +84,7 @@ public class SchemaAgreementCheck
                           .filter(endpointState -> !ignoredEndpoints.contains(endpointState.getKey()))
                           .filter(endpointState -> !isLeftOrRemoved(endpointState.getValue()))
                           .allMatch(endpointState -> schemaIsEqualToLocalVersion(localSchemaVersion, endpointState.getKey(), endpointState.getValue()));
-            return (peerEndpointsExist || isNewCluster) && schemaIsInAgreeement;
+            return (peerEndpointsExist || !requirePeers) && schemaIsInAgreeement;
         }
         catch (Exception e)
         {

--- a/src/java/com/palantir/cassandra/utils/SchemaAgreementCheck.java
+++ b/src/java/com/palantir/cassandra/utils/SchemaAgreementCheck.java
@@ -37,8 +37,6 @@ import org.apache.cassandra.gms.ApplicationState;
 import org.apache.cassandra.gms.EndpointState;
 import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.gms.VersionedValue;
-import org.apache.cassandra.locator.TokenMetadata;
-import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 
 public class SchemaAgreementCheck
@@ -47,18 +45,26 @@ public class SchemaAgreementCheck
     private final Supplier<UUID> localSchemaVersionSupplier;
     private final Supplier<Set<Map.Entry<InetAddress, EndpointState>>> endpointStatesSupplier;
     private final InetAddress localAddress;
+    private final boolean isNewCluster;
 
     public SchemaAgreementCheck()
     {
-        this(Schema.instance::getVersion, Gossiper.instance::getEndpointStates, FBUtilities.getBroadcastAddress());
+        this(Schema.instance::getVersion,
+             Gossiper.instance::getEndpointStates,
+             FBUtilities.getBroadcastAddress(),
+             Boolean.getBoolean("palantir_cassandra.is_new_cluster"));
     }
 
     @VisibleForTesting
-    SchemaAgreementCheck(Supplier<UUID> localSchemaVersionSupplier, Supplier<Set<Map.Entry<InetAddress, EndpointState>>> endpointStatesSupplier, InetAddress localAddress)
+    SchemaAgreementCheck(Supplier<UUID> localSchemaVersionSupplier,
+                         Supplier<Set<Map.Entry<InetAddress, EndpointState>>> endpointStatesSupplier,
+                         InetAddress localAddress,
+                         boolean isNewCluster)
     {
         this.localSchemaVersionSupplier = localSchemaVersionSupplier;
         this.endpointStatesSupplier = endpointStatesSupplier;
         this.localAddress = localAddress;
+        this.isNewCluster = isNewCluster;
     }
 
     public boolean isSchemaInAgreement() {
@@ -78,7 +84,7 @@ public class SchemaAgreementCheck
                           .filter(endpointState -> !ignoredEndpoints.contains(endpointState.getKey()))
                           .filter(endpointState -> !isLeftOrRemoved(endpointState.getValue()))
                           .allMatch(endpointState -> schemaIsEqualToLocalVersion(localSchemaVersion, endpointState.getKey(), endpointState.getValue()));
-            return peerEndpointsExist && schemaIsInAgreeement;
+            return (peerEndpointsExist || isNewCluster) && schemaIsInAgreeement;
         }
         catch (Exception e)
         {

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -692,7 +692,7 @@ public class DatabaseDescriptor
             conf.server_encryption_options = conf.encryption_options;
         }
 
-        if (Boolean.getBoolean("palantir_cassandra.is_new_cluster"))
+        if (getIsNewCluster())
         {
             if (conf.data_file_directories.length == 0)
                 throw new ConfigurationException("At least one DataFileDirectory must be specified", false);
@@ -2105,5 +2105,10 @@ public class DatabaseDescriptor
 
     public static int getWriteDelay() {
         return conf.write_delay_in_s;
+    }
+
+    public static boolean getIsNewCluster()
+    {
+        return Boolean.getBoolean("palantir_cassandra.is_new_cluster");
     }
 }

--- a/src/java/org/apache/cassandra/dht/BootStrapper.java
+++ b/src/java/org/apache/cassandra/dht/BootStrapper.java
@@ -205,7 +205,7 @@ public class BootStrapper extends ProgressEventNotifierSupport
                                             int numTokens,
                                             int schemaWaitDelay)
     {
-        StorageService.instance.waitForSchema(schemaWaitDelay);
+        StorageService.instance.waitForSchema(schemaWaitDelay, !DatabaseDescriptor.getIsNewCluster());
         if (!FBUtilities.getBroadcastAddress().equals(InetAddress.getLoopbackAddress()))
             Gossiper.waitToSettle();
 
@@ -224,7 +224,7 @@ public class BootStrapper extends ProgressEventNotifierSupport
                                             int numTokens,
                                             int schemaWaitDelay)
     {
-        StorageService.instance.waitForSchema(schemaWaitDelay);
+        StorageService.instance.waitForSchema(schemaWaitDelay, !DatabaseDescriptor.getIsNewCluster());
         if (!FBUtilities.getBroadcastAddress().equals(InetAddress.getLoopbackAddress()))
             Gossiper.waitToSettle();
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -902,14 +902,14 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
     }
 
-    public void waitForSchema(int delay)
+    public void waitForSchema(int delay, boolean requirePeers)
     {
         // first sleep the delay to make sure we see all our peers
         Uninterruptibles.sleepUninterruptibly(delay, TimeUnit.MILLISECONDS);
 
         // if our schema hasn't matched yet, keep sleeping until it does
         // (post CASSANDRA-1391 we don't expect this to be necessary very often, but it doesn't hurt to be careful)
-        SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck();
+        SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(requirePeers);
         List<InetAddress> ignoredEndpoints = replacing && !isReplacingSameAddress() ?
                                              ImmutableList.of(DatabaseDescriptor.getReplaceAddress()) : ImmutableList.of();
 
@@ -979,7 +979,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                 setBootstrapState(SystemKeyspace.BootstrapState.IN_PROGRESS);
             }
             setMode(Mode.JOINING, "waiting for ring information", true);
-            waitForSchema(delay);
+            waitForSchema(delay, true);
             setMode(Mode.JOINING, "schema complete, ready to bootstrap", true);
             setMode(Mode.JOINING, "waiting for pending range calculation", true);
             PendingRangeCalculatorService.instance.blockUntilFinished();
@@ -4176,7 +4176,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         if (operationMode != Mode.NORMAL)
             throw new UnsupportedOperationException("Node in " + operationMode + " state; wait for status to become normal or restart");
 
-        SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck();
+        SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(true);
         if(!schemaAgreementCheck.isSchemaInAgreement()) {
             throw new UnsupportedOperationException("The cluster does not agree on schema; wait for agreement before triggering a decommission");
         }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -917,8 +917,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         {
             setMode(Mode.JOINING, "waiting for schema information to complete", true);
             logger.info(
-            "Local schema version {} is not consistent with peers, waiting for schema to become consistent",
-            SafeArg.of("localSchemaVersion", Schema.instance.getVersion().toString()));
+                "Local schema version {} is not consistent with peers, waiting for schema to become consistent",
+                SafeArg.of("localSchemaVersion", Schema.instance.getVersion().toString()));
             Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
         }
     }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5427,7 +5427,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     @Override
     public boolean isNewCluster()
     {
-        return Boolean.parseBoolean(System.getProperty("palantir_cassandra.is_new_cluster", "false"));
+        return DatabaseDescriptor.getIsNewCluster();
     }
 
     @Override

--- a/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
+++ b/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
@@ -51,7 +51,8 @@ public class SchemaAgreementCheckTest
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state,
                                                                                                    InetAddresses.forString("127.0.0.2"), state,
                                                                                                    InetAddresses.forString("127.0.0.3"), state).entrySet(),
-                                                                             InetAddresses.forString("127.0.0.1"));
+                                                                             InetAddresses.forString("127.0.0.1"),
+                                                                             false);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isTrue();
     }
 
@@ -70,7 +71,8 @@ public class SchemaAgreementCheckTest
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state1,
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
                                                                                                    InetAddresses.forString("127.0.0.3"), state2).entrySet(),
-                                                                             InetAddresses.forString("127.0.0.1"));
+                                                                             InetAddresses.forString("127.0.0.1"),
+                                                                             false);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isFalse();
     }
 
@@ -85,7 +87,8 @@ public class SchemaAgreementCheckTest
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state1,
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
                                                                                                    InetAddresses.forString("127.0.0.3"), state2).entrySet(),
-                                                                             InetAddresses.forString("127.0.0.1"));
+                                                                             InetAddresses.forString("127.0.0.1"),
+                                                                             false);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isFalse();
     }
 
@@ -101,7 +104,8 @@ public class SchemaAgreementCheckTest
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state1,
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
                                                                                                    InetAddresses.forString("127.0.0.3"), state2).entrySet(),
-                                                                             InetAddresses.forString("127.0.0.1"));
+                                                                             InetAddresses.forString("127.0.0.1"),
+                                                                             false);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isTrue();
     }
 
@@ -117,7 +121,8 @@ public class SchemaAgreementCheckTest
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state1,
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
                                                                                                    InetAddresses.forString("127.0.0.3"), state2).entrySet(),
-                                                                             InetAddresses.forString("127.0.0.1"));
+                                                                             InetAddresses.forString("127.0.0.1"),
+                                                                             false);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isTrue();
     }
 
@@ -133,7 +138,8 @@ public class SchemaAgreementCheckTest
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state1,
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
                                                                                                    InetAddresses.forString("127.0.0.3"), state2).entrySet(),
-                                                                             InetAddresses.forString("127.0.0.1"));
+                                                                             InetAddresses.forString("127.0.0.1"),
+                                                                             false);
         assertThat(schemaAgreementCheck.isSchemaInAgreement(ImmutableList.of(InetAddresses.forString("127.0.0.3")))).isTrue();
     }
 
@@ -153,7 +159,8 @@ public class SchemaAgreementCheckTest
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state1,
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
                                                                                                    InetAddresses.forString("127.0.0.3"), state2).entrySet(),
-                                                                             InetAddresses.forString("127.0.0.1"));
+                                                                             InetAddresses.forString("127.0.0.1"),
+                                                                             false);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isFalse();
     }
 
@@ -165,7 +172,8 @@ public class SchemaAgreementCheckTest
 
         SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(() -> schema,
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state).entrySet(),
-                                                                             InetAddresses.forString("127.0.0.1"));
+                                                                             InetAddresses.forString("127.0.0.1"),
+                                                                             false);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isFalse();
     }
 

--- a/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
+++ b/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
@@ -52,7 +52,7 @@ public class SchemaAgreementCheckTest
                                                                                                    InetAddresses.forString("127.0.0.2"), state,
                                                                                                    InetAddresses.forString("127.0.0.3"), state).entrySet(),
                                                                              InetAddresses.forString("127.0.0.1"),
-                                                                             false);
+                                                                             true);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isTrue();
     }
 
@@ -72,7 +72,7 @@ public class SchemaAgreementCheckTest
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
                                                                                                    InetAddresses.forString("127.0.0.3"), state2).entrySet(),
                                                                              InetAddresses.forString("127.0.0.1"),
-                                                                             false);
+                                                                             true);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isFalse();
     }
 
@@ -88,7 +88,7 @@ public class SchemaAgreementCheckTest
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
                                                                                                    InetAddresses.forString("127.0.0.3"), state2).entrySet(),
                                                                              InetAddresses.forString("127.0.0.1"),
-                                                                             false);
+                                                                             true);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isFalse();
     }
 
@@ -105,7 +105,7 @@ public class SchemaAgreementCheckTest
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
                                                                                                    InetAddresses.forString("127.0.0.3"), state2).entrySet(),
                                                                              InetAddresses.forString("127.0.0.1"),
-                                                                             false);
+                                                                             true);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isTrue();
     }
 
@@ -122,7 +122,7 @@ public class SchemaAgreementCheckTest
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
                                                                                                    InetAddresses.forString("127.0.0.3"), state2).entrySet(),
                                                                              InetAddresses.forString("127.0.0.1"),
-                                                                             false);
+                                                                             true);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isTrue();
     }
 
@@ -139,7 +139,7 @@ public class SchemaAgreementCheckTest
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
                                                                                                    InetAddresses.forString("127.0.0.3"), state2).entrySet(),
                                                                              InetAddresses.forString("127.0.0.1"),
-                                                                             false);
+                                                                             true);
         assertThat(schemaAgreementCheck.isSchemaInAgreement(ImmutableList.of(InetAddresses.forString("127.0.0.3")))).isTrue();
     }
 
@@ -160,7 +160,7 @@ public class SchemaAgreementCheckTest
                                                                                                    InetAddresses.forString("127.0.0.2"), state1,
                                                                                                    InetAddresses.forString("127.0.0.3"), state2).entrySet(),
                                                                              InetAddresses.forString("127.0.0.1"),
-                                                                             false);
+                                                                             true);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isFalse();
     }
 
@@ -173,7 +173,7 @@ public class SchemaAgreementCheckTest
         SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(() -> schema,
                                                                              () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state).entrySet(),
                                                                              InetAddresses.forString("127.0.0.1"),
-                                                                             false);
+                                                                             true);
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isFalse();
     }
 

--- a/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
+++ b/test/unit/com/palantir/cassandra/utils/SchemaAgreementCheckTest.java
@@ -177,6 +177,19 @@ public class SchemaAgreementCheckTest
         assertThat(schemaAgreementCheck.isSchemaInAgreement()).isFalse();
     }
 
+    @Test
+    public void checkSchemaAgreement_passesIfEndpointsAreMissingRequirePeersDisabled()
+    {
+        UUID schema = UUID.randomUUID();
+        EndpointState state = createNormal(schema);
+
+        SchemaAgreementCheck schemaAgreementCheck = new SchemaAgreementCheck(() -> schema,
+                                                                             () -> ImmutableMap.of(InetAddresses.forString("127.0.0.1"), state).entrySet(),
+                                                                             InetAddresses.forString("127.0.0.1"),
+                                                                             false);
+        assertThat(schemaAgreementCheck.isSchemaInAgreement()).isTrue();
+    }
+
     private static EndpointState createNormal(UUID schema)
     {
         EndpointState state = EndpointStateFactory.create();

--- a/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
+++ b/test/unit/org/apache/cassandra/dht/BootStrapperTest.java
@@ -66,6 +66,7 @@ public class BootStrapperTest
     @BeforeClass
     public static void setup() throws ConfigurationException
     {
+        System.setProperty("palantir_cassandra.is_new_cluster", "true");
         oldPartitioner = DatabaseDescriptor.getPartitioner();
         DatabaseDescriptor.setPartitioner(Murmur3Partitioner.instance);
         SchemaLoader.startGossiper();


### PR DESCRIPTION
Merging https://github.com/palantir/cassandra/pull/626 and https://github.com/palantir/cassandra/pull/623 cause a conflict resulting in test failures.

The new token allocator requires that schema is in agreement before proceeding, but our modified schema agreement check requires the existence of at least one peer endpoint.

Previously this was not an issue because the schema agreement check was run for new non-seed nodes when they bootstrapped, but now the token allocator runs on every new node, including seeds.

This PR removes the requirement for a peer endpoint to exist in the schema agreement check when run by the allocator, but preserves that requirement during the existing bootstrap and decommission paths.