### PR TITLE
Add allocator tests for skewed clusters and BOP

### DIFF
--- a/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
@@ -200,10 +200,14 @@ public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
             if (verifyMetrics)
             {
                 updateSummary(t, su, st, true);
-                double maxExpected = 1.0 + tc.spreadExpectation() * strategy.spreadExpectation() / perUnitCount / Math.pow(skewFactor, 2);
+                double maxExpected = Math.pow(skewFactor, -0.25) + tc.spreadExpectation() * strategy.spreadExpectation() / perUnitCount;
                 if (su.max > maxExpected)
                 {
                     Assert.fail(String.format("Expected max unit size below %.4f, was %.4f", maxExpected, su.max));
+                }
+                else
+                {
+                    System.out.println("Threshold: " + maxExpected);
                 }
             }
         }

--- a/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
@@ -57,7 +57,7 @@ public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
         testNewCluster(new ByteOrderedPartitioner());
     }
 
-    private void testNewCluster(IPartitioner partitioner)
+    public void testNewCluster(IPartitioner partitioner)
     {
         for (int perUnitCount = 1; perUnitCount <= MAX_VNODE_COUNT; perUnitCount *= 4)
         {
@@ -117,7 +117,7 @@ public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
         testExistingCluster(new ByteOrderedPartitioner());
     }
 
-    private void testExistingCluster(IPartitioner partitioner)
+    public void testExistingCluster(IPartitioner partitioner)
     {
         for (int perUnitCount = 1; perUnitCount <= MAX_VNODE_COUNT; perUnitCount *= 4)
         {

--- a/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
@@ -205,10 +205,6 @@ public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
                 {
                     Assert.fail(String.format("Expected max unit size below %.4f, was %.4f", maxExpected, su.max));
                 }
-                else
-                {
-                    System.out.println("Threshold: " + maxExpected);
-                }
             }
         }
     }

--- a/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
@@ -30,6 +30,7 @@ import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.junit.Test;
 
 import junit.framework.Assert;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.dht.RandomPartitioner;
@@ -48,6 +49,12 @@ public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
     public void testNewClusterWithRandomPartitioner()
     {
         testNewCluster(new RandomPartitioner());
+    }
+
+    @Test
+    public void testNewClusterWithByteOrderedPartitioner()
+    {
+        testNewCluster(new ByteOrderedPartitioner());
     }
 
     private void testNewCluster(IPartitioner partitioner)
@@ -81,6 +88,33 @@ public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
     public void testExistingClusterWithRandomPartitioner()
     {
         testExistingCluster(new RandomPartitioner());
+    }
+
+    @Test
+    public void testExistingClusterWithByteOrderedPartitioner()
+    {
+        testExistingCluster(new ByteOrderedPartitioner());
+    }
+
+    @Test
+    public void testExistingClusterSkewedWithMurmur3Partitioner()
+    {
+        skewFactor = 0.6;
+        testExistingCluster(new Murmur3Partitioner());
+    }
+
+    @Test
+    public void testExistingClusterSkewedWithRandomPartitioner()
+    {
+        skewFactor = 0.5;
+        testExistingCluster(new RandomPartitioner());
+    }
+
+    @Test
+    public void testExistingClusterSkewedWithByteOrderedPartitioner()
+    {
+        skewFactor = 0.5;
+        testExistingCluster(new ByteOrderedPartitioner());
     }
 
     private void testExistingCluster(IPartitioner partitioner)
@@ -166,10 +200,14 @@ public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
             if (verifyMetrics)
             {
                 updateSummary(t, su, st, true);
-                double maxExpected = 1.0 + tc.spreadExpectation() * strategy.spreadExpectation() / perUnitCount;
+                double maxExpected = 1.0 + tc.spreadExpectation() * strategy.spreadExpectation() / perUnitCount / Math.pow(skewFactor, 2);
                 if (su.max > maxExpected)
                 {
                     Assert.fail(String.format("Expected max unit size below %.4f, was %.4f", maxExpected, su.max));
+                }
+                else
+                {
+                    System.out.printf("Expected max unit size below %.4f, was %.4f%n\n", maxExpected, su.max);
                 }
             }
         }

--- a/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorTest.java
@@ -205,10 +205,6 @@ public class NoReplicationTokenAllocatorTest extends TokenAllocatorTestBase
                 {
                     Assert.fail(String.format("Expected max unit size below %.4f, was %.4f", maxExpected, su.max));
                 }
-                else
-                {
-                    System.out.printf("Expected max unit size below %.4f, was %.4f%n\n", maxExpected, su.max);
-                }
             }
         }
     }

--- a/test/long/org/apache/cassandra/dht/tokenallocator/TokenAllocatorTestBase.java
+++ b/test/long/org/apache/cassandra/dht/tokenallocator/TokenAllocatorTestBase.java
@@ -25,6 +25,8 @@ import java.util.Random;
 
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
+import org.junit.Before;
+
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token;
 
@@ -35,6 +37,14 @@ abstract class TokenAllocatorTestBase
 {
     protected static final int TARGET_CLUSTER_SIZE = 250;
     protected static final int MAX_VNODE_COUNT = 64;
+
+    protected double skewFactor;
+
+    @Before
+    public void beforeEach()
+    {
+        skewFactor = 1;
+    }
 
     interface TestReplicationStrategy extends ReplicationStrategy<Unit>
     {
@@ -111,7 +121,8 @@ abstract class TokenAllocatorTestBase
             int tokens = tc.tokenCount(perUnitCount, rand);
             for (int j = 0; j < tokens; j++)
             {
-                map.put(partitioner.getRandomToken(rand), unit);
+                Token token = partitioner.getRandomToken(rand);
+                map.put(partitioner.split(partitioner.getMinimumToken(), token, skewFactor), unit);
             }
         }
     }


### PR DESCRIPTION
This PR introduces some more tests for the token allocator first added in #623.

1. Runs the existing `NoReplicationTokenAllocatorTest` on the `ByteOrderedPartitioner`. When `rf == num_racks`, the `NoReplicationTokenAllocator` is used.
2. Adds new tests to the `NoReplicationTokenAllocatorTest` for clusters that are initially skewed. These tests are controlled by a skew factor.