### PR TITLE
Cleanup and scrub propagate replay stats

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.compaction.CompactionInfo.Holder;
+import org.apache.cassandra.db.composites.CellNameType;
 import org.apache.cassandra.db.index.SecondaryIndexBuilder;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.dht.Bounds;
@@ -1227,12 +1228,17 @@ public class CompactionManager implements CompactionManagerMBean
     {
         FileUtils.createDirectory(compactionFileLocation);
 
-        return SSTableWriter.create(cfs.metadata,
-                                    Descriptor.fromFilename(cfs.getTempSSTablePath(compactionFileLocation)),
+        MetadataCollector collector = new MetadataCollector(Collections.singletonList(sstable),
+                                                            cfs.metadata.comparator,
+                                                            sstable.getSSTableLevel(),
+                                                            false);
+
+        return SSTableWriter.create(Descriptor.fromFilename(cfs.getTempSSTablePath(compactionFileLocation)),
                                     expectedBloomFilterSize,
                                     repairedAt,
-                                    sstable.getSSTableLevel(),
-                                    cfs.partitioner);
+                                    cfs.metadata,
+                                    cfs.partitioner,
+                                    collector);
     }
 
     public static SSTableWriter createWriterForAntiCompaction(ColumnFamilyStore cfs,

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -1119,7 +1119,7 @@ public class CompactionManager implements CompactionManagerMBean
     @VisibleForTesting
     void doCleanupOne(final ColumnFamilyStore cfs, LifecycleTransaction txn, Collection<Range<Token>> ranges) throws IOException
     {
-        doCleanupOne(cfs, txn, new CleanupStrategy.Full(cfs, ranges), ranges,false);
+        doCleanupOne(cfs, txn, CleanupStrategy.get(cfs, ranges), ranges,false);
     }
 
     private static abstract class CleanupStrategy

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -1114,6 +1114,13 @@ public class CompactionManager implements CompactionManagerMBean
 
     }
 
+    /* Used in tests. */
+    @VisibleForTesting
+    void doCleanupOne(final ColumnFamilyStore cfs, LifecycleTransaction txn, Collection<Range<Token>> ranges) throws IOException
+    {
+        doCleanupOne(cfs, txn, new CleanupStrategy.Full(cfs, ranges), ranges,false);
+    }
+
     private static abstract class CleanupStrategy
     {
         public static CleanupStrategy get(ColumnFamilyStore cfs, Collection<Range<Token>> ranges)

--- a/src/java/org/apache/cassandra/io/sstable/metadata/MetadataCollector.java
+++ b/src/java/org/apache/cassandra/io/sstable/metadata/MetadataCollector.java
@@ -107,6 +107,11 @@ public class MetadataCollector
     protected ICardinality cardinality = new HyperLogLogPlus(13, 25);
     private final CellNameType columnNameComparator;
 
+    /**
+     * Warning: this constructor does not propagate replay metadata.
+     * If the targeted sstable is derived from existing ones, use
+     * MetadataCollector(sstables, columnNameComparator, level, skipAncestors) instead.
+     */
     public MetadataCollector(CellNameType columnNameComparator)
     {
         this.columnNameComparator = columnNameComparator;

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
@@ -784,6 +784,7 @@ public class CompactionsTest
 
         ReplayPosition upperBound = sstable.getSSTableMetadata().commitLogUpperBound;
         ReplayPosition lowerBound = sstable.getSSTableMetadata().commitLogLowerBound;
+        assertTrue(lowerBound != ReplayPosition.NONE);
         assertTrue(upperBound != ReplayPosition.NONE);
 
         LifecycleTransaction txn = store.getTracker().tryModify(store.getSSTables(), OperationType.UNKNOWN);
@@ -794,8 +795,8 @@ public class CompactionsTest
         SSTableReader cleanedSstable = store.getSSTables().iterator().next();
 
         assertTrue(cleanedSstable.descriptor.generation != sstable.descriptor.generation);
-        assertTrue(cleanedSstable.getSSTableMetadata().commitLogLowerBound == lowerBound);
-        assertTrue(cleanedSstable.getSSTableMetadata().commitLogUpperBound == upperBound);
+        assertEquals(cleanedSstable.getSSTableMetadata().commitLogLowerBound, lowerBound);
+        assertEquals(cleanedSstable.getSSTableMetadata().commitLogUpperBound, upperBound);
 
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
@@ -784,7 +784,6 @@ public class CompactionsTest
 
         ReplayPosition upperBound = sstable.getSSTableMetadata().commitLogUpperBound;
         ReplayPosition lowerBound = sstable.getSSTableMetadata().commitLogLowerBound;
-        assertTrue(lowerBound != ReplayPosition.NONE);
         assertTrue(upperBound != ReplayPosition.NONE);
 
         LifecycleTransaction txn = store.getTracker().tryModify(store.getSSTables(), OperationType.UNKNOWN);

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.columniterator.IdentityQueryFilter;
 import org.apache.cassandra.db.columniterator.OnDiskAtomIterator;
+import org.apache.cassandra.db.commitlog.ReplayPosition;
 import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
 import org.apache.cassandra.db.compaction.writers.MaxSSTableSizeWriter;
 import org.apache.cassandra.db.filter.QueryFilter;
@@ -74,7 +75,7 @@ import static org.mockito.Mockito.*;
 public class CompactionsTest
 {
     private static final String KEYSPACE1 = "Keyspace1";
-    private static final String CF_STANDARD1 = "CF_STANDARD1";
+    private static final String CF_STANDARD1 = "Standard1";
     private static final String CF_STANDARD2 = "Standard2";
     private static final String CF_STANDARD3 = "Standard3";
     private static final String CF_STANDARD4 = "Standard4";
@@ -82,6 +83,7 @@ public class CompactionsTest
     private static final String CF_STANDARD6 = "Standard6";
     private static final String CF_STANDARD7 = "Standard7";
     private static final String CF_STANDARD8 = "Standard8";
+    private static final String CF_STANDARD9 = "Standard9";
     private static final String CF_SUPER1 = "Super1";
     private static final String CF_SUPER5 = "Super5";
     private static final String CF_SUPERGC = "SuperDirectGC";
@@ -103,6 +105,7 @@ public class CompactionsTest
                                     SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD6),
                                     SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD7),
                                     SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD8),
+                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD9),
                                     SchemaLoader.superCFMD(KEYSPACE1, CF_SUPER1, LongType.instance),
                                     SchemaLoader.superCFMD(KEYSPACE1, CF_SUPER5, BytesType.instance),
                                     SchemaLoader.superCFMD(KEYSPACE1, CF_SUPERGC, BytesType.instance).gcGraceSeconds(0));
@@ -701,6 +704,102 @@ public class CompactionsTest
         assertTrue("compaction resources were closed successfully after an interrupted compaction", compaction.compactionController.closed);
     }
 
+    @Test
+    public void testCompactionPropagatesReplayPositions() throws InterruptedException
+    {
+        Keyspace keyspace = Keyspace.open(KEYSPACE1);
+        final String cfname = CF_STANDARD9; // use clean(no sstable) CF
+        ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(cfname);
+
+        // disable compaction while flushing
+        cfs.disableAutoCompaction();
+
+        for (int i = 0; i < 2; i++) {
+            DecoratedKey key = Util.dk(String.valueOf(i));
+            Mutation rm = new Mutation(KEYSPACE1, key.getKey());
+            rm.add(cfname, Util.cellname("col"),
+                   ByteBufferUtil.EMPTY_BYTE_BUFFER,
+                   System.currentTimeMillis());
+            rm.applyUnsafe();
+            cfs.forceBlockingFlush();
+        }
+
+        Collection<SSTableReader> sstables = cfs.getSSTables();
+        assertEquals(2, sstables.size());
+
+        Iterator<SSTableReader> sstableIterator = sstables.iterator();
+        SSTableReader sstable1 = sstableIterator.next();
+        SSTableReader sstable2 = sstableIterator.next();
+
+        int maxGeneration = Math.max(sstable1.descriptor.generation, sstable2.descriptor.generation);
+
+        ReplayPosition lowerBound1 = sstable1.getSSTableMetadata().commitLogLowerBound;
+        ReplayPosition upperBound1 = sstable1.getSSTableMetadata().commitLogUpperBound;
+        ReplayPosition lowerBound2 = sstable2.getSSTableMetadata().commitLogLowerBound;
+        ReplayPosition upperBound2 = sstable2.getSSTableMetadata().commitLogUpperBound;
+
+        ReplayPosition minLowerBound = lowerBound1.compareTo(lowerBound2) < 0 ? lowerBound1 : lowerBound2;
+        ReplayPosition maxUpperBound = upperBound1.compareTo(upperBound2) > 0 ? upperBound1 : upperBound2;
+
+        assertTrue(minLowerBound.compareTo(maxUpperBound) < 0);
+        assertTrue(maxUpperBound != ReplayPosition.NONE);
+
+        String file1 = new File(sstable1.descriptor.filenameFor(Component.DATA)).getAbsolutePath();
+        String file2 = new File(sstable2.descriptor.filenameFor(Component.DATA)).getAbsolutePath();
+
+        CompactionManager.instance.forceUserDefinedCompaction(file1 + "," + file2);
+        do
+        {
+            Thread.sleep(100);
+        } while (CompactionManager.instance.getPendingTasks() > 0 || CompactionManager.instance.getActiveCompactions() > 0);
+        // CF should have only one sstable with generation number advanced
+        sstables = cfs.getSSTables();
+        assertEquals(1, sstables.size());
+        SSTableReader compactedSstable = sstables.iterator().next();
+
+        assertEquals(maxGeneration + 1, compactedSstable.descriptor.generation);
+        assertEquals(minLowerBound, compactedSstable.getSSTableMetadata().commitLogLowerBound);
+        assertEquals(maxUpperBound, compactedSstable.getSSTableMetadata().commitLogUpperBound);
+    }
+
+    @Test
+    public void testCleanupPropagatesReplayPositions() throws IOException
+    {
+        Keyspace keyspace = Keyspace.open(KEYSPACE1);
+        ColumnFamilyStore store = keyspace.getColumnFamilyStore(CF_STANDARD1);
+        store.clearUnsafe();
+
+        // disable compaction while flushing
+        store.disableAutoCompaction();
+
+        // write two groups of 9 keys: [001, 002, ... 008, 009] and [101, 102, ... 108, 109]
+        for (int i = 1; i < 10; i++)
+        {
+            insertRowWithKey(i);
+            insertRowWithKey(i + 100);
+        }
+        store.forceBlockingFlush();
+
+        assertEquals(1, store.getSSTables().size());
+        SSTableReader sstable = store.getSSTables().iterator().next();
+
+        ReplayPosition upperBound = sstable.getSSTableMetadata().commitLogUpperBound;
+        ReplayPosition lowerBound = sstable.getSSTableMetadata().commitLogLowerBound;
+        assertTrue(upperBound != ReplayPosition.NONE);
+
+        LifecycleTransaction txn = store.getTracker().tryModify(store.getSSTables(), OperationType.UNKNOWN);
+        Collection<Range<Token>> ranges = makeRanges(100, 109);
+        CompactionManager.instance.doCleanupOne(store, txn, ranges);
+
+        assertEquals(1, store.getSSTables().size());
+        SSTableReader cleanedSstable = store.getSSTables().iterator().next();
+
+        assertTrue(cleanedSstable.descriptor.generation != sstable.descriptor.generation);
+        assertTrue(cleanedSstable.getSSTableMetadata().commitLogLowerBound == lowerBound);
+        assertTrue(cleanedSstable.getSSTableMetadata().commitLogUpperBound == upperBound);
+
+    }
+
     private static class FailedAbortCompactionWriter extends MaxSSTableSizeWriter
     {
 
@@ -796,7 +895,7 @@ public class CompactionsTest
         long timestamp = System.currentTimeMillis();
         DecoratedKey decoratedKey = Util.dk(String.format("%03d", key));
         Mutation rm = new Mutation(KEYSPACE1, decoratedKey.getKey());
-        rm.add("CF_STANDARD1", Util.cellname("col"), ByteBufferUtil.EMPTY_BYTE_BUFFER, timestamp, 1000);
+        rm.add("Standard1", Util.cellname("col"), ByteBufferUtil.EMPTY_BYTE_BUFFER, timestamp, 1000);
         rm.applyUnsafe();
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
@@ -83,7 +83,6 @@ public class CompactionsTest
     private static final String CF_STANDARD6 = "Standard6";
     private static final String CF_STANDARD7 = "Standard7";
     private static final String CF_STANDARD8 = "Standard8";
-    private static final String CF_STANDARD9 = "Standard9";
     private static final String CF_SUPER1 = "Super1";
     private static final String CF_SUPER5 = "Super5";
     private static final String CF_SUPERGC = "SuperDirectGC";
@@ -105,7 +104,6 @@ public class CompactionsTest
                                     SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD6),
                                     SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD7),
                                     SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD8),
-                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD9),
                                     SchemaLoader.superCFMD(KEYSPACE1, CF_SUPER1, LongType.instance),
                                     SchemaLoader.superCFMD(KEYSPACE1, CF_SUPER5, BytesType.instance),
                                     SchemaLoader.superCFMD(KEYSPACE1, CF_SUPERGC, BytesType.instance).gcGraceSeconds(0));
@@ -708,8 +706,9 @@ public class CompactionsTest
     public void testCompactionPropagatesReplayPositions() throws InterruptedException
     {
         Keyspace keyspace = Keyspace.open(KEYSPACE1);
-        final String cfname = CF_STANDARD9; // use clean(no sstable) CF
+        final String cfname = CF_STANDARD4;
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(cfname);
+        cfs.clearUnsafe();
 
         // disable compaction while flushing
         cfs.disableAutoCompaction();


### PR DESCRIPTION
### Context

Unlike compaction, the cleanup operation targets each SSTable individually: [code ref](https://github.com/palantir/cassandra/blob/36c51744810e357bf104c19b6ae2864d1a700a41/src/java/org/apache/cassandra/db/compaction/CompactionManager.java#L511). For each SSTable, Cassandra first checks if it contains any data that is no longer owned by the node. If it does, Cassandra rewrites the SSTable through a compaction process, which also removes all unowned rows from the old SSTable.

Due to what appears to be a bug in the Cassandra implementation, the cleanup code does not propagate the replay statistics from the old SSTable to the writer ([createWriter](https://github.com/palantir/cassandra/blob/36c51744810e357bf104c19b6ae2864d1a700a41/src/java/org/apache/cassandra/db/compaction/CompactionManager.java#L1016) call from cleanup, resulting [SSTableWriter create](https://github.com/palantir/cassandra/blob/297cddf39475a9423ae81a653aae09b97a350424/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java#L98-L107)). Consequently, the new SSTable loses all replay position information from its predecessor:

```
Minimum replay position: ReplayPosition(segmentId=-1, position=0)
Maximum replay position: ReplayPosition(segmentId=-1, position=0)
```

It seems that Cassandra 5.0 still has the same behavior: https://github.com/apache/cassandra/blob/cassandra-5.0.3/src/java/org/apache/cassandra/db/compaction/CompactionManager.java#L1627.

As a result, after each horizontal expansion operation (typically followed by a cleanup), column families may have their replay position statistics completely erased. This can lead to resurrected data if, on the next restart, the commit log begins replaying data that has already been subject to gc_grace: https://issues.apache.org/jira/browse/CASSANDRA-8498.

### Fix
The codepath targeted by the fix is also used by the scrub operation. This should be the same principle as cleanup.
The reasoning here being that since cleanup solely removes data from SSTables that is no longer owned by the node, and the commit log writes data in continuously increasing positions, the replay statistics will remain valid even after cleanup. Replaying unowned data after the cleanup could actually be dangerous, as it might lead to data resurrection during the next decommissioning process.