### PR TITLE
tests demonstrating a failure case of CF digests

### DIFF
--- a/test/unit/com/palantir/cassandra/utils/DigestTest.java
+++ b/test/unit/com/palantir/cassandra/utils/DigestTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.utils;
+
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.junit.Test;
+
+import org.apache.cassandra.utils.FBUtilities;
+import org.assertj.core.api.ByteArrayAssert;
+
+public class DigestTest
+{
+    @Test
+    public void testDigestIsNotCommunative() throws Exception
+    {
+        MessageDigest digest1 = MessageDigest.getInstance("MD5");
+        MessageDigest digest2 = MessageDigest.getInstance("MD5");
+
+
+        byte[] a = new byte[] {'a'};
+        byte[] b = new byte[] {'b'};
+
+        digest1.update(a);
+        digest1.update(b);
+
+        digest2.update(b);
+        digest2.update(a);
+
+        new ByteArrayAssert(digest1.digest()).isNotEqualTo(digest2.digest());
+    }
+
+    @Test
+    public void testLongUpdateEquivalence() throws Exception
+    {
+        MessageDigest digest1 = MessageDigest.getInstance("MD5");
+        MessageDigest digest2 = MessageDigest.getInstance("MD5");
+
+        ByteBuffer longBuffer = ByteBuffer.allocate(8);
+        longBuffer.putLong(0, 42);
+        digest1.update(longBuffer.array(), 0, 8);
+
+        FBUtilities.updateWithLong(digest2, 42);
+
+        new ByteArrayAssert(digest1.digest()).isEqualTo(digest2.digest());
+    }
+}

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyTest.java
@@ -22,6 +22,8 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.TreeMap;
 
 import com.google.common.collect.Iterables;
@@ -36,12 +38,18 @@ import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.locator.SimpleStrategy;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.assertj.core.api.ByteArrayAssert;
 
 import static org.apache.cassandra.Util.column;
 import static org.apache.cassandra.Util.cellname;
 import static org.apache.cassandra.Util.tombstone;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.spy;
 
 public class ColumnFamilyTest
 {
@@ -233,5 +241,73 @@ public class ColumnFamilyTest
 
         assertEquals(ByteBufferUtil.bytes("col2"), stats.minColumnNames.get(0));
         assertEquals(ByteBufferUtil.bytes("col61"), stats.maxColumnNames.get(0));
+    }
+
+    @Test
+    public void testDigestCollision() throws Exception
+    {
+        // Cell digest: [ name, value, 8-bytes-timestamp, 0]
+        //              [ A,    B,     0,0,0,0,0,0,0,1,   0]
+        Cell cell = column("A", "B", 1);
+        MessageDigest cellDigest = MessageDigest.getInstance("MD5");
+        cell.updateDigest(cellDigest);
+
+        // DeletionInfo digest: [ start, end, 8-bytes-timestamp]
+        //                      [ A B,   0,   0,0,0,0,0,0,1,0  ]
+        RangeTombstone rangeTombstone = tombstone("AB", "\0", 1 << 8, 0);
+        ColumnFamily cf = ArrayBackedSortedColumns.factory.create(KEYSPACE1, CF_STANDARD1);
+        cf.delete(rangeTombstone);
+        MessageDigest deletionDigest = MessageDigest.getInstance("MD5");
+        cf.deletionInfo().updateDigest(deletionDigest);
+
+        // This is unexpected! A cell can be crafted to have the same digest as a range tombstone.
+        new ByteArrayAssert(cellDigest.digest()).isEqualTo(deletionDigest.digest());
+    }
+
+    @Test
+    public void testDigestCollisionRealisticTimestamps() throws Exception
+    {
+        long timeMicros = 11745568765000000L;
+
+        Cell cell = column("A", "B", timeMicros);
+        MessageDigest cellDigest = MessageDigest.getInstance("MD5");
+        cell.updateDigest(cellDigest);
+
+        RangeTombstone rangeTombstone = tombstone("AB", "\0", timeMicros << 8, 0);
+        ColumnFamily cf = ArrayBackedSortedColumns.factory.create(KEYSPACE1, CF_STANDARD1);
+        cf.delete(rangeTombstone);
+        MessageDigest deletionDigest = MessageDigest.getInstance("MD5");
+        cf.deletionInfo().updateDigest(deletionDigest);
+
+        // This is unexpected! A cell can be crafted to have the same digest as a range tombstone.
+        new ByteArrayAssert(cellDigest.digest()).isEqualTo(deletionDigest.digest());
+    }
+
+    @Test
+    public void testCfDigestCollision() throws Exception
+    {
+        ColumnFamily cf1 = ArrayBackedSortedColumns.factory.create(KEYSPACE1, CF_STANDARD1);
+        ColumnFamily cf2 = ArrayBackedSortedColumns.factory.create(KEYSPACE1, CF_STANDARD1);
+
+        Cell c1 = column("A", "X", 1);
+        Cell c2 = column("B", "C", 1);
+
+        RangeTombstone del2 = tombstone("BC", "\0", 1 << 8, 0);
+
+        cf1.addColumn(c1);
+        cf1.addColumn(c2);
+
+        cf2.addColumn(c1);
+        cf2.delete(del2);
+
+        assertFalse(cf1.equals(cf2));
+
+        MessageDigest digest1 = MessageDigest.getInstance("MD5");
+        MessageDigest digest2 = MessageDigest.getInstance("MD5");
+
+        cf1.updateDigest(digest1);
+        cf2.updateDigest(digest2);
+
+        new ByteArrayAssert(digest1.digest()).isEqualTo(digest2.digest());
     }
 }


### PR DESCRIPTION
During the review of #639, some concerns were raised about the potential for digest collisions when added the PageToken to the column family digest.

We should expect CFs that are not equal to have different digests, except for the unlucky hash collision.
After close inspection, it appears that the existing code is actually vulnerable to collisions of crafted Cells or DeletionInfos.

A Cell digest has the following structure
```
[ name, value, 8-bytes-timestamp, 0]
```

A DeletionInfo digest has the following structure (assuming there is no row tombstone)
```
[ start, end, 8-bytes-timestamp]
```

`name`, `value` in the Cell and `start`, `end` in the DeletionInfo are arbitrary-length ByteBuffers, so the structure of these digests is almost identical, except for the suffixed `0` at the end of the Cell digest. With some simple bit shifting, we can easily craft a Cell and a DeletionInfo that have the same digest.

```
cell("A", "B", 1)
[ name, value, 8-bytes-timestamp, 0]
[ 65,   66,    0,0,0,0,0,0,0,1,   0]

tombstone("AB", "\0", 1 << 8)
[ start,     end, 8-bytes-timestamp]
[ 65, 66,    0,   0,0,0,0,0,0,1,0 ]

```

