### PR TITLE
Coerce consistency level only for specified keyspaces

### DIFF
--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -314,6 +314,7 @@ public class Config
     public int otc_coalescing_window_us = otc_coalescing_window_us_default;
     public int otc_coalescing_enough_coalesced_messages = 8;
 
+    public volatile String[] coerce_read_consistency_all_ignored_keyspaces = new String[0];
     public volatile boolean coerce_read_consistency_all = false;
     public volatile boolean disable_read_repair_mutation = false;
     public volatile boolean disable_block_on_read_repair = false;

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -314,7 +315,7 @@ public class Config
     public int otc_coalescing_window_us = otc_coalescing_window_us_default;
     public int otc_coalescing_enough_coalesced_messages = 8;
 
-    public volatile String[] coerce_read_consistency_all_ignored_keyspaces = new String[0];
+    public volatile Set<String> coerce_read_consistency_all_keyspaces = new HashSet<>();
     public volatile boolean coerce_read_consistency_all = false;
     public volatile boolean disable_read_repair_mutation = false;
     public volatile boolean disable_block_on_read_repair = false;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2114,7 +2114,9 @@ public class DatabaseDescriptor
     }
 
     public static boolean getCoerceReadConsistencyAllForKeyspace(String keyspace) {
-        return conf.coerce_read_consistency_all && conf.coerce_read_consistency_all_keyspaces.contains(keyspace);
+        return conf.coerce_read_consistency_all &&
+               (conf.coerce_read_consistency_all_keyspaces.isEmpty() ||
+                conf.coerce_read_consistency_all_keyspaces.contains(keyspace));
     }
 
     public static void setCoerceReadConsistencyAllForKeyspace(Set<String> keyspaces) {

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -60,6 +60,7 @@ import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.thrift.ThriftServer;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.memory.*;
+import org.assertj.core.util.Sets;
 
 import static org.apache.cassandra.io.util.FileUtils.ONE_GB;
 import static org.apache.cassandra.io.util.FileUtils.ONE_MB;
@@ -111,6 +112,7 @@ public class DatabaseDescriptor
     private static boolean hasLoggedConfig;
 
     private static final String allHostsRaw = System.getProperty("palantir_cassandra.all_hosts", "");
+    private static final Set<String> coerceReadConsistencyIgnoredKeyspaces = Sets.newHashSet(Arrays.asList(conf.coerce_read_consistency_all_ignored_keyspaces));
 
     private static boolean daemonInitialized;
 
@@ -2105,6 +2107,14 @@ public class DatabaseDescriptor
     public static void setCoerceReadConsistencyAll(boolean value)
     {
         conf.coerce_read_consistency_all = value;
+    }
+
+    public static boolean getCoerceReadConsistencyAllForKeyspace(String keyspace) {
+        return conf.coerce_read_consistency_all && !coerceReadConsistencyIgnoredKeyspaces.contains(keyspace);
+    }
+
+    public static boolean setCoerceReadConsistencyAllForKeyspace(String keyspace) {
+        return coerceReadConsistencyIgnoredKeyspaces.add(keyspace);
     }
 
     public static boolean getDisableReadRepairMutation()

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2103,6 +2103,11 @@ public class DatabaseDescriptor
         return conf.coerce_read_consistency_all;
     }
 
+    public static Set<String> getCoerceReadConsistencyAllKeyspaces()
+    {
+        return conf.coerce_read_consistency_all_keyspaces;
+    }
+
     public static void setCoerceReadConsistencyAll(boolean value)
     {
         conf.coerce_read_consistency_all = value;
@@ -2112,8 +2117,8 @@ public class DatabaseDescriptor
         return conf.coerce_read_consistency_all && conf.coerce_read_consistency_all_keyspaces.contains(keyspace);
     }
 
-    public static void setCoerceReadConsistencyAllForKeyspace(String keyspace) {
-        conf.coerce_read_consistency_all_keyspaces.add(keyspace);
+    public static void setCoerceReadConsistencyAllForKeyspace(Set<String> keyspaces) {
+        conf.coerce_read_consistency_all_keyspaces = keyspaces;
     }
 
     public static boolean getDisableReadRepairMutation()

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -112,7 +112,6 @@ public class DatabaseDescriptor
     private static boolean hasLoggedConfig;
 
     private static final String allHostsRaw = System.getProperty("palantir_cassandra.all_hosts", "");
-    private static final Set<String> coerceReadConsistencyIgnoredKeyspaces = Sets.newHashSet(Arrays.asList(conf.coerce_read_consistency_all_ignored_keyspaces));
 
     private static boolean daemonInitialized;
 
@@ -2110,11 +2109,11 @@ public class DatabaseDescriptor
     }
 
     public static boolean getCoerceReadConsistencyAllForKeyspace(String keyspace) {
-        return conf.coerce_read_consistency_all && !coerceReadConsistencyIgnoredKeyspaces.contains(keyspace);
+        return conf.coerce_read_consistency_all && conf.coerce_read_consistency_all_keyspaces.contains(keyspace);
     }
 
-    public static boolean setCoerceReadConsistencyAllForKeyspace(String keyspace) {
-        return coerceReadConsistencyIgnoredKeyspaces.add(keyspace);
+    public static void setCoerceReadConsistencyAllForKeyspace(String keyspace) {
+        conf.coerce_read_consistency_all_keyspaces.add(keyspace);
     }
 
     public static boolean getDisableReadRepairMutation()

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -1276,7 +1276,6 @@ public class StorageProxy implements StorageProxyMBean
     public static List<Row> read(List<ReadCommand> commands, ConsistencyLevel consistencyLevel, ClientState state)
     throws UnavailableException, IsBootstrappingException, ReadFailureException, ReadTimeoutException, InvalidRequestException
     {
-        consistencyLevel = maybeCoerceReadConsistencyLevel(consistencyLevel);
         if (StorageService.instance.isBootstrapMode() && !systemKeyspaceQuery(commands))
         {
             consistencyLevelReadMetrics.get(consistencyLevel).unavailables.mark();
@@ -1300,16 +1299,15 @@ public class StorageProxy implements StorageProxyMBean
         final ConsistencyLevel consistencyForCommit = consistencyLevel == ConsistencyLevel.LOCAL_SERIAL
                                                                         ? ConsistencyLevel.LOCAL_QUORUM
                                                                         : ConsistencyLevel.QUORUM;
-        final ConsistencyLevel consistencyForFetch = maybeCoerceReadConsistencyLevel(consistencyForCommit);
-        ClientRequestMetrics readMetrics = consistencyLevelReadMetrics.get(consistencyForFetch);
+        ReadCommand command = commands.get(0);
+        consistencyLevel = maybeCoerceReadConsistencyLevel(command.ksName, consistencyForCommit);
+        ClientRequestMetrics readMetrics = consistencyLevelReadMetrics.get(consistencyLevel);
 
         try
         {
             // make sure any in-progress paxos writes are done (i.e., committed to a majority of replicas), before performing a quorum read
             if (commands.size() > 1)
                 throw new InvalidRequestException("SERIAL/LOCAL_SERIAL consistency may only be requested for one row at a time");
-            ReadCommand command = commands.get(0);
-
             CFMetaData metadata = Schema.instance.getCFMetaData(command.ksName, command.cfName);
             Pair<List<InetAddress>, Integer> p = getPaxosParticipants(command.ksName, command.key, consistencyLevel);
             List<InetAddress> liveEndpoints = p.left;
@@ -1330,7 +1328,7 @@ public class StorageProxy implements StorageProxyMBean
                 throw new ReadFailureException(consistencyLevel, e.received, e.failures, e.blockFor, false);
             }
 
-            rows = fetchRows(commands, consistencyForFetch);
+            rows = fetchRows(commands, consistencyLevel);
         }
         catch (UnavailableException e)
         {
@@ -1356,8 +1354,8 @@ public class StorageProxy implements StorageProxyMBean
             readMetrics.addNano(latency);
             casReadMetrics.addNano(latency);
             // TODO avoid giving every command the same latency number.  Can fix this in CASSADRA-5329
-            for (ReadCommand command : commands)
-                Keyspace.open(command.ksName).getColumnFamilyStore(command.cfName).metric.coordinatorReadLatencyByCL.get(consistencyForFetch).addNano(latency);
+            for (ReadCommand cmd : commands)
+                Keyspace.open(cmd.ksName).getColumnFamilyStore(cmd.cfName).metric.coordinatorReadLatencyByCL.get(consistencyLevel).addNano(latency);
         }
 
         return rows;
@@ -1434,6 +1432,7 @@ public class StorageProxy implements StorageProxyMBean
                 ReadCommand command = commands.get(i);
                 assert !command.isDigestQuery();
 
+                consistencyLevel = maybeCoerceReadConsistencyLevel(command.ksName, consistencyLevel);
                 AbstractReadExecutor exec = AbstractReadExecutor.getReadExecutor(command, consistencyLevel);
                 exec.executeAsync();
                 readExecutors[i] = exec;
@@ -1749,7 +1748,7 @@ public class StorageProxy implements StorageProxyMBean
     public static List<Row> getRangeSlice(AbstractRangeCommand command, ConsistencyLevel consistency_level)
     throws UnavailableException, ReadFailureException, ReadTimeoutException
     {
-        consistency_level = maybeCoerceReadConsistencyLevel(consistency_level);
+        consistency_level = maybeCoerceReadConsistencyLevel(command.keyspace, consistency_level);
         Tracing.trace("Computing ranges to query");
         long startTime = System.nanoTime();
 
@@ -2460,13 +2459,13 @@ public class StorageProxy implements StorageProxyMBean
         return ReadRepairMetrics.repairedBackground.getCount();
     }
 
-    private static ConsistencyLevel maybeCoerceReadConsistencyLevel(ConsistencyLevel consistencyLevel)
+    private static ConsistencyLevel maybeCoerceReadConsistencyLevel(String keyspace, ConsistencyLevel consistencyLevel)
     {
         if (!consistencyLevelIsSafeToCoerce(consistencyLevel))
         {
             return consistencyLevel;
         }
-        boolean shouldCoerce = DatabaseDescriptor.getCoerceReadConsistencyAll();
+        boolean shouldCoerce = DatabaseDescriptor.getCoerceReadConsistencyAllForKeyspace(keyspace);
         return shouldCoerce ? ConsistencyLevel.ALL : consistencyLevel;
     }
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5539,6 +5539,17 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         logger.info("Updated coerce_read_consistency_level to {}", SafeArg.of("value", value));
     }
 
+    public Set<String> getCoerceReadConsistencyAllKeyspaces()
+    {
+        return DatabaseDescriptor.getCoerceReadConsistencyAllKeyspaces();
+    }
+
+    public void setCoerceReadConsistencyAllKeyspaces(Set<String> value)
+    {
+        DatabaseDescriptor.setCoerceReadConsistencyAllForKeyspace(value);
+        logger.info("Updated keyspaces in coerce_read_consistency_level_keyspaces", SafeArg.of("value", value));
+    }
+
     public boolean getDisableReadRepairMutation()
     {
         return DatabaseDescriptor.getDisableReadRepairMutation();

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5539,6 +5539,11 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         logger.info("Updated coerce_read_consistency_level to {}", SafeArg.of("value", value));
     }
 
+    public boolean getCoerceReadConsistencyAllForKeyspace(String keyspace)
+    {
+        return DatabaseDescriptor.getCoerceReadConsistencyAllForKeyspace(keyspace);
+    }
+
     public Set<String> getCoerceReadConsistencyAllKeyspaces()
     {
         return DatabaseDescriptor.getCoerceReadConsistencyAllKeyspaces();

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -939,6 +939,8 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
 
     public Set<String> getCoerceReadConsistencyAllKeyspaces();
 
+    public boolean getCoerceReadConsistencyAllForKeyspace(String keyspace);
+
     public void setCoerceReadConsistencyAllKeyspaces(Set<String> value);
 
     public boolean getDisableReadRepairMutation();

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -937,6 +937,10 @@ public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkDa
 
     public void setCoerceReadConsistencyAll(boolean value);
 
+    public Set<String> getCoerceReadConsistencyAllKeyspaces();
+
+    public void setCoerceReadConsistencyAllKeyspaces(Set<String> value);
+
     public boolean getDisableReadRepairMutation();
 
     public void setDisableReadRepairMutation(boolean value);

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1194,6 +1194,10 @@ public class NodeProbe implements AutoCloseable
         ssProxy.setCoerceReadConsistencyAll(value);
     }
 
+    public boolean getCoerceReadConsistencyAllForKeyspace(String keyspace) {
+        return ssProxy.getCoerceReadConsistencyAllForKeyspace(keyspace);
+    }
+
     public Set<String> getCoerceReadConsistencyAllKeyspaces()
     {
         return ssProxy.getCoerceReadConsistencyAllKeyspaces();

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1194,6 +1194,16 @@ public class NodeProbe implements AutoCloseable
         ssProxy.setCoerceReadConsistencyAll(value);
     }
 
+    public Set<String> getCoerceReadConsistencyAllKeyspaces()
+    {
+        return ssProxy.getCoerceReadConsistencyAllKeyspaces();
+    }
+
+    public void setCoerceReadConsistencyAllKeyspaces(Set<String> value)
+    {
+        ssProxy.setCoerceReadConsistencyAllKeyspaces(value);
+    }
+
     public boolean getDisableReadRepairMutation()
     {
         return ssProxy.getDisableReadRepairMutation();

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -169,7 +169,9 @@ public class NodeTool
                 GetDisableReadRepairMutation.class,
                 SetDisableReadRepairMutation.class,
                 GetDisableBlockOnReadRepair.class,
-                SetDisableBlockOnReadRepair.class
+                SetDisableBlockOnReadRepair.class,
+                GetCoerceReadConsistencyAllKeyspaces.class,
+                SetCoerceReadConsistencyAllKeyspaces.class
         );
 
         Cli.CliBuilder<NodeToolCmdRunnable> builder = Cli.builder("nodetool");

--- a/src/java/org/apache/cassandra/tools/nodetool/GetCoerceReadConsistencyAllKeyspaces.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetCoerceReadConsistencyAllKeyspaces.java
@@ -18,12 +18,14 @@
 
 package org.apache.cassandra.tools.nodetool;
 
+import java.util.Set;
+
 import io.airlift.command.Command;
 import io.airlift.command.Option;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool;
 
-@Command(name = "getcoercereadconsistencyallkeyspaces", description = "Get all the keyspace coercion read consistency levels, or a single keyspace level if using the 'keyspace' option")
+@Command(name = "getcoercereadconsistencyallkeyspaces", description = "Get list of keyspaces for which read consistency level is coerced to ALL, or if, a keyspace is provided, whether that keyspace is coerced or not")
 public class GetCoerceReadConsistencyAllKeyspaces extends NodeTool.NodeToolCmd
 {
 
@@ -34,9 +36,14 @@ public class GetCoerceReadConsistencyAllKeyspaces extends NodeTool.NodeToolCmd
     public void execute(NodeProbe probe)
     {
         if (keyspace.isEmpty()) {
-            probe.output().out.println(probe.getCoerceReadConsistencyAllKeyspaces());
-            return;
+            Set<String> coercedKeyspaces = probe.getCoerceReadConsistencyAllKeyspaces();
+            if (coercedKeyspaces.isEmpty()) {
+                probe.output().out.println("All keyspaces coerced QUORUM read consistency to ALL");
+            } else {
+                probe.output().out.println(probe.getCoerceReadConsistencyAllKeyspaces());
+            }
+        } else {
+            probe.output().out.println(probe.getCoerceReadConsistencyAllForKeyspace(keyspace));
         }
-        probe.output().out.println(probe.getCoerceReadConsistencyAllKeyspaces().contains(keyspace));
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetCoerceReadConsistencyAllKeyspaces.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetCoerceReadConsistencyAllKeyspaces.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import io.airlift.command.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool;
+
+@Command(name = "getcoercereadconsistencyallkeyspaces", description = "Get the coerce read consistency level, if present")
+public class GetCoerceReadConsistencyAllKeyspaces extends NodeTool.NodeToolCmd
+{
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        probe.output().out.println(probe.getCoerceReadConsistencyAllKeyspaces());
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/GetCoerceReadConsistencyAllKeyspaces.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetCoerceReadConsistencyAllKeyspaces.java
@@ -35,7 +35,7 @@ public class GetCoerceReadConsistencyAllKeyspaces extends NodeTool.NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        if (keyspace.isEmpty()) {
+        if (keyspace == null || keyspace.isEmpty()) {
             Set<String> coercedKeyspaces = probe.getCoerceReadConsistencyAllKeyspaces();
             if (coercedKeyspaces.isEmpty()) {
                 probe.output().out.println("All keyspaces coerced QUORUM read consistency to ALL");

--- a/src/java/org/apache/cassandra/tools/nodetool/GetCoerceReadConsistencyAllKeyspaces.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetCoerceReadConsistencyAllKeyspaces.java
@@ -19,15 +19,24 @@
 package org.apache.cassandra.tools.nodetool;
 
 import io.airlift.command.Command;
+import io.airlift.command.Option;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool;
 
-@Command(name = "getcoercereadconsistencyallkeyspaces", description = "Get the coerce read consistency level, if present")
+@Command(name = "getcoercereadconsistencyallkeyspaces", description = "Get all the keyspace coercion read consistency levels, or a single keyspace level if using the 'keyspace' option")
 public class GetCoerceReadConsistencyAllKeyspaces extends NodeTool.NodeToolCmd
 {
+
+    @Option(name = {"-k", "--keyspace"}, description = "The keyspace to check for read consistency level coercion")
+    private String keyspace;
+
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.output().out.println(probe.getCoerceReadConsistencyAllKeyspaces());
+        if (keyspace.isEmpty()) {
+            probe.output().out.println(probe.getCoerceReadConsistencyAllKeyspaces());
+            return;
+        }
+        probe.output().out.println(probe.getCoerceReadConsistencyAllKeyspaces().contains(keyspace));
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/SetCoerceReadConsistencyAllKeyspaces.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/SetCoerceReadConsistencyAllKeyspaces.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import java.util.HashSet;
+import java.util.List;
+
+import io.airlift.command.Arguments;
+import io.airlift.command.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool;
+
+@Command(name = "setcoercereadconsistencyallkeyspaces", description = "Upgrade the consistency level used by all QUORUM requests to ALL, regardless of what is set by the client, for the provided keyspace")
+public class SetCoerceReadConsistencyAllKeyspaces extends NodeTool.NodeToolCmd
+{
+    @Arguments(title = "keyspaces", usage = "", description = "true to enable, false to disable (default)", required = true)
+    private List<String> keyspaces;
+
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        probe.setCoerceReadConsistencyAllKeyspaces(new HashSet<>(keyspaces));
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/SetCoerceReadConsistencyAllKeyspaces.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/SetCoerceReadConsistencyAllKeyspaces.java
@@ -26,10 +26,10 @@ import io.airlift.command.Command;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool;
 
-@Command(name = "setcoercereadconsistencyallkeyspaces", description = "Upgrade the consistency level used by all QUORUM requests to ALL, regardless of what is set by the client, for the provided keyspace")
+@Command(name = "setcoercereadconsistencyallkeyspaces", description = "Upgrade the consistency level used by all QUORUM requests to ALL, regardless of what is set by the client, for the provided keyspaces")
 public class SetCoerceReadConsistencyAllKeyspaces extends NodeTool.NodeToolCmd
 {
-    @Arguments(title = "keyspaces", usage = "", description = "true to enable, false to disable (default)", required = true)
+    @Arguments(title = "keyspaces", usage = "<keyspace> <keyspace> <keyspace>", description = "A space-delimited list of keyspaces to set coercion for", required = true)
     private List<String> keyspaces;
 
     @Override


### PR DESCRIPTION
Effectively the same change as in #678, this PR is based on a slightly later commit in the branch with all of these features (notably, the blocking read repair flags), and adds the ability to modify these settings with some additional nodetool commands, so restarts aren't necessary to update which keyspaces this applies to. 