### PR TITLE
Add Large Compaction Metrics

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -134,7 +134,7 @@ public class CompactionTask extends AbstractCompactionTask
         if (expectedWriteSize > FIVE_GIBIBYTES_IN_BYTES)
         {
             cfs.metric.incrementOngoingLargeCompactionTasks();
-            logger.info("Started compaction for ks/cf {}/{} that is expected to exceed 5GiB with size of {}",
+            logger.info("Starting compaction for ks/cf {}/{} that is expected to exceed 5GiB with size of {}",
                     SafeArg.of("keyspace", cfs.keyspace.getName()),
                     SafeArg.of("columnFamily", cfs.name),
                     SafeArg.of("size", expectedWriteSize));

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -131,8 +131,9 @@ public class CompactionTask extends AbstractCompactionTask
 
         final long expectedWriteSize = checkAvailableDiskSpaceAndGetWriteSize(checkAvailableDiskSpaceFunction);
 
-        if (expectedWriteSize > FIVE_GIBIBYTES_IN_BYTES)
+        if (expectedWriteSize > 0)
         {
+            cfs.metric.ongoingLargeCompactionTasks.inc();
             logger.info("Compaction for ks/cf {}/{} exceeds 5GiB with total size of {}",
                     SafeArg.of("keyspace", cfs.keyspace.getName()),
                     SafeArg.of("columnFamily", cfs.name),
@@ -315,6 +316,10 @@ public class CompactionTask extends AbstractCompactionTask
             // update the metrics
             cfs.metric.compactionBytesWritten.inc(endsize);
             cfs.metric.compactionsCompleted.inc();
+            if (expectedWriteSize > 0)
+            {
+                cfs.metric.ongoingLargeCompactionTasks.dec();
+            }
             CompactionThroughputThrottler.instance.maybeRemoveThrottledCompaction(cfs.metadata);
         }
     }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -131,10 +131,10 @@ public class CompactionTask extends AbstractCompactionTask
 
         final long expectedWriteSize = checkAvailableDiskSpaceAndGetWriteSize(checkAvailableDiskSpaceFunction);
 
-        if (expectedWriteSize > 0)
+        if (expectedWriteSize > FIVE_GIBIBYTES_IN_BYTES)
         {
-            cfs.metric.ongoingLargeCompactionTasks.inc();
-            logger.info("Compaction for ks/cf {}/{} exceeds 5GiB with total size of {}",
+            cfs.metric.incrementOngoingLargeCompactionTasks();
+            logger.info("Started compaction for ks/cf {}/{} that is expected to exceed 5GiB with size of {}",
                     SafeArg.of("keyspace", cfs.keyspace.getName()),
                     SafeArg.of("columnFamily", cfs.name),
                     SafeArg.of("size", expectedWriteSize));
@@ -316,9 +316,13 @@ public class CompactionTask extends AbstractCompactionTask
             // update the metrics
             cfs.metric.compactionBytesWritten.inc(endsize);
             cfs.metric.compactionsCompleted.inc();
-            if (expectedWriteSize > 0)
+            if (expectedWriteSize > FIVE_GIBIBYTES_IN_BYTES)
             {
-                cfs.metric.ongoingLargeCompactionTasks.dec();
+                cfs.metric.decrementOngoingLargeCompactionTasks();
+                logger.info("Finished compaction for ks/cf {}/{} that was expected to exceed 5GiB with an actual size of {}",
+                        SafeArg.of("keyspace", cfs.keyspace.getName()),
+                        SafeArg.of("columnFamily", cfs.name),
+                        SafeArg.of("size", endsize));
             }
             CompactionThroughputThrottler.instance.maybeRemoveThrottledCompaction(cfs.metadata);
         }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -137,7 +137,7 @@ public class CompactionTask extends AbstractCompactionTask
             logger.info("Starting compaction for ks/cf {}/{} that is expected to exceed 5GiB with size of {}",
                     SafeArg.of("keyspace", cfs.keyspace.getName()),
                     SafeArg.of("columnFamily", cfs.name),
-                    SafeArg.of("size", expectedWriteSize));
+                    SafeArg.of("sizeBytes", expectedWriteSize));
         }
 
         // sanity check: all sstables must belong to the same cfs
@@ -322,7 +322,7 @@ public class CompactionTask extends AbstractCompactionTask
                 logger.info("Finished compaction for ks/cf {}/{} that was expected to exceed 5GiB with an actual size of {}",
                         SafeArg.of("keyspace", cfs.keyspace.getName()),
                         SafeArg.of("columnFamily", cfs.name),
-                        SafeArg.of("size", endsize));
+                        SafeArg.of("sizeBytes", endsize));
             }
             CompactionThroughputThrottler.instance.maybeRemoveThrottledCompaction(cfs.metadata);
         }

--- a/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.metrics;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -42,7 +43,7 @@ import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
  */
 public class ColumnFamilyMetrics
 {
-
+    private final AtomicInteger ongoingLargeCompactionTaskCount = new AtomicInteger(0);
     /** Total amount of data stored in the memtable that resides on-heap, including column related overhead and overwritten rows. */
     public final Gauge<Long> memtableOnHeapSize;
     /** Total amount of data stored in the memtable that resides off-heap, including column related overhead and overwritten rows. */
@@ -174,14 +175,13 @@ public class ColumnFamilyMetrics
     public final Gauge<Double> liveTombstoneCount;
     /** Estimated count of tombstones and number of cells in this table */
     public final Gauge<Double> tombstoneCount;
+    /** Number of ongoing compactions over 5GiB */
+    public final Gauge<Integer> ongoingLargeCompactionTasks;
 
     /** Bytes read on range scans **/
     public final Meter rangeScanBytesRead;
     /** Bytes read on reads **/
     public final Meter readBytesRead;
-
-    /** Number of ongoing compactions over 5GiB */
-    public final Counter ongoingLargeCompactionTasks;
 
     public final LatencyMetrics coordinatorReadLatency;
     public final LatencyMetrics coordinatorReadScanLatency;
@@ -434,7 +434,6 @@ public class ColumnFamilyMetrics
         pendingFlushes = createColumnFamilyCounter("PendingFlushes");
         bytesFlushed = createColumnFamilyCounter("BytesFlushed");
         compactionBytesWritten = createColumnFamilyCounter("CompactionBytesWritten");
-        ongoingLargeCompactionTasks = createColumnFamilyCounter("OngoingLargeCompactionTasks");
         compactionsCompleted = createColumnFamilyCounter("CompactionsCompleted");
         pendingCompactions = createColumnFamilyGauge("PendingCompactions", new Gauge<Integer>()
         {
@@ -513,6 +512,23 @@ public class ColumnFamilyMetrics
                 return max;
             }
         });
+        ongoingLargeCompactionTasks = createColumnFamilyGauge(
+                "OngoingLargeCompactionTasks",
+                new Gauge<Integer>() {
+                    public Integer getValue() {
+                        return ongoingLargeCompactionTaskCount.get();
+                    }
+                },
+                new Gauge<Integer>() {
+                    public Integer getValue() {
+                        int total = 0;
+                        for (Metric cfGauge : allColumnFamilyMetrics.get("OngoingLargeCompactionTasks")) {
+                            total += ((Gauge<? extends Number>) cfGauge).getValue().intValue();
+                        }
+                        return total;
+                    }
+                }
+        );
         meanRowSize = createColumnFamilyGauge("MeanRowSize", new Gauge<Long>()
         {
             public Long getValue()
@@ -743,6 +759,14 @@ public class ColumnFamilyMetrics
         rangeScanBytesRead = Metrics.meter(factory.createMetricName("RangeScanBytesRead"));
         readBytesRead = Metrics.meter(factory.createMetricName("ReadBytesRead"));
         droppableTombstones = Metrics.meter(factory.createMetricName("DroppableTombstonesRead"));
+    }
+
+    public void incrementOngoingLargeCompactionTasks() {
+        ongoingLargeCompactionTaskCount.incrementAndGet();
+    }
+
+    public void decrementOngoingLargeCompactionTasks() {
+        ongoingLargeCompactionTaskCount.decrementAndGet();
     }
 
     public void updateSSTableIterated(int count)

--- a/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ColumnFamilyMetrics.java
@@ -180,6 +180,9 @@ public class ColumnFamilyMetrics
     /** Bytes read on reads **/
     public final Meter readBytesRead;
 
+    /** Number of ongoing compactions over 5GiB */
+    public final Counter ongoingLargeCompactionTasks;
+
     public final LatencyMetrics coordinatorReadLatency;
     public final LatencyMetrics coordinatorReadScanLatency;
     public final LatencyMetrics coordinatorScanLatency;
@@ -431,6 +434,7 @@ public class ColumnFamilyMetrics
         pendingFlushes = createColumnFamilyCounter("PendingFlushes");
         bytesFlushed = createColumnFamilyCounter("BytesFlushed");
         compactionBytesWritten = createColumnFamilyCounter("CompactionBytesWritten");
+        ongoingLargeCompactionTasks = createColumnFamilyCounter("OngoingLargeCompactionTasks");
         compactionsCompleted = createColumnFamilyCounter("CompactionsCompleted");
         pendingCompactions = createColumnFamilyGauge("PendingCompactions", new Gauge<Integer>()
         {


### PR DESCRIPTION
Add metrics and improve logging for large compactions (compactions expected to be over 5GiB in size).

- Metrics: A gauge that increments at the start of a large compaction task, and decrements at the end of that task.
- Logs: Clearer logging at the start and end of a large compaction, with the expected value logged at the start of the compaction and the actual value logged at the end.

This will help diagnose performance issues potentially caused by large, ongoing compactions. Tested this change on IL.