### PR TITLE
Remove two frequent allocations

### DIFF
--- a/src/java/com/palantir/cassandra/utils/OwnershipVerificationUtils.java
+++ b/src/java/com/palantir/cassandra/utils/OwnershipVerificationUtils.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -63,7 +64,7 @@ public class OwnershipVerificationUtils
             mutation,
             Keyspace.open(mutation.getKeyspaceName()),
             StorageService.getPartitioner().getToken(mutation.key()),
-            Hex.bytesToHex(mutation.key().array()),
+            OwnershipVerificationUtils::getKeyToLog,
             MutationVerificationHandler.INSTANCE);
     }
 
@@ -77,7 +78,7 @@ public class OwnershipVerificationUtils
             command,
             Keyspace.open(command.getKeyspace()),
             StorageService.getPartitioner().getToken(command.key),
-            Hex.bytesToHex(command.key.array()),
+            OwnershipVerificationUtils::getKeyToLog,
             ReadVerificationHandler.INSTANCE);
     }
 
@@ -91,11 +92,11 @@ public class OwnershipVerificationUtils
             command,
             Keyspace.open(command.keyspace),
             command.keyRange.right.getToken(),
-            command.keyRange.right.toString(),
+            OwnershipVerificationUtils::getKeyToLog,
             RangeSliceVerificationHandler.INSTANCE);
     }
 
-    private static <T> void verifyOperation(T payload, Keyspace keyspace, Token tk, String keyToLog, OwnershipVerificationHandler<T> handler)
+    private static <T> void verifyOperation(T payload, Keyspace keyspace, Token tk, Function<T, String> keyToLog, OwnershipVerificationHandler<T> handler)
     {
         if (!(keyspace.getReplicationStrategy() instanceof NetworkTopologyStrategy))
         {
@@ -127,7 +128,7 @@ public class OwnershipVerificationUtils
             {
                 logger.warn("Ignoring InvalidOwnership error detected using stale token ring cache. Error was originally detected for key {} in keyspace {}."
                                 + " Cached owners {}. Actual owners {}. Pending owners (non-cached) {}.",
-                            UnsafeArg.of("key", keyToLog),
+                            UnsafeArg.of("key", keyToLog.apply(payload)),
                             SafeArg.of("keyspace", keyspaceName),
                             SafeArg.of("cachedNaturalEndpoints", cachedNaturalEndpoints),
                             SafeArg.of("refreshedNaturalEndpoints", refreshedNaturalEndpoints),
@@ -135,6 +136,18 @@ public class OwnershipVerificationUtils
             }
         }
         handler.onValid(keyspace);
+    }
+
+    private static String getKeyToLog(Mutation mutation) {
+        return Hex.bytesToHex(mutation.key().array());
+    }
+
+    private static String getKeyToLog(ReadCommand command) {
+        return Hex.bytesToHex(command.key.array());
+    }
+
+    private static String getKeyToLog(AbstractRangeCommand command) {
+        return command.keyRange.right.toString();
     }
 
     private static void refreshCache()

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -2423,7 +2423,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
         assert !(range.keyRange() instanceof Range) || !((Range<?>)range.keyRange()).isWrapAround() || range.keyRange().right.isMinimum() : range.keyRange();
 
         final ViewFragment view = select(viewFilter(range.keyRange()));
-        Tracing.trace("Executing seq scan across {} sstables for {}", view.sstables.size(), range.keyRange().getString(metadata.getKeyValidator()));
+        Tracing.trace("Executing seq scan across {} sstables", view.sstables.size());
 
         final CloseableIterator<Row> iterator = RowIteratorFactory.getIterator(view.memtables, view.sstables, range, this, now);
 

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -2423,7 +2423,11 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
         assert !(range.keyRange() instanceof Range) || !((Range<?>)range.keyRange()).isWrapAround() || range.keyRange().right.isMinimum() : range.keyRange();
 
         final ViewFragment view = select(viewFilter(range.keyRange()));
-        Tracing.trace("Executing seq scan across {} sstables", view.sstables.size());
+
+        if (Tracing.isTracing())
+        {
+            Tracing.trace("Executing seq scan across {} sstables for {}", view.sstables.size(), range.keyRange().getString(metadata.getKeyValidator()));
+        }
 
         final CloseableIterator<Row> iterator = RowIteratorFactory.getIterator(view.memtables, view.sstables, range, this, now);
 


### PR DESCRIPTION
Noticed these two suspicious methods accounting for a rather large portion of `byte[]` allocations in a JFR I took recently.
(note that in this image I'm selected to only `byte[]` allocations, which accounted for around 16% of all allocations recorded, so these methods are quite a large proportion of total allocations!)

<img width="1980" alt="image" src="https://github.com/user-attachments/assets/cc9ec5c6-c517-4c70-a721-0e117a168f99" />

  - **OwnershipVerificationUtils.java:** This one is silly because the log is only logged if the verification fails, but the argument is converted to a string pre-emptively. I've made it pass through the stringify method to use and only stringify when necessary.
  - **ColumnFamilyStore.java:** This one is in a trace log, so it can't be optimised in the same way as above. But we don't consume Cassandra trace logs anyway AFAIK, so just opting to remove this arg.

A JFR with a similar load profile after this fix:
<img width="1979" alt="image" src="https://github.com/user-attachments/assets/6b2c7082-52cc-4b3b-bdcd-0c93072b9ca7" />
