### PR TITLE
Feature: Make filter experiment configurable

### DIFF
--- a/src/java/org/apache/cassandra/FilterExperiment.java
+++ b/src/java/org/apache/cassandra/FilterExperiment.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Timer;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Cell;
 import org.apache.cassandra.db.ColumnFamily;
 import org.apache.cassandra.db.DeletionInfo;
@@ -86,7 +87,7 @@ public enum FilterExperiment
     }
 
     public static boolean shouldRunExperiment() {
-        return ThreadLocalRandom.current().nextDouble() <= 0.01;
+        return ThreadLocalRandom.current().nextDouble() <= DatabaseDescriptor.getFilterExperimentProbability();
     }
 
     private static <T> T time(Supplier<T> delegate, Timer timer) {

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -322,6 +322,8 @@ public class Config
 
     public boolean enable_user_defined_functions = false;
 
+    public double filter_experiment_probability = 0.01;
+
     public static boolean getOutboundBindAny()
     {
         return outboundBindAny;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2111,4 +2111,8 @@ public class DatabaseDescriptor
     {
         return Boolean.getBoolean("palantir_cassandra.is_new_cluster");
     }
+
+    public static double getFilterExperimentProbability() {
+        return conf.filter_experiment_probability;
+    }
 }


### PR DESCRIPTION
There's only two failures of this experiment across the entire fleet - giving us not a lot of data to work with. If we could increase the times we run the experiment on internal stacks we may be able to reproduce this more easily. 