### PR TITLE
Add config to always submit local mutations to the SEP

### DIFF
--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -117,7 +117,6 @@ public class Config
     public Integer concurrent_reads = 32;
     public Integer concurrent_writes = 32;
     public Integer concurrent_counter_writes = 32;
-    public Boolean always_async_read = false;
     public Boolean always_async_write = false;
 
     @Deprecated
@@ -213,7 +212,7 @@ public class Config
     public int commitlog_segment_size_in_mb = 32;
     public ParameterizedClass commitlog_compression;
     public int commitlog_max_compression_buffers_in_pool = 3;
- 
+
     @Deprecated
     public int commitlog_periodic_queue_size = -1;
 

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -117,6 +117,8 @@ public class Config
     public Integer concurrent_reads = 32;
     public Integer concurrent_writes = 32;
     public Integer concurrent_counter_writes = 32;
+    public Boolean always_async_read = false;
+    public Boolean always_async_write = false;
 
     @Deprecated
     public Integer concurrent_replicates = null;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1235,10 +1235,6 @@ public class DatabaseDescriptor
         return conf.concurrent_counter_writes;
     }
 
-    public static boolean getAlwaysAsyncRead() {
-        return conf.always_async_read;
-    }
-
     public static boolean getAlwaysAsyncWrite() {
         return conf.always_async_write;
     }

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1235,6 +1235,14 @@ public class DatabaseDescriptor
         return conf.concurrent_counter_writes;
     }
 
+    public static boolean getAlwaysAsyncRead() {
+        return conf.always_async_read;
+    }
+
+    public static boolean getAlwaysAsyncWrite() {
+        return conf.always_async_write;
+    }
+
     public static int getFlushWriters()
     {
             return conf.memtable_flush_writers;

--- a/src/java/org/apache/cassandra/service/AbstractReadExecutor.java
+++ b/src/java/org/apache/cassandra/service/AbstractReadExecutor.java
@@ -33,7 +33,6 @@ import org.apache.cassandra.concurrent.KeyspaceAwareSepQueue;
 import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.concurrent.StageManager;
 import org.apache.cassandra.config.CFMetaData.SpeculativeRetry.RetryType;
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.config.ReadRepairDecision;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -128,14 +127,7 @@ public abstract class AbstractReadExecutor
             long localStart = System.nanoTime();
             logger.trace("reading {} locally", readCommand.isDigestQuery() ? "digest" : "data");
             KeyspaceAwareSepQueue.setCurrentKeyspace(command.ksName);
-            Runnable localReadRunnable = new LocalReadRunnable(command, handler);
-
-            if (DatabaseDescriptor.getAlwaysAsyncRead()) {
-                StageManager.getStage(stage(command)).submit(localReadRunnable);
-            } else {
-                StageManager.getStage(stage(command)).maybeExecuteImmediately(localReadRunnable);
-            }
-
+            StageManager.getStage(stage(command)).maybeExecuteImmediately(new LocalReadRunnable(command, handler));
             latencies.add(System.nanoTime() - localStart);
         }
         logger.trace("measured read latencies {} ns", latencies);

--- a/src/java/org/apache/cassandra/service/AbstractReadExecutor.java
+++ b/src/java/org/apache/cassandra/service/AbstractReadExecutor.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.concurrent.KeyspaceAwareSepQueue;
 import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.concurrent.StageManager;
 import org.apache.cassandra.config.CFMetaData.SpeculativeRetry.RetryType;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.config.ReadRepairDecision;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -127,7 +128,14 @@ public abstract class AbstractReadExecutor
             long localStart = System.nanoTime();
             logger.trace("reading {} locally", readCommand.isDigestQuery() ? "digest" : "data");
             KeyspaceAwareSepQueue.setCurrentKeyspace(command.ksName);
-            StageManager.getStage(stage(command)).maybeExecuteImmediately(new LocalReadRunnable(command, handler));
+            Runnable localReadRunnable = new LocalReadRunnable(command, handler);
+
+            if (DatabaseDescriptor.getAlwaysAsyncRead()) {
+                StageManager.getStage(stage(command)).submit(localReadRunnable);
+            } else {
+                StageManager.getStage(stage(command)).maybeExecuteImmediately(localReadRunnable);
+            }
+
             latencies.add(System.nanoTime() - localStart);
         }
         logger.trace("measured read latencies {} ns", latencies);

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -1109,7 +1109,7 @@ public class StorageProxy implements StorageProxyMBean
     private static void insertLocal(final Mutation mutation, final AbstractWriteResponseHandler<IMutation> responseHandler)
     {
 
-        StageManager.getStage(Stage.MUTATION).maybeExecuteImmediately(new LocalMutationRunnable()
+        Runnable localMutationRunnable = new LocalMutationRunnable()
         {
             public void runMayThrow()
             {
@@ -1130,7 +1130,13 @@ public class StorageProxy implements StorageProxyMBean
             {
                 return MessagingService.Verb.MUTATION;
             }
-        });
+        };
+
+        if (DatabaseDescriptor.getAlwaysAsyncWrite()) {
+            StageManager.getStage(Stage.MUTATION).submit(localMutationRunnable);
+        } else {
+            StageManager.getStage(Stage.MUTATION).maybeExecuteImmediately(localMutationRunnable);
+        }
     }
 
     /**


### PR DESCRIPTION
We have observed that when we have a batch mutate, all the local mutations occur serially because of this "optimisation" to skip the SEP.

Want to test a config where we just always submit the mutations async.