### PR TITLE
Add an optimized version of WaitQueue specifically for commit log syncs

### DIFF
--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -117,6 +117,7 @@ public class Config
     public Integer concurrent_reads = 32;
     public Integer concurrent_writes = 32;
     public Integer concurrent_counter_writes = 32;
+    public Boolean commitlog_use_progress_wait_queue = false;
 
     @Deprecated
     public Integer concurrent_replicates = null;
@@ -211,7 +212,7 @@ public class Config
     public int commitlog_segment_size_in_mb = 32;
     public ParameterizedClass commitlog_compression;
     public int commitlog_max_compression_buffers_in_pool = 3;
- 
+
     @Deprecated
     public int commitlog_periodic_queue_size = -1;
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1235,6 +1235,11 @@ public class DatabaseDescriptor
         return conf.concurrent_counter_writes;
     }
 
+    public static boolean getCommitLogUseProgressWaitQueue()
+    {
+        return conf.commitlog_use_progress_wait_queue;
+    }
+
     public static int getFlushWriters()
     {
             return conf.memtable_flush_writers;

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
@@ -100,6 +100,7 @@ public abstract class CommitLogSegment
     private int endOfBuffer;
 
     // a signal for writers to wait on to confirm the log message they provided has been written to disk
+    private final WaitQueue syncQueue = new WaitQueue();
     private final ProgressWaitQueue syncProgress = new ProgressWaitQueue();
 
     // a map of Cf->dirty position; this is used to permit marking Cfs clean whilst the log is still in use
@@ -301,7 +302,19 @@ public abstract class CommitLogSegment
         lastSyncedOffset = nextMarker;
         if (close)
             internalClose();
-        syncProgress.signalUntil(lastSyncedOffset);
+
+        signalWaiters();
+    }
+
+    private void signalWaiters()
+    {
+        if (DatabaseDescriptor.getCommitLogUseProgressWaitQueue())
+        {
+            syncProgress.signalUntil(lastSyncedOffset);
+        } else
+        {
+            syncQueue.signalAll();
+        }
     }
 
     protected static void writeSyncMarker(long id, ByteBuffer buffer, int offset, int filePos, int nextMarker)
@@ -360,7 +373,7 @@ public abstract class CommitLogSegment
     {
         while (true)
         {
-            WaitQueue.Signal signal = syncProgress.register(-1L);
+            WaitQueue.Signal signal = registerWaiter(endOfBuffer);
             if (lastSyncedOffset < endOfBuffer)
             {
                 signal.awaitUninterruptibly();
@@ -378,12 +391,28 @@ public abstract class CommitLogSegment
         while (lastSyncedOffset < position)
         {
             WaitQueue.Signal signal = waitingOnCommit != null ?
-                                      syncProgress.register(position, waitingOnCommit.time()) :
-                                      syncProgress.register(position);
+                                      registerWaiter(position, waitingOnCommit.time()) :
+                                      registerWaiter(position);
             if (lastSyncedOffset < position)
                 signal.awaitUninterruptibly();
             else
                 signal.cancel();
+        }
+    }
+
+    private WaitQueue.Signal registerWaiter(int waitUntil, Timer.Context timer) {
+        if (DatabaseDescriptor.getCommitLogUseProgressWaitQueue()) {
+            return syncProgress.register(waitUntil, timer);
+        } else {
+            return syncQueue.register(timer);
+        }
+    }
+
+    private WaitQueue.Signal registerWaiter(int waitUntil) {
+        if (DatabaseDescriptor.getCommitLogUseProgressWaitQueue()) {
+            return syncProgress.register(waitUntil);
+        } else {
+            return syncQueue.register();
         }
     }
 

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
@@ -52,6 +52,7 @@ import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.CLibrary;
 import org.apache.cassandra.utils.concurrent.OpOrder;
+import org.apache.cassandra.utils.concurrent.ProgressWaitQueue;
 import org.apache.cassandra.utils.concurrent.WaitQueue;
 
 /*
@@ -99,7 +100,7 @@ public abstract class CommitLogSegment
     private int endOfBuffer;
 
     // a signal for writers to wait on to confirm the log message they provided has been written to disk
-    private final WaitQueue syncComplete = new WaitQueue();
+    private final ProgressWaitQueue syncProgress = new ProgressWaitQueue();
 
     // a map of Cf->dirty position; this is used to permit marking Cfs clean whilst the log is still in use
     private final NonBlockingHashMap<UUID, AtomicInteger> cfDirty = new NonBlockingHashMap<>(1024);
@@ -150,7 +151,7 @@ public abstract class CommitLogSegment
         {
             throw new FSWriteError(e, logFile);
         }
-        
+
         buffer = createBuffer(commitLog);
         // write the header
         CommitLogDescriptor.writeHeader(buffer, descriptor);
@@ -270,7 +271,7 @@ public abstract class CommitLogSegment
         // Note: Even if the very first allocation of this sync section failed, we still want to enter this
         // to ensure the segment is closed. As allocatePosition is set to 1 beyond the capacity of the buffer,
         // this will always be entered when a mutation allocation has been attempted after the marker allocation
-        // succeeded in the previous sync. 
+        // succeeded in the previous sync.
         assert buffer != null;  // Only close once.
 
         int startMarker = lastSyncedOffset;
@@ -300,7 +301,7 @@ public abstract class CommitLogSegment
         lastSyncedOffset = nextMarker;
         if (close)
             internalClose();
-        syncComplete.signalAll();
+        syncProgress.signalUntil(lastSyncedOffset);
     }
 
     protected static void writeSyncMarker(long id, ByteBuffer buffer, int offset, int filePos, int nextMarker)
@@ -359,7 +360,7 @@ public abstract class CommitLogSegment
     {
         while (true)
         {
-            WaitQueue.Signal signal = syncComplete.register();
+            WaitQueue.Signal signal = syncProgress.register(-1L);
             if (lastSyncedOffset < endOfBuffer)
             {
                 signal.awaitUninterruptibly();
@@ -377,8 +378,8 @@ public abstract class CommitLogSegment
         while (lastSyncedOffset < position)
         {
             WaitQueue.Signal signal = waitingOnCommit != null ?
-                                      syncComplete.register(waitingOnCommit.time()) :
-                                      syncComplete.register();
+                                      syncProgress.register(position, waitingOnCommit.time()) :
+                                      syncProgress.register(position);
             if (lastSyncedOffset < position)
                 signal.awaitUninterruptibly();
             else

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
@@ -53,6 +53,8 @@ import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.CLibrary;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 import org.apache.cassandra.utils.concurrent.ProgressWaitQueue;
+import org.apache.cassandra.utils.concurrent.ProgressWaitQueueAdapter;
+import org.apache.cassandra.utils.concurrent.SkipListProgressWaitQueue;
 import org.apache.cassandra.utils.concurrent.WaitQueue;
 
 /*
@@ -100,8 +102,7 @@ public abstract class CommitLogSegment
     private int endOfBuffer;
 
     // a signal for writers to wait on to confirm the log message they provided has been written to disk
-    private final WaitQueue syncQueue = new WaitQueue();
-    private final ProgressWaitQueue syncProgress = new ProgressWaitQueue();
+    private final ProgressWaitQueue syncComplete;
 
     // a map of Cf->dirty position; this is used to permit marking Cfs clean whilst the log is still in use
     private final NonBlockingHashMap<UUID, AtomicInteger> cfDirty = new NonBlockingHashMap<>(1024);
@@ -159,6 +160,10 @@ public abstract class CommitLogSegment
         endOfBuffer = buffer.capacity();
         lastSyncedOffset = buffer.position();
         allocatePosition.set(lastSyncedOffset + SYNC_MARKER_SIZE);
+
+        syncComplete = DatabaseDescriptor.getCommitLogUseProgressWaitQueue()
+                ? new SkipListProgressWaitQueue()
+                : new ProgressWaitQueueAdapter(new WaitQueue());
     }
 
     abstract ByteBuffer createBuffer(CommitLog commitLog);
@@ -303,18 +308,7 @@ public abstract class CommitLogSegment
         if (close)
             internalClose();
 
-        signalWaiters();
-    }
-
-    private void signalWaiters()
-    {
-        if (DatabaseDescriptor.getCommitLogUseProgressWaitQueue())
-        {
-            syncProgress.signalUntil(lastSyncedOffset);
-        } else
-        {
-            syncQueue.signalAll();
-        }
+        syncComplete.signalUntil(lastSyncedOffset);
     }
 
     protected static void writeSyncMarker(long id, ByteBuffer buffer, int offset, int filePos, int nextMarker)
@@ -373,7 +367,7 @@ public abstract class CommitLogSegment
     {
         while (true)
         {
-            WaitQueue.Signal signal = registerWaiter(endOfBuffer);
+            WaitQueue.Signal signal = syncComplete.register(endOfBuffer);
             if (lastSyncedOffset < endOfBuffer)
             {
                 signal.awaitUninterruptibly();
@@ -391,28 +385,12 @@ public abstract class CommitLogSegment
         while (lastSyncedOffset < position)
         {
             WaitQueue.Signal signal = waitingOnCommit != null ?
-                                      registerWaiter(position, waitingOnCommit.time()) :
-                                      registerWaiter(position);
+                                      syncComplete.register(position, waitingOnCommit.time()) :
+                                      syncComplete.register(position);
             if (lastSyncedOffset < position)
                 signal.awaitUninterruptibly();
             else
                 signal.cancel();
-        }
-    }
-
-    private WaitQueue.Signal registerWaiter(int waitUntil, Timer.Context timer) {
-        if (DatabaseDescriptor.getCommitLogUseProgressWaitQueue()) {
-            return syncProgress.register(waitUntil, timer);
-        } else {
-            return syncQueue.register(timer);
-        }
-    }
-
-    private WaitQueue.Signal registerWaiter(int waitUntil) {
-        if (DatabaseDescriptor.getCommitLogUseProgressWaitQueue()) {
-            return syncProgress.register(waitUntil);
-        } else {
-            return syncQueue.register();
         }
     }
 

--- a/src/java/org/apache/cassandra/utils/concurrent/ProgressWaitQueue.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/ProgressWaitQueue.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.concurrent;
+
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.locks.LockSupport;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.codahale.metrics.Timer;
+import com.palantir.tracing.CloseableTracer;
+import com.palantir.tracing.DetachedSpan;
+import com.palantir.tracing.Tracer;
+
+public final class ProgressWaitQueue
+{
+    private static final int CANCELLED = -1;
+    private static final int SIGNALLED = 1;
+    private static final int NOT_SET = 0;
+
+    private static final AtomicIntegerFieldUpdater signalledUpdater = AtomicIntegerFieldUpdater.newUpdater(ProgressWaitQueue.RegisteredSignal.class, "state");
+
+    private final ConcurrentNavigableMap<Long, RegisteredSignal> waiters = new ConcurrentSkipListMap<>();
+
+    public WaitQueue.Signal register(long waitUntil)
+    {
+        RegisteredSignal signal = new RegisteredSignal();
+        waiters.put(waitUntil, signal);
+        return signal;
+    }
+
+    public WaitQueue.Signal register(long waitUntil, Timer.Context context)
+    {
+        assert context != null;
+        RegisteredSignal signal = new TimedSignal(context);
+        waiters.put(waitUntil, signal);
+        return signal;
+    }
+
+    public void signalUntil(long until) {
+        ConcurrentNavigableMap<Long, RegisteredSignal> dueWaiters = waiters.headMap(until, true);
+        try (CloseableTracer ignored = CloseableTracer.startSpan("ProgressWaitQueue#signalAll", ImmutableMap.of("numWaiters", Integer.toString(waiters.size()), "numDueWaiters", Integer.toString(dueWaiters.size()))))
+        {
+            Iterator<RegisteredSignal> iter = dueWaiters.values().iterator();
+            while (iter.hasNext())
+            {
+                RegisteredSignal signal = iter.next();
+                signal.signal();
+                iter.remove();
+            }
+        }
+    }
+
+    private void cleanUpCancelled()
+    {
+        waiters.values().removeIf(RegisteredSignal::isCancelled);
+    }
+
+    /**
+     * A signal registered with this WaitQueue
+     */
+    private class RegisteredSignal extends WaitQueue.AbstractSignal
+    {
+        private final DetachedSpan span = DetachedSpan.start("ProgressWaitQueue#parked");
+        private volatile Thread thread = Thread.currentThread();
+        volatile int state;
+
+        public boolean isSignalled()
+        {
+            return state == SIGNALLED;
+        }
+
+        public boolean isCancelled()
+        {
+            return state == CANCELLED;
+        }
+
+        public boolean isSet()
+        {
+            return state != NOT_SET;
+        }
+
+        private Thread signal()
+        {
+            if (!isSet() && signalledUpdater.compareAndSet(this, NOT_SET, SIGNALLED))
+            {
+                Thread thread = this.thread;
+                LockSupport.unpark(thread);
+                if (Tracer.hasTraceId()) {
+                    this.span.complete(ImmutableMap.of("childTraceIds", Tracer.getTraceId()));
+                } else {
+                    this.span.complete();
+                }
+                this.thread = null;
+                return thread;
+            }
+            return null;
+        }
+
+        public boolean checkAndClear()
+        {
+            if (!isSet() && signalledUpdater.compareAndSet(this, NOT_SET, CANCELLED))
+            {
+                thread = null;
+                cleanUpCancelled();
+                return false;
+            }
+            // must now be signalled assuming correct API usage
+            return true;
+        }
+
+        /**
+         * Should only be called by the registered thread. Indicates the signal can be retired,
+         */
+        public void cancel()
+        {
+            if (isCancelled())
+                return;
+            if (!signalledUpdater.compareAndSet(this, NOT_SET, CANCELLED))
+            {
+                // must already be signalled - switch to cancelled
+                state = CANCELLED;
+            }
+            thread = null;
+            cleanUpCancelled();
+        }
+    }
+
+    /**
+     * A RegisteredSignal that stores a TimerContext, and stops the timer when either cancelled or
+     * finished waiting. i.e. if the timer is started when the signal is registered it tracks the
+     * time in between registering and invalidating the signal.
+     */
+    private final class TimedSignal extends ProgressWaitQueue.RegisteredSignal
+    {
+        private final Timer.Context context;
+
+        private TimedSignal(Timer.Context context)
+        {
+            this.context = context;
+        }
+
+        @Override
+        public boolean checkAndClear()
+        {
+            context.stop();
+            return super.checkAndClear();
+        }
+
+        @Override
+        public void cancel()
+        {
+            if (!isCancelled())
+            {
+                context.stop();
+                super.cancel();
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/utils/concurrent/ProgressWaitQueue.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/ProgressWaitQueue.java
@@ -20,6 +20,13 @@ package org.apache.cassandra.utils.concurrent;
 
 import com.codahale.metrics.Timer;
 
+/**
+ * Similar in concept to a {@link WaitQueue} but additionally tracks an (assumed) monotonically increasing "progress"
+ * quantity.
+ * The queue will attempt to only wake threads when the signaled "until" progress quantity reaches or exceeds their
+ * requested "waitUntil" value.
+ * Note that this is not a strong guarantee, and threads should still wait in a loop to ensure the condition is met.
+ */
 public interface ProgressWaitQueue
 {
     WaitQueue.Signal register(long waitUntil);

--- a/src/java/org/apache/cassandra/utils/concurrent/ProgressWaitQueueAdapter.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/ProgressWaitQueueAdapter.java
@@ -20,11 +20,27 @@ package org.apache.cassandra.utils.concurrent;
 
 import com.codahale.metrics.Timer;
 
-public interface ProgressWaitQueue
+public final class ProgressWaitQueueAdapter implements ProgressWaitQueue
 {
-    WaitQueue.Signal register(long waitUntil);
+    private final WaitQueue waitQueue;
 
-    WaitQueue.Signal register(long waitUntil, Timer.Context context);
+    public ProgressWaitQueueAdapter(WaitQueue waitQueue)
+    {
+        this.waitQueue = waitQueue;
+    }
 
-    void signalUntil(long until);
+    public WaitQueue.Signal register(long _waitUntil)
+    {
+        return waitQueue.register();
+    }
+
+    public WaitQueue.Signal register(long _waitUntil, Timer.Context context)
+    {
+        return waitQueue.register(context);
+    }
+
+    public void signalUntil(long _until)
+    {
+        waitQueue.signalAll();
+    }
 }

--- a/src/java/org/apache/cassandra/utils/concurrent/SkipListProgressWaitQueue.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/SkipListProgressWaitQueue.java
@@ -58,7 +58,11 @@ public final class SkipListProgressWaitQueue implements ProgressWaitQueue
 
     public void signalUntil(long until) {
         ConcurrentNavigableMap<Long, RegisteredSignal> dueWaiters = waiters.headMap(until, true);
-        try (CloseableTracer ignored = CloseableTracer.startSpan("ProgressWaitQueue#signalAll", ImmutableMap.of("numWaiters", Integer.toString(waiters.size()), "numDueWaiters", Integer.toString(dueWaiters.size()))))
+        try (CloseableTracer ignored = CloseableTracer.startSpan(
+            "SkipListProgressWaitQueue#signalAll",
+                ImmutableMap.of(
+                    "numWaiters", Integer.toString(waiters.size()),
+                    "numDueWaiters", Integer.toString(dueWaiters.size()))))
         {
             Iterator<RegisteredSignal> iter = dueWaiters.values().iterator();
             while (iter.hasNext())
@@ -80,7 +84,7 @@ public final class SkipListProgressWaitQueue implements ProgressWaitQueue
      */
     private class RegisteredSignal extends WaitQueue.AbstractSignal
     {
-        private final DetachedSpan span = DetachedSpan.start("ProgressWaitQueue#parked");
+        private final DetachedSpan span = DetachedSpan.start("SkipListProgressWaitQueue#parked");
         private volatile Thread thread = Thread.currentThread();
         volatile int state;
 

--- a/src/java/org/apache/cassandra/utils/concurrent/SkipListProgressWaitQueue.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/SkipListProgressWaitQueue.java
@@ -19,11 +19,13 @@
 package org.apache.cassandra.utils.concurrent;
 
 import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.locks.LockSupport;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import com.codahale.metrics.Timer;
@@ -84,6 +86,9 @@ public final class SkipListProgressWaitQueue implements ProgressWaitQueue
      */
     private class RegisteredSignal extends WaitQueue.AbstractSignal
     {
+        private static final Map<String, String> METADATA_COMPLETE = ImmutableMap.of("status", "complete");
+        private static final Map<String, String> METADATA_CANCELED = ImmutableMap.of("status", "canceled");
+
         private final DetachedSpan span = DetachedSpan.start("SkipListProgressWaitQueue#parked");
         private volatile Thread thread = Thread.currentThread();
         volatile int state;
@@ -109,11 +114,17 @@ public final class SkipListProgressWaitQueue implements ProgressWaitQueue
             {
                 Thread thread = this.thread;
                 LockSupport.unpark(thread);
-                if (Tracer.hasTraceId()) {
-                    this.span.complete(ImmutableMap.of("childTraceIds", Tracer.getTraceId()));
+
+                if (Tracer.hasTraceId() && Tracer.isTraceObservable()) {
+                    // Only allocate a custom metadata map if trace is observable.
+                    this.span.complete(ImmutableMap.<String, String>builder()
+                                                   .putAll(METADATA_COMPLETE)
+                                                   .put("childTraceIds", Tracer.getTraceId())
+                                                   .build());
                 } else {
-                    this.span.complete();
+                    this.span.complete(METADATA_COMPLETE);
                 }
+
                 this.thread = null;
                 return thread;
             }
@@ -124,6 +135,7 @@ public final class SkipListProgressWaitQueue implements ProgressWaitQueue
         {
             if (!isSet() && signalledUpdater.compareAndSet(this, NOT_SET, CANCELLED))
             {
+                this.span.complete(METADATA_CANCELED);
                 thread = null;
                 cleanUpCancelled();
                 return false;
@@ -144,6 +156,7 @@ public final class SkipListProgressWaitQueue implements ProgressWaitQueue
                 // must already be signalled - switch to cancelled
                 state = CANCELLED;
             }
+            this.span.complete(METADATA_CANCELED);
             thread = null;
             cleanUpCancelled();
         }

--- a/src/java/org/apache/cassandra/utils/concurrent/SkipListProgressWaitQueue.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/SkipListProgressWaitQueue.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.concurrent;
+
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.locks.LockSupport;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.codahale.metrics.Timer;
+import com.palantir.tracing.CloseableTracer;
+import com.palantir.tracing.DetachedSpan;
+import com.palantir.tracing.Tracer;
+
+public final class SkipListProgressWaitQueue implements ProgressWaitQueue
+{
+    private static final int CANCELLED = -1;
+    private static final int SIGNALLED = 1;
+    private static final int NOT_SET = 0;
+
+    private static final AtomicIntegerFieldUpdater signalledUpdater = AtomicIntegerFieldUpdater.newUpdater(SkipListProgressWaitQueue.RegisteredSignal.class, "state");
+
+    private final ConcurrentNavigableMap<Long, RegisteredSignal> waiters = new ConcurrentSkipListMap<>();
+
+    public WaitQueue.Signal register(long waitUntil)
+    {
+        RegisteredSignal signal = new RegisteredSignal();
+        waiters.put(waitUntil, signal);
+        return signal;
+    }
+
+    public WaitQueue.Signal register(long waitUntil, Timer.Context context)
+    {
+        assert context != null;
+        RegisteredSignal signal = new TimedSignal(context);
+        waiters.put(waitUntil, signal);
+        return signal;
+    }
+
+    public void signalUntil(long until) {
+        ConcurrentNavigableMap<Long, RegisteredSignal> dueWaiters = waiters.headMap(until, true);
+        try (CloseableTracer ignored = CloseableTracer.startSpan("ProgressWaitQueue#signalAll", ImmutableMap.of("numWaiters", Integer.toString(waiters.size()), "numDueWaiters", Integer.toString(dueWaiters.size()))))
+        {
+            Iterator<RegisteredSignal> iter = dueWaiters.values().iterator();
+            while (iter.hasNext())
+            {
+                RegisteredSignal signal = iter.next();
+                signal.signal();
+                iter.remove();
+            }
+        }
+    }
+
+    private void cleanUpCancelled()
+    {
+        waiters.values().removeIf(RegisteredSignal::isCancelled);
+    }
+
+    /**
+     * A signal registered with this WaitQueue
+     */
+    private class RegisteredSignal extends WaitQueue.AbstractSignal
+    {
+        private final DetachedSpan span = DetachedSpan.start("ProgressWaitQueue#parked");
+        private volatile Thread thread = Thread.currentThread();
+        volatile int state;
+
+        public boolean isSignalled()
+        {
+            return state == SIGNALLED;
+        }
+
+        public boolean isCancelled()
+        {
+            return state == CANCELLED;
+        }
+
+        public boolean isSet()
+        {
+            return state != NOT_SET;
+        }
+
+        private Thread signal()
+        {
+            if (!isSet() && signalledUpdater.compareAndSet(this, NOT_SET, SIGNALLED))
+            {
+                Thread thread = this.thread;
+                LockSupport.unpark(thread);
+                if (Tracer.hasTraceId()) {
+                    this.span.complete(ImmutableMap.of("childTraceIds", Tracer.getTraceId()));
+                } else {
+                    this.span.complete();
+                }
+                this.thread = null;
+                return thread;
+            }
+            return null;
+        }
+
+        public boolean checkAndClear()
+        {
+            if (!isSet() && signalledUpdater.compareAndSet(this, NOT_SET, CANCELLED))
+            {
+                thread = null;
+                cleanUpCancelled();
+                return false;
+            }
+            // must now be signalled assuming correct API usage
+            return true;
+        }
+
+        /**
+         * Should only be called by the registered thread. Indicates the signal can be retired,
+         */
+        public void cancel()
+        {
+            if (isCancelled())
+                return;
+            if (!signalledUpdater.compareAndSet(this, NOT_SET, CANCELLED))
+            {
+                // must already be signalled - switch to cancelled
+                state = CANCELLED;
+            }
+            thread = null;
+            cleanUpCancelled();
+        }
+    }
+
+    /**
+     * A RegisteredSignal that stores a TimerContext, and stops the timer when either cancelled or
+     * finished waiting. i.e. if the timer is started when the signal is registered it tracks the
+     * time in between registering and invalidating the signal.
+     */
+    private final class TimedSignal extends SkipListProgressWaitQueue.RegisteredSignal
+    {
+        private final Timer.Context context;
+
+        private TimedSignal(Timer.Context context)
+        {
+            this.context = context;
+        }
+
+        @Override
+        public boolean checkAndClear()
+        {
+            context.stop();
+            return super.checkAndClear();
+        }
+
+        @Override
+        public void cancel()
+        {
+            if (!isCancelled())
+            {
+                context.stop();
+                super.cancel();
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/utils/concurrent/SkipListProgressWaitQueue.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/SkipListProgressWaitQueue.java
@@ -35,6 +35,9 @@ import com.palantir.tracing.Tracer;
 
 public final class SkipListProgressWaitQueue implements ProgressWaitQueue
 {
+    private static final Map<String, String> METADATA_COMPLETE = ImmutableMap.of("status", "complete");
+    private static final Map<String, String> METADATA_CANCELED = ImmutableMap.of("status", "canceled");
+
     private static final int CANCELLED = -1;
     private static final int SIGNALLED = 1;
     private static final int NOT_SET = 0;
@@ -86,9 +89,6 @@ public final class SkipListProgressWaitQueue implements ProgressWaitQueue
      */
     private class RegisteredSignal extends WaitQueue.AbstractSignal
     {
-        private static final Map<String, String> METADATA_COMPLETE = ImmutableMap.of("status", "complete");
-        private static final Map<String, String> METADATA_CANCELED = ImmutableMap.of("status", "canceled");
-
         private final DetachedSpan span = DetachedSpan.start("SkipListProgressWaitQueue#parked");
         private volatile Thread thread = Thread.currentThread();
         volatile int state;

--- a/test/unit/org/apache/cassandra/concurrent/ProgressWaitQueueTest.java
+++ b/test/unit/org/apache/cassandra/concurrent/ProgressWaitQueueTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.concurrent;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import org.apache.cassandra.Util;
+import org.apache.cassandra.utils.concurrent.ProgressWaitQueue;
+import org.apache.cassandra.utils.concurrent.SkipListProgressWaitQueue;
+import org.apache.cassandra.utils.concurrent.WaitQueue;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public final class ProgressWaitQueueTest
+{
+    @Test
+    public void testProgressWaitQueue() throws InterruptedException
+    {
+        ProgressWaitQueue queue = new SkipListProgressWaitQueue();
+        AtomicLong progress = new AtomicLong(0);
+        List<TestThread> threads = ImmutableList.of(
+            new TestThread(queue, progress::get, 0),
+            new TestThread(queue, progress::get, 100),
+            new TestThread(queue, progress::get, 200),
+            new TestThread(queue, progress::get, 300),
+            new TestThread(queue, progress::get, 400)
+        );
+
+        threads.forEach(Thread::start);
+        awaitReady(threads);
+
+        progress.set(100);
+        queue.signalUntil(progress.get());
+
+        Util.joinThread(threads.get(0));
+        Util.joinThread(threads.get(1));
+
+        assertFalse(threads.get(0).isAlive());
+        assertFalse(threads.get(0).isFailed());
+
+        assertFalse(threads.get(1).isAlive());
+        assertFalse(threads.get(1).isFailed());
+
+        assertTrue(threads.get(2).isAlive());
+        assertTrue(threads.get(3).isAlive());
+        assertTrue(threads.get(4).isAlive());
+
+        progress.set(300);
+        queue.signalUntil(progress.get());
+
+        Util.joinThread(threads.get(2));
+        Util.joinThread(threads.get(3));
+
+        assertFalse(threads.get(2).isAlive());
+        assertFalse(threads.get(2).isFailed());
+
+        assertFalse(threads.get(3).isAlive());
+        assertFalse(threads.get(3).isFailed());
+
+        assertTrue(threads.get(4).isAlive());
+
+        progress.set(400);
+        queue.signalUntil(progress.get());
+
+        Util.joinThread(threads.get(4));
+        assertFalse(threads.get(4).isAlive());
+        assertFalse(threads.get(4).isFailed());
+    }
+
+    private void awaitReady(List<TestThread> threads)
+    {
+        int iterations = 0;
+        while (!threads.stream().allMatch(TestThread::isReady) && iterations < 100)
+        {
+            try
+            {
+                Thread.sleep(10);
+                iterations += 1;
+            }
+            catch (InterruptedException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private class TestThread extends Thread
+    {
+        private final ProgressWaitQueue queue;
+        private final LongSupplier progress;
+        private final long target;
+        private final AtomicBoolean ready = new AtomicBoolean(false);
+        private final AtomicBoolean failed = new AtomicBoolean(false);
+
+        private TestThread(ProgressWaitQueue queue, LongSupplier progress, long target)
+        {
+            this.queue = queue;
+            this.progress = progress;
+            this.target = target;
+        }
+
+        @Override
+        public void run()
+        {
+            WaitQueue.Signal signal = queue.register(target);
+            ready.set(true);
+            signal.awaitUninterruptibly();
+
+            if (target > progress.getAsLong()) {
+                failed.set(true);
+            }
+        }
+
+        public boolean isReady() { return ready.get(); }
+        public boolean isFailed() { return failed.get(); }
+    }
+}


### PR DESCRIPTION
The existing `WaitQueue` doesn't know anything about which waiters are actually "ready" to wake up on each loop of the commit log sync, so it just tries to wake them all up.

The waiting threads then rejoin the queue if their data isn't synced yet.

This creates a death loop whereby if there are enough waiting threads, they can be rejoining the back of the queue just as fast as we're popping them off and waking them, meaning the queue can't make progress.

The existing implementation papers over this by tracking a random item in the queue and bailing out if we see it loop around. But this is not very effective.

In practice, we've seen queues containing only ~100 waiting threads pop and wake over **500** threads before bailing. This blocks the commit log from continuing to the next sync iteration. We've seen it block for several milliseconds, which materially impacts write performance.

This new implementation (hidden behind a config flag) tracks the waiters in a skip list, and only wakes exactly the threads which are ready to be woken.

See results from a test environment, left is with the skip list, right is the default behaviour on trunk.
<img width="872" alt="image" src="https://github.com/user-attachments/assets/9fbbe421-ffec-46c6-9080-2f4d6fc40322" />
