### PR TITLE
Wrap AbstractLocalAwareExecutorService tasks with tracing information

### DIFF
--- a/src/java/org/apache/cassandra/concurrent/AbstractLocalAwareExecutorService.java
+++ b/src/java/org/apache/cassandra/concurrent/AbstractLocalAwareExecutorService.java
@@ -30,8 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.palantir.tracing.Tracers;
-import org.apache.cassandra.tracing.TraceState;
-import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.concurrent.SimpleCondition;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 

--- a/src/java/org/apache/cassandra/concurrent/AbstractLocalAwareExecutorService.java
+++ b/src/java/org/apache/cassandra/concurrent/AbstractLocalAwareExecutorService.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.tracing.Tracers;
 import org.apache.cassandra.tracing.TraceState;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.concurrent.SimpleCondition;
@@ -150,7 +151,7 @@ public abstract class AbstractLocalAwareExecutorService implements LocalAwareExe
 
         public FutureTask(Callable<T> callable)
         {
-            this.callable = callable;
+            this.callable = Tracers.wrap("FutureTask#run", callable);
         }
         public FutureTask(Runnable runnable, T result)
         {


### PR DESCRIPTION
Previously, tasks submitted to the `AbstractLocalAwareExecutorService` would lose tracing information, as tracing information is stored in thread local data and the task would be executed on a different thread. This PR wraps the lower-most `Callable` (all task-producing code paths end in this constructor) with a deferred tracer, allowing the task to be associated with the correct trace ID and parent span.