### PR TITLE
Feature: Add log statements to all non-successful branches of the FilterExperiment

### DIFF
--- a/src/java/org/apache/cassandra/FilterExperiment.java
+++ b/src/java/org/apache/cassandra/FilterExperiment.java
@@ -21,6 +21,7 @@ package org.apache.cassandra;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -70,14 +71,22 @@ public enum FilterExperiment
             ColumnFamily optimizedResult = time(() -> function.apply(USE_OPTIMIZED), optimizedTimer);
             if (areEqual(legacyResult, optimizedResult)) {
                 successes.inc();
-            } else if (!areTrulyEqual(legacyResult, function.apply(USE_LEGACY))
-                       || (legacyResult.metadata().getGcGraceSeconds() == 0
+            } else if (!areTrulyEqual(legacyResult, function.apply(USE_LEGACY))) {
+                indeterminate.inc();
+                log.warn("Query result changed while running experiments, result is indeterminate; Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
+                         legacyResult, optimizedResult, legacyResult.metadata(), optimizedResult.metadata());
+            } else if ((legacyResult.metadata().getGcGraceSeconds() == 0
                            && areEqual(fallback.apply(USE_LEGACY), fallback.apply(USE_OPTIMIZED)))) {
                 indeterminate.inc();
+                // TODO(lkjaerozhang): Give a better log message when I actually understand what this means.
+                //  The indeterminate codepath seems to have never been hit so it's probably fine to defer for now as
+                //  long as we still have signal if we do hit it.
+                log.warn("Query result changed under immediate compaction but results from 60 seconds ago are identical, result is indeterminate; Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
+                         legacyResult, optimizedResult, legacyResult.metadata(), optimizedResult.metadata());
             } else {
                 failures.inc();
-                log.warn("Comparison failure while experimenting; Legacy: {}, Optimized: {}",
-                         legacyResult, optimizedResult);
+                log.warn("Comparison failure while experimenting; Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
+                         legacyResult, optimizedResult, legacyResult.metadata(), optimizedResult.metadata());
             }
         } catch (RuntimeException e) {
             failures.inc();
@@ -120,14 +129,23 @@ public enum FilterExperiment
      */
     @VisibleForTesting
     static boolean areEqual(ColumnFamily legacy, ColumnFamily modern) {
-        if (areTrulyEqual(legacy, modern)) {
+        if (compareAndLogMetadataIfFalse(legacy, modern, "md5", FilterExperiment::areTrulyEqual)) {
             return true;
         }
         if (legacy == null) {
-            return !iterator(modern).hasNext();
+            boolean areEqual = !iterator(modern).hasNext();
+            log.warn("The legacy column family was null when comparing results but the modern column family was not; Modern: {}, Modern metadata: {}", modern, modern.metadata());
+            return areEqual;
         } else if (modern == null) {
-            return !iterator(legacy).hasNext();
+            boolean areEqual =  !iterator(legacy).hasNext();
+            log.warn("The modern column family was null when comparing results but the legacy column family was not; Legacy: {}, Legacy metadata: {}", legacy, legacy.metadata());
+            return areEqual;
         }
+        return compareAndLogMetadataIfFalse(legacy, modern, "iterator", FilterExperiment::compareUsingIterator);
+    }
+
+    private static boolean compareUsingIterator(ColumnFamily legacy, ColumnFamily modern)
+    {
         return Iterators.elementsEqual(iterator(legacy), iterator(modern));
     }
 
@@ -138,5 +156,15 @@ public enum FilterExperiment
 
     static boolean areTrulyEqual(ColumnFamily legacy, ColumnFamily modern) {
         return ColumnFamily.digest(legacy).equals(ColumnFamily.digest(modern));
+    }
+
+    private static boolean compareAndLogMetadataIfFalse(ColumnFamily legacy, ColumnFamily modern, String comparisonType, BiFunction<ColumnFamily, ColumnFamily, Boolean> comparator)
+    {
+        boolean equal = comparator.apply(legacy, modern);
+        if (!equal) {
+            log.warn("Comparison failure while experimenting; Comparison type: {}, Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
+                     legacy, modern, comparisonType, legacy.metadata(), modern.metadata());
+        }
+        return equal;
     }
 }

--- a/src/java/org/apache/cassandra/FilterExperiment.java
+++ b/src/java/org/apache/cassandra/FilterExperiment.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Timer;
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.config.CFMetaData;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Cell;
@@ -76,7 +77,7 @@ public enum FilterExperiment
             } else if (!areTrulyEqual(legacyResult, function.apply(USE_LEGACY))) {
                 indeterminate.inc();
                 log.warn("Query result changed while running experiments, result is indeterminate; Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
-                         legacyResult, optimizedResult, safeLoggableColumnFamilyMetadata(legacyResult.metadata()), safeLoggableColumnFamilyMetadata(optimizedResult.metadata()));
+                         legacyResult, optimizedResult, safeLoggableColumnFamilyMetadata("legacyMetadata", legacyResult.metadata()), safeLoggableColumnFamilyMetadata("optimizedMetadata", optimizedResult.metadata()));
             } else if ((legacyResult.metadata().getGcGraceSeconds() == 0
                            && areEqual(fallback.apply(USE_LEGACY), fallback.apply(USE_OPTIMIZED)))) {
                 indeterminate.inc();
@@ -84,11 +85,11 @@ public enum FilterExperiment
                 //  The indeterminate codepath seems to have never been hit so it's probably fine to defer for now as
                 //  long as we still have signal if we do hit it.
                 log.warn("Query result changed under immediate compaction but results from 60 seconds ago are identical, result is indeterminate; Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
-                         legacyResult, optimizedResult, safeLoggableColumnFamilyMetadata(legacyResult.metadata()), safeLoggableColumnFamilyMetadata(optimizedResult.metadata()));
+                         legacyResult, optimizedResult, safeLoggableColumnFamilyMetadata("legacyMetadata", legacyResult.metadata()), safeLoggableColumnFamilyMetadata("optimizedMetadata", optimizedResult.metadata()));
             } else {
                 failures.inc();
                 log.warn("Comparison failure while experimenting; Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
-                         legacyResult, optimizedResult, safeLoggableColumnFamilyMetadata(legacyResult.metadata()), safeLoggableColumnFamilyMetadata(optimizedResult.metadata()));
+                         legacyResult, optimizedResult, safeLoggableColumnFamilyMetadata("legacyMetadata", legacyResult.metadata()), safeLoggableColumnFamilyMetadata("optimizedMetadata", optimizedResult.metadata()));
             }
         } catch (RuntimeException e) {
             failures.inc();
@@ -136,11 +137,11 @@ public enum FilterExperiment
         }
         if (legacy == null) {
             boolean areEqual = !iterator(modern).hasNext();
-            log.warn("The legacy column family was null when comparing results but the modern column family was not; Modern: {}, Modern metadata: {}", modern, safeLoggableColumnFamilyMetadata(modern.metadata()));
+            log.warn("The legacy column family was null when comparing results but the modern column family was not; Optimized: {}, Optimized metadata: {}", modern, safeLoggableColumnFamilyMetadata("optimizedMetadata", modern.metadata()));
             return areEqual;
         } else if (modern == null) {
             boolean areEqual =  !iterator(legacy).hasNext();
-            log.warn("The modern column family was null when comparing results but the legacy column family was not; Legacy: {}, Legacy metadata: {}", legacy, safeLoggableColumnFamilyMetadata(legacy.metadata()));
+            log.warn("The modern column family was null when comparing results but the legacy column family was not; Legacy: {}, Legacy metadata: {}", legacy, safeLoggableColumnFamilyMetadata("legacyMetadata", legacy.metadata()));
             return areEqual;
         }
         return compareAndLogMetadataIfFalse(legacy, modern, "iterator", FilterExperiment::compareUsingIterator);
@@ -165,13 +166,13 @@ public enum FilterExperiment
         boolean equal = comparator.apply(legacy, modern);
         if (!equal) {
             log.warn("Comparison failure while experimenting; Comparison type: {}, Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
-                     legacy, modern, comparisonType, safeLoggableColumnFamilyMetadata(legacy.metadata()), safeLoggableColumnFamilyMetadata(modern.metadata()));
+                     legacy, modern, comparisonType, safeLoggableColumnFamilyMetadata("legacyMetadata", legacy.metadata()), safeLoggableColumnFamilyMetadata("optimizedMetadata", modern.metadata()));
         }
         return equal;
     }
 
-    private static String safeLoggableColumnFamilyMetadata(CFMetaData metaData) {
-        return new ToStringBuilder(metaData)
+    private static SafeArg safeLoggableColumnFamilyMetadata(String argName, CFMetaData metaData) {
+        return SafeArg.of(argName, new ToStringBuilder(metaData)
         .append("cfId", metaData.cfId) // UUID
         .append("ksName", metaData.ksName) // Is a metric label
         .append("cfName", metaData.cfName) // Is a metric label
@@ -190,6 +191,6 @@ public enum FilterExperiment
         .append("maxIndexInterval", metaData.getMaxIndexInterval()) // visible in config
         .append("speculativeRetry", metaData.getSpeculativeRetry()) // Enum and percentage
         .append("isDense", metaData.getIsDense()) // boolean
-        .toString();
+        .toString());
     }
 }

--- a/src/java/org/apache/cassandra/FilterExperiment.java
+++ b/src/java/org/apache/cassandra/FilterExperiment.java
@@ -29,11 +29,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Timer;
+import org.apache.cassandra.config.CFMetaData;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Cell;
 import org.apache.cassandra.db.ColumnFamily;
@@ -74,7 +76,7 @@ public enum FilterExperiment
             } else if (!areTrulyEqual(legacyResult, function.apply(USE_LEGACY))) {
                 indeterminate.inc();
                 log.warn("Query result changed while running experiments, result is indeterminate; Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
-                         legacyResult, optimizedResult, legacyResult.metadata(), optimizedResult.metadata());
+                         legacyResult, optimizedResult, safeLoggableColumnFamilyMetadata(legacyResult.metadata()), safeLoggableColumnFamilyMetadata(optimizedResult.metadata()));
             } else if ((legacyResult.metadata().getGcGraceSeconds() == 0
                            && areEqual(fallback.apply(USE_LEGACY), fallback.apply(USE_OPTIMIZED)))) {
                 indeterminate.inc();
@@ -82,11 +84,11 @@ public enum FilterExperiment
                 //  The indeterminate codepath seems to have never been hit so it's probably fine to defer for now as
                 //  long as we still have signal if we do hit it.
                 log.warn("Query result changed under immediate compaction but results from 60 seconds ago are identical, result is indeterminate; Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
-                         legacyResult, optimizedResult, legacyResult.metadata(), optimizedResult.metadata());
+                         legacyResult, optimizedResult, safeLoggableColumnFamilyMetadata(legacyResult.metadata()), safeLoggableColumnFamilyMetadata(optimizedResult.metadata()));
             } else {
                 failures.inc();
                 log.warn("Comparison failure while experimenting; Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
-                         legacyResult, optimizedResult, legacyResult.metadata(), optimizedResult.metadata());
+                         legacyResult, optimizedResult, safeLoggableColumnFamilyMetadata(legacyResult.metadata()), safeLoggableColumnFamilyMetadata(optimizedResult.metadata()));
             }
         } catch (RuntimeException e) {
             failures.inc();
@@ -134,11 +136,11 @@ public enum FilterExperiment
         }
         if (legacy == null) {
             boolean areEqual = !iterator(modern).hasNext();
-            log.warn("The legacy column family was null when comparing results but the modern column family was not; Modern: {}, Modern metadata: {}", modern, modern.metadata());
+            log.warn("The legacy column family was null when comparing results but the modern column family was not; Modern: {}, Modern metadata: {}", modern, safeLoggableColumnFamilyMetadata(modern.metadata()));
             return areEqual;
         } else if (modern == null) {
             boolean areEqual =  !iterator(legacy).hasNext();
-            log.warn("The modern column family was null when comparing results but the legacy column family was not; Legacy: {}, Legacy metadata: {}", legacy, legacy.metadata());
+            log.warn("The modern column family was null when comparing results but the legacy column family was not; Legacy: {}, Legacy metadata: {}", legacy, safeLoggableColumnFamilyMetadata(legacy.metadata()));
             return areEqual;
         }
         return compareAndLogMetadataIfFalse(legacy, modern, "iterator", FilterExperiment::compareUsingIterator);
@@ -163,8 +165,31 @@ public enum FilterExperiment
         boolean equal = comparator.apply(legacy, modern);
         if (!equal) {
             log.warn("Comparison failure while experimenting; Comparison type: {}, Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
-                     legacy, modern, comparisonType, legacy.metadata(), modern.metadata());
+                     legacy, modern, comparisonType, safeLoggableColumnFamilyMetadata(legacy.metadata()), safeLoggableColumnFamilyMetadata(modern.metadata()));
         }
         return equal;
+    }
+
+    private static String safeLoggableColumnFamilyMetadata(CFMetaData metaData) {
+        return new ToStringBuilder(metaData)
+        .append("cfId", metaData.cfId) // UUID
+        .append("ksName", metaData.ksName) // Is a metric label
+        .append("cfName", metaData.cfName) // Is a metric label
+        .append("cfType", metaData.cfType) // Enum
+        .append("readRepairChance", metaData.getReadRepairChance()) // visible in config
+        .append("dcLocalReadRepairChance", metaData.getDcLocalReadRepairChance()) // visible in config
+        .append("gcGraceSeconds", metaData.getGcGraceSeconds()) // visible in config
+        .append("minCompactionThreshold", metaData.getMinCompactionThreshold()) // visible in config
+        .append("maxCompactionThreshold", metaData.getMaxCompactionThreshold()) // visible in config
+        .append("compactionStrategyClass", metaData.compactionStrategyClass) // Class name
+        .append("bloomFilterFpChance", metaData.getBloomFilterFpChance()) // visible in config
+        .append("memtableFlushPeriod", metaData.getMemtableFlushPeriod()) // visible in config
+        .append("caching", metaData.getCaching()) // Enums
+        .append("defaultTimeToLive", metaData.getDefaultTimeToLive()) // visible in config
+        .append("minIndexInterval", metaData.getMinIndexInterval()) // visible in config
+        .append("maxIndexInterval", metaData.getMaxIndexInterval()) // visible in config
+        .append("speculativeRetry", metaData.getSpeculativeRetry()) // Enum and percentage
+        .append("isDense", metaData.getIsDense()) // boolean
+        .toString();
     }
 }

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -2115,7 +2115,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
             }
             else
             {
-                // This boolean is not necessay for correctness, but is necessary for the metrics to be updated in the
+                // This boolean is not necessary for correctness, but is necessary for the metrics to be updated in the
                 // same cases, since slice queries skip updating metrics when no data was returned (for some reason).
                 // While this should be fixed, let's not do this in a PR that changes behaviour.
                 AtomicBoolean wasNotNull = new AtomicBoolean(false);


### PR DESCRIPTION
When the `FilterExperiment` fails validation we know that it has failed, but we don't know why. The comparison function is pretty complicated and there's quite a few ways it can go wrong.

This adds log statements to each branch to tell us which method failed. Additionally we log as much column family metadata as possible to make it easier to compare any failures, basically anything I was sure was safe to log. In particular we care about keyspace and column family to see if it's any particular load pattern that triggers this. 