### PR TITLE
Fix noisy JFR error

### DIFF
--- a/conf/jvm-clients.options
+++ b/conf/jvm-clients.options
@@ -52,3 +52,5 @@
 --add-exports java.base/java.nio=ALL-UNNAMED
 --add-exports java.base/java.lang=ALL-UNNAMED
 
+# JFR
+--add-exports=jdk.jfr/jdk.jfr.internal=ALL-UNNAMED

--- a/conf/jvm-server.options
+++ b/conf/jvm-server.options
@@ -52,3 +52,5 @@
 --add-exports java.base/java.nio=ALL-UNNAMED
 --add-exports java.base/java.lang=ALL-UNNAMED
 
+# JFR
+--add-exports=jdk.jfr/jdk.jfr.internal=ALL-UNNAMED


### PR DESCRIPTION
This PR adds a JVM flag to silence an error when taking JFRs

`--add-exports=jdk.jfr/jdk.jfr.internal=ALL-UNNAMED`

The specific error this silences is 
```
com.palantir.jfr.logger.impl.JfrRecorderInternalUtil: Couldn't override JFR base path (throwable0_message: class com.palantir.jfr.logger.impl.JfrRecorderInternalUtil (in unnamed module @0x63753b6d) cannot access class jdk.jfr.internal.SecuritySupport$SafePath (in module jdk.jfr) because module jdk.jfr does not export jdk.jfr.internal to unnamed module @0x63753b6d)
java.lang.IllegalAccessError: class com.palantir.jfr.logger.impl.JfrRecorderInternalUtil (in unnamed module @0x63753b6d) cannot access class jdk.jfr.internal.SecuritySupport$SafePath (in module jdk.jfr) because module jdk.jfr does not export jdk.jfr.internal to unnamed module @0x63753b6d
```

We add this to both the client and server options because thus far we have kept the arguments consistent, and there's no reason to believe we wouldn't want to take a JFR of an expensive `nodetool` command in the future.