### PR TITLE
Fix wait for sync bug

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
@@ -382,15 +382,17 @@ public abstract class CommitLogSegment
 
     void waitForSync(int position, Timer waitingOnCommit)
     {
-        try (Timer.Context ignored2 = commitLog.metrics.totalWaitingOnCommit.time())
+        try (Timer.Context ignored = commitLog.metrics.totalWaitingOnCommit.time())
         {
-            WaitQueue.Signal signal = waitingOnCommit != null ?
-                                      syncComplete.register(position, waitingOnCommit.time()) :
-                                      syncComplete.register(position);
-            if (lastSyncedOffset < position)
-                signal.awaitUninterruptibly();
-            else
-                signal.cancel();
+            while (lastSyncedOffset < position) {
+                WaitQueue.Signal signal = waitingOnCommit != null ?
+                                          syncComplete.register(position, waitingOnCommit.time()) :
+                                          syncComplete.register(position);
+                if (lastSyncedOffset < position)
+                    signal.awaitUninterruptibly();
+                else
+                    signal.cancel();
+            }
         }
     }
 


### PR DESCRIPTION
We accidentally lost this loop in this change: https://github.com/palantir/cassandra/pull/689/files#diff-18edf4fd7e8f12c8a98281aa0867852be76d78bdb4994782e907d8d64ecde0baL377

Without the loop, it's possible for a writer to be woken up before their data is actually durably fsynced to disk and apply their writes to the memtables anyway. This is a possible vector for corruption.