### PR TITLE
Added better exception coverage for deserialization

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -720,7 +720,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
                 CompactionMetadata compactionMetadata = (CompactionMetadata) desc.getMetadataSerializer().deserialize(desc, MetadataType.COMPACTION);
                 ancestors = compactionMetadata.ancestors;
             }
-            catch (IOException e)
+            catch (IOException | IndexOutOfBoundsException e)
             {
                 throw new FSReadError(e, desc.filenameFor(Component.STATS));
             }


### PR DESCRIPTION
This catches the issue of when data files are deserialized, causing an ArrayIndexOutOfBoundsException where the number of bytes stated that the file is for the length exceeds the actual size of the file. Now instead of an ambiguous error message, the message will include which file is being deserialized incorrectly.