### PR TITLE
Log when KeyspaceTableOpStatePersister fails to persist and test CleanupStateTracker losing cache

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -398,8 +398,7 @@
 	         <exclusion groupId="commons-logging" artifactId="commons-logging"/>
           </dependency>
           <dependency groupId="junit" artifactId="junit" version="4.6" />
-          <dependency groupId="org.mockito" artifactId="mockito-core" version="3.4.0" />
-          <dependency groupId="org.mockito" artifactId="mockito-inline" version="3.4.0" />
+          <dependency groupId="org.mockito" artifactId="mockito-core" version="3.2.4" />
           <dependency groupId="org.apache.cassandra" artifactId="dtest-api" version="0.0.3" />
           <dependency groupId="org.apache.rat" artifactId="apache-rat" version="0.10">
              <exclusion groupId="commons-lang" artifactId="commons-lang"/>
@@ -524,7 +523,6 @@
                 version="${version}"/>
         <dependency groupId="junit" artifactId="junit"/>
         <dependency groupId="org.mockito" artifactId="mockito-core" />
-        <dependency groupId="org.mockito" artifactId="mockito-inline" />
         <dependency groupId="org.apache.cassandra" artifactId="dtest-api" />
         <dependency groupId="org.assertj" artifactId="assertj-core"/>
         <dependency groupId="org.apache.rat" artifactId="apache-rat"/>
@@ -555,7 +553,6 @@
                 version="${version}"/>
         <dependency groupId="junit" artifactId="junit"/>
         <dependency groupId="org.mockito" artifactId="mockito-core" />
-        <dependency groupId="org.mockito" artifactId="mockito-inline" />
         <dependency groupId="org.assertj" artifactId="assertj-core"/>
         <dependency groupId="org.apache.pig" artifactId="pig">
           <exclusion groupId="xmlenc" artifactId="xmlenc"/>

--- a/build.xml
+++ b/build.xml
@@ -398,7 +398,8 @@
 	         <exclusion groupId="commons-logging" artifactId="commons-logging"/>
           </dependency>
           <dependency groupId="junit" artifactId="junit" version="4.6" />
-          <dependency groupId="org.mockito" artifactId="mockito-core" version="3.2.4" />
+          <dependency groupId="org.mockito" artifactId="mockito-core" version="3.4.0" />
+          <dependency groupId="org.mockito" artifactId="mockito-inline" version="3.4.0" />
           <dependency groupId="org.apache.cassandra" artifactId="dtest-api" version="0.0.3" />
           <dependency groupId="org.apache.rat" artifactId="apache-rat" version="0.10">
              <exclusion groupId="commons-lang" artifactId="commons-lang"/>
@@ -523,6 +524,7 @@
                 version="${version}"/>
         <dependency groupId="junit" artifactId="junit"/>
         <dependency groupId="org.mockito" artifactId="mockito-core" />
+        <dependency groupId="org.mockito" artifactId="mockito-inline" />
         <dependency groupId="org.apache.cassandra" artifactId="dtest-api" />
         <dependency groupId="org.assertj" artifactId="assertj-core"/>
         <dependency groupId="org.apache.rat" artifactId="apache-rat"/>
@@ -553,6 +555,7 @@
                 version="${version}"/>
         <dependency groupId="junit" artifactId="junit"/>
         <dependency groupId="org.mockito" artifactId="mockito-core" />
+        <dependency groupId="org.mockito" artifactId="mockito-inline" />
         <dependency groupId="org.assertj" artifactId="assertj-core"/>
         <dependency groupId="org.apache.pig" artifactId="pig">
           <exclusion groupId="xmlenc" artifactId="xmlenc"/>

--- a/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
+++ b/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
@@ -99,7 +99,10 @@ public class CleanupStateTracker
         Map<KeyspaceTableKey, Instant> updatedEntries = state.updateTsForEntry(key, value);
         updateCacheIfHasNotYetSuccessfullyReadFromPersister();
         if (!successfulReadFromPersister || !persister.updateStateInPersistentLocation(updatedEntries))
-            log.warn("Failed to update persistant cleanup state, but cache has been updated. Will retry at next update.", SafeArg.of("key", key));
+            log.warn("Failed to update persistant cleanup state, but cache has been updated. Will retry at next update.",
+                     SafeArg.of("keyspace", key.getKeyspace()),
+                     SafeArg.of("cf", key.getColumnFamily())
+            );
     }
 
     private void updateCacheIfHasNotYetSuccessfullyReadFromPersister()

--- a/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
+++ b/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
@@ -30,6 +30,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
 import org.apache.cassandra.config.DatabaseDescriptor;
 
 public class CleanupStateTracker
@@ -98,7 +99,7 @@ public class CleanupStateTracker
         Map<KeyspaceTableKey, Instant> updatedEntries = state.updateTsForEntry(key, value);
         updateCacheIfHasNotYetSuccessfullyReadFromPersister();
         if (!successfulReadFromPersister || !persister.updateStateInPersistentLocation(updatedEntries))
-            log.warn("Failed to update persistant cleanup state, but cache has been updated. Will retry at next update.");
+            log.warn("Failed to update persistant cleanup state, but cache has been updated. Will retry at next update.", SafeArg.of("key", key));
     }
 
     private void updateCacheIfHasNotYetSuccessfullyReadFromPersister()

--- a/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
+++ b/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
@@ -62,11 +62,11 @@ public class CleanupStateTracker
     }
 
     @VisibleForTesting
-    CleanupStateTracker(KeyspaceTableOpStateCache state, KeyspaceTableOpStatePersister persister, boolean successfulReadFromPersister)
+    CleanupStateTracker(KeyspaceTableOpStateCache state, KeyspaceTableOpStatePersister persister)
     {
         this.persister = persister;
         this.state = state;
-        this.successfulReadFromPersister = true;
+        this.successfulReadFromPersister = false;
     }
 
     /** Creates table entry if it does not already exist */
@@ -97,12 +97,8 @@ public class CleanupStateTracker
     {
         Map<KeyspaceTableKey, Instant> updatedEntries = state.updateTsForEntry(key, value);
         updateCacheIfHasNotYetSuccessfullyReadFromPersister();
-        if (successfulReadFromPersister) {
-            boolean result = persister.updateStateInPersistentLocation(updatedEntries);
-            if (!result) {
-                log.warn("Failed to update persistant cleanup state, but cache has been updated. Will retry at next update.");
-            }
-        }
+        if (!successfulReadFromPersister || !persister.updateStateInPersistentLocation(updatedEntries))
+            log.warn("Failed to update persistant cleanup state, but cache has been updated. Will retry at next update.");
     }
 
     private void updateCacheIfHasNotYetSuccessfullyReadFromPersister()

--- a/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
+++ b/src/java/org/apache/cassandra/service/opstate/CleanupStateTracker.java
@@ -62,7 +62,7 @@ public class CleanupStateTracker
     }
 
     @VisibleForTesting
-    CleanupStateTracker(KeyspaceTableOpStateCache state, KeyspaceTableOpStatePersister persister)
+    CleanupStateTracker(KeyspaceTableOpStateCache state, KeyspaceTableOpStatePersister persister, boolean successfulReadFromPersister)
     {
         this.persister = persister;
         this.state = state;
@@ -97,8 +97,12 @@ public class CleanupStateTracker
     {
         Map<KeyspaceTableKey, Instant> updatedEntries = state.updateTsForEntry(key, value);
         updateCacheIfHasNotYetSuccessfullyReadFromPersister();
-        if (!successfulReadFromPersister || !persister.updateStateInPersistentLocation(updatedEntries))
-            log.warn("Failed to update persistant cleanup state, but cache has been updated. Will retry at next update.");
+        if (successfulReadFromPersister) {
+            boolean result = persister.updateStateInPersistentLocation(updatedEntries);
+            if (!result) {
+                log.warn("Failed to update persistant cleanup state, but cache has been updated. Will retry at next update.");
+            }
+        }
     }
 
     private void updateCacheIfHasNotYetSuccessfullyReadFromPersister()

--- a/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
+++ b/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
@@ -149,7 +149,9 @@ public class KeyspaceTableOpStatePersister
         }
         finally
         {
-            Files.delete(tmpFile.toPath());
+            if (tmpFile.exists()) {
+                Files.delete(tmpFile.toPath());
+            }
         }
     }
 

--- a/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
+++ b/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.logsafe.SafeArg;
 
 public class KeyspaceTableOpStatePersister
 {
@@ -93,7 +94,7 @@ public class KeyspaceTableOpStatePersister
         }
         catch (IOException e)
         {
-            log.warn("Cannot retrieve or create state file.", operationStateFile.getAbsolutePath(), e);
+            log.warn("Cannot retrieve or create state file.", SafeArg.of("file", operationStateFile.getName()), e);
             return null;
         }
         this.persistentFile = operationStateFile;
@@ -110,7 +111,7 @@ public class KeyspaceTableOpStatePersister
         }
         catch (IOException e)
         {
-            log.warn("Failed to read state from file.", file.getAbsolutePath(), e);
+            log.warn("Failed to read state from file.", SafeArg.of("file", file.getName()), e);
             throw e;
         }
     }
@@ -124,7 +125,7 @@ public class KeyspaceTableOpStatePersister
         }
         catch (IOException e)
         {
-            log.warn("Failed to write state to file.", file.getAbsolutePath(), e);
+            log.warn("Failed to write state to file.", SafeArg.of("file", file.getName()), e);
             return false;
         }
     }
@@ -142,7 +143,7 @@ public class KeyspaceTableOpStatePersister
         }
         catch (IOException e)
         {
-            log.warn("Failed to write state to file.", file.getAbsolutePath(), e);
+            log.warn("Failed to write state to file.", SafeArg.of("file", file.getName()), e);
             throw e;
         }
         finally

--- a/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
+++ b/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
@@ -124,6 +124,7 @@ public class KeyspaceTableOpStatePersister
         }
         catch (IOException e)
         {
+            log.warn("Failed to write state to file.", file.getAbsolutePath(), e);
             return false;
         }
     }

--- a/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
+++ b/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
@@ -137,8 +137,6 @@ public class KeyspaceTableOpStatePersister
         {
             tmpFile.createNewFile();
             Files.write(tmpFile.toPath(), content.getBytes(), StandardOpenOption.TRUNCATE_EXISTING);
-            // exception thrown here due to the .tmp file not existing, but the .tmp file did successfully
-            // move to the real json file.
             Files.move(tmpFile.toPath(), file.toPath(),
                        StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
         }

--- a/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
+++ b/src/java/org/apache/cassandra/service/opstate/KeyspaceTableOpStatePersister.java
@@ -137,6 +137,8 @@ public class KeyspaceTableOpStatePersister
         {
             tmpFile.createNewFile();
             Files.write(tmpFile.toPath(), content.getBytes(), StandardOpenOption.TRUNCATE_EXISTING);
+            // exception thrown here due to the .tmp file not existing, but the .tmp file did successfully
+            // move to the real json file.
             Files.move(tmpFile.toPath(), file.toPath(),
                        StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
         }

--- a/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
+++ b/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
@@ -35,10 +35,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import org.mockito.MockedStatic;
 
 public class CleanupStateTrackerTest
 {
@@ -138,7 +141,7 @@ public class CleanupStateTrackerTest
     }
 
     @Test
-    public void recordSuccessfulCleanupForTableDoesNotPersistAndLosesCache()
+    public void cleanupEntryDoesNotPersistAndLosesCacheFallsBackToMin()
     {
         Instant instant1 = Instant.now().minusSeconds(30);
 
@@ -160,5 +163,40 @@ public class CleanupStateTrackerTest
         tracker = new CleanupStateTracker(state, persister);
         Instant lastCleanupTs = tracker.getLastSuccessfulCleanupTsForNode();
         assertThat(lastCleanupTs).isEqualTo(CleanupStateTracker.MIN_TS);
+    }
+
+    @Test
+    public void cleanupEntryDoesNotPersistNewValueAndLosesCacheFallsBackToOldCleanupTs()
+    {
+        Instant instant1 = Instant.now().minusSeconds(30);
+
+        KeyspaceTableOpStateCache state = spy(new KeyspaceTableOpStateCache(ImmutableMap.of()));
+        when(state.getValidKeyspaceTableEntries()).thenReturn(OpStateTestConstants.KEYSPACE_TABLE_VALID_ENTRIES);
+
+        KeyspaceTableOpStatePersister persister = spy(new KeyspaceTableOpStatePersister(stateFilePath));
+        CleanupStateTracker tracker = new CleanupStateTracker(state, persister);
+        tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.of(instant1));
+        tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2, Optional.of(instant1));
+        assertThat(tracker.getLastSuccessfulCleanupTsForNode()).isEqualTo(instant1);
+
+        Instant instant2 = instant1.plusSeconds(30);
+        Instant instant3 = instant1.plusSeconds(35);
+        doReturn(false).when(persister).updateStateInPersistentLocation(
+            argThat(map -> map.containsKey(OpStateTestConstants.KEYSPACE_TABLE_KEY_2) && map.get(OpStateTestConstants.KEYSPACE_TABLE_KEY_2).equals(instant3)
+        ));
+        try (MockedStatic<Instant> mockInstant = mockStatic(Instant.class)) {
+            mockInstant.when(Instant::now).thenReturn(instant2);
+            tracker.recordSuccessfulCleanupForTable(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1);
+
+            mockInstant.when(Instant::now).thenReturn(instant3);
+            tracker.recordSuccessfulCleanupForTable(OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2);
+        }
+        assertThat(tracker.getLastSuccessfulCleanupTsForNode()).isEqualTo(instant2);
+
+        state = spy(new KeyspaceTableOpStateCache(ImmutableMap.of()));
+        when(state.getValidKeyspaceTableEntries()).thenReturn(OpStateTestConstants.KEYSPACE_TABLE_VALID_ENTRIES);
+        tracker = new CleanupStateTracker(state, persister);
+        Instant lastCleanupTs = tracker.getLastSuccessfulCleanupTsForNode();
+        assertThat(lastCleanupTs).isEqualTo(instant1);
     }
 }

--- a/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
+++ b/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
@@ -32,7 +32,9 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -61,7 +63,7 @@ public class CleanupStateTrackerTest
         KeyspaceTableOpStatePersister persister = spy(new KeyspaceTableOpStatePersister(stateFilePath));
         KeyspaceTableOpStateCache state = spy(new KeyspaceTableOpStateCache(ImmutableMap.of()));
 
-        CleanupStateTracker tracker = new CleanupStateTracker(state, persister);
+        CleanupStateTracker tracker = new CleanupStateTracker(state, persister, true);
         tracker.updateTsForEntry(OpStateTestConstants.KEYSPACE_TABLE_KEY_1, Instant.ofEpochMilli(10L));
         verify(state, times(1))
             .updateTsForEntry(eq(OpStateTestConstants.KEYSPACE_TABLE_KEY_1), eq(Instant.ofEpochMilli(10L)));
@@ -76,7 +78,7 @@ public class CleanupStateTrackerTest
         KeyspaceTableOpStateCache state =
             new KeyspaceTableOpStateCache(ImmutableMap.of(OpStateTestConstants.KEYSPACE_TABLE_KEY_1, Instant.ofEpochMilli(20L)));
 
-        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister));
+        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister, true));
         tracker.createCleanupEntryForTableIfNotExists(
             OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.empty());
         verify(tracker, times(0)).updateTsForEntry(any(), any());
@@ -88,7 +90,7 @@ public class CleanupStateTrackerTest
         KeyspaceTableOpStatePersister persister = new KeyspaceTableOpStatePersister(stateFilePath);
         KeyspaceTableOpStateCache state = new KeyspaceTableOpStateCache(ImmutableMap.of());
 
-        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister));
+        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister, true));
         tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.empty());
         verify(tracker, times(1))
             .updateTsForEntry(eq(OpStateTestConstants.KEYSPACE_TABLE_KEY_1), eq(CleanupStateTracker.MIN_TS));
@@ -100,7 +102,7 @@ public class CleanupStateTrackerTest
         KeyspaceTableOpStatePersister persister = new KeyspaceTableOpStatePersister(stateFilePath);
         KeyspaceTableOpStateCache state = new KeyspaceTableOpStateCache(ImmutableMap.of());
 
-        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister));
+        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister, true));
         tracker.createCleanupEntryForTableIfNotExists(
             OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.of(OpStateTestConstants.INSTANT_10));
         verify(tracker, times(1))
@@ -115,7 +117,7 @@ public class CleanupStateTrackerTest
         KeyspaceTableOpStateCache state =
             new KeyspaceTableOpStateCache(ImmutableMap.of(OpStateTestConstants.KEYSPACE_TABLE_KEY_1, instant1));
 
-        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister));
+        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister, true));
         Map<KeyspaceTableKey, Instant> cacheEntries = state.getTableEntries();
         assertThat(cacheEntries.get(KeyspaceTableKey.of(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1)))
             .isEqualTo(instant1);
@@ -131,7 +133,7 @@ public class CleanupStateTrackerTest
     {
         KeyspaceTableOpStatePersister persister = new KeyspaceTableOpStatePersister(stateFilePath);
         KeyspaceTableOpStateCache state = new KeyspaceTableOpStateCache(ImmutableMap.of());
-        CleanupStateTracker tracker = new CleanupStateTracker(state, persister);
+        CleanupStateTracker tracker = new CleanupStateTracker(state, persister, true);
         assertThat(tracker.getLastSuccessfulCleanupTsForNode()).isEqualTo(CleanupStateTracker.MIN_TS);
     }
 
@@ -139,20 +141,30 @@ public class CleanupStateTrackerTest
     public void recordSuccessfulCleanupForTableDoesNotPersistAndLosesCache()
     {
         Instant instant1 = Instant.now().minusSeconds(30);
-        Instant instant2 = instant1.plusSeconds(1);
 
-        KeyspaceTableOpStateCache state = new KeyspaceTableOpStateCache(ImmutableMap.of());
-        KeyspaceTableOpStatePersister persister = new KeyspaceTableOpStatePersister(stateFilePath);
-        when(persister.updateStateInPersistentLocation(ImmutableMap.of(
-        OpStateTestConstants.KEYSPACE_TABLE_KEY_2, instant2))).thenReturn(false);
+        KeyspaceTableOpStateCache state = spy(new KeyspaceTableOpStateCache(ImmutableMap.of()));
+        doReturn(OpStateTestConstants.KEYSPACE_TABLE_VALID_ENTRIES).when(state).getValidKeyspaceTableEntries();
 
-        CleanupStateTracker tracker = new CleanupStateTracker(state, persister);
+        KeyspaceTableOpStatePersister persister = spy(new KeyspaceTableOpStatePersister(stateFilePath));
+        // todo, wonky mock
+        doReturn(false).when(persister).updateStateInPersistentLocation(
+            argThat(argument -> {
+                if (argument instanceof Map) {
+                    Map<?, ?> map = (Map<?, ?>) argument;
+                    return map.containsKey(OpStateTestConstants.KEYSPACE_TABLE_KEY_2) &&
+                           map.get(OpStateTestConstants.KEYSPACE_TABLE_KEY_2).equals(instant1);
+                }
+                return false;
+            })
+        );
 
-        tracker.recordSuccessfulCleanupForTable(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1);
-        tracker.recordSuccessfulCleanupForTable(OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2);
 
+        CleanupStateTracker tracker = new CleanupStateTracker(state, persister, true);
+        tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.of(instant1));
+        tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2, Optional.of(instant1));
+        assertThat(tracker.getLastSuccessfulCleanupTsForNode()).isEqualTo(instant1);
 
-        tracker = new CleanupStateTracker(state, persister);
+        tracker = new CleanupStateTracker(new KeyspaceTableOpStateCache(ImmutableMap.of()), persister, false);
         assertThat(tracker.getLastSuccessfulCleanupTsForNode()).isEqualTo(CleanupStateTracker.MIN_TS);
     }
 }

--- a/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
+++ b/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
@@ -35,13 +35,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.mockito.MockedStatic;
 
 public class CleanupStateTrackerTest
 {
@@ -150,12 +148,15 @@ public class CleanupStateTrackerTest
 
         KeyspaceTableOpStatePersister persister = spy(new KeyspaceTableOpStatePersister(stateFilePath));
         doReturn(false).when(persister).updateStateInPersistentLocation(
-            argThat(map -> map.containsKey(OpStateTestConstants.KEYSPACE_TABLE_KEY_2) && map.get(OpStateTestConstants.KEYSPACE_TABLE_KEY_2).equals(instant1)
-        ));
+            argThat(
+            map -> map.containsKey(OpStateTestConstants.KEYSPACE_TABLE_KEY_2)
+                   && map.get(OpStateTestConstants.KEYSPACE_TABLE_KEY_2).equals(instant1)));
 
         CleanupStateTracker tracker = new CleanupStateTracker(state, persister);
-        tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.of(instant1));
-        tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2, Optional.of(instant1));
+        tracker.createCleanupEntryForTableIfNotExists(
+            OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.of(instant1));
+        tracker.createCleanupEntryForTableIfNotExists(
+            OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2, Optional.of(instant1));
         assertThat(tracker.getLastSuccessfulCleanupTsForNode()).isEqualTo(instant1);
 
         state = spy(new KeyspaceTableOpStateCache(ImmutableMap.of()));
@@ -175,22 +176,21 @@ public class CleanupStateTrackerTest
 
         KeyspaceTableOpStatePersister persister = spy(new KeyspaceTableOpStatePersister(stateFilePath));
         CleanupStateTracker tracker = new CleanupStateTracker(state, persister);
-        tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.of(instant1));
-        tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2, Optional.of(instant1));
+        tracker.createCleanupEntryForTableIfNotExists(
+            OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.of(instant1));
+        tracker.createCleanupEntryForTableIfNotExists(
+            OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2, Optional.of(instant1));
         assertThat(tracker.getLastSuccessfulCleanupTsForNode()).isEqualTo(instant1);
 
         Instant instant2 = instant1.plusSeconds(30);
         Instant instant3 = instant1.plusSeconds(35);
         doReturn(false).when(persister).updateStateInPersistentLocation(
-            argThat(map -> map.containsKey(OpStateTestConstants.KEYSPACE_TABLE_KEY_2) && map.get(OpStateTestConstants.KEYSPACE_TABLE_KEY_2).equals(instant3)
-        ));
-        try (MockedStatic<Instant> mockInstant = mockStatic(Instant.class)) {
-            mockInstant.when(Instant::now).thenReturn(instant2);
-            tracker.recordSuccessfulCleanupForTable(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1);
+            argThat(
+                map -> map.containsKey(OpStateTestConstants.KEYSPACE_TABLE_KEY_2)
+                       && map.get(OpStateTestConstants.KEYSPACE_TABLE_KEY_2).equals(instant3)));
 
-            mockInstant.when(Instant::now).thenReturn(instant3);
-            tracker.recordSuccessfulCleanupForTable(OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2);
-        }
+        tracker.updateTsForEntry(OpStateTestConstants.KEYSPACE_TABLE_KEY_1, instant2);
+        tracker.updateTsForEntry(OpStateTestConstants.KEYSPACE_TABLE_KEY_2, instant3);
         assertThat(tracker.getLastSuccessfulCleanupTsForNode()).isEqualTo(instant2);
 
         state = spy(new KeyspaceTableOpStateCache(ImmutableMap.of()));

--- a/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
+++ b/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
@@ -63,7 +63,7 @@ public class CleanupStateTrackerTest
         KeyspaceTableOpStatePersister persister = spy(new KeyspaceTableOpStatePersister(stateFilePath));
         KeyspaceTableOpStateCache state = spy(new KeyspaceTableOpStateCache(ImmutableMap.of()));
 
-        CleanupStateTracker tracker = new CleanupStateTracker(state, persister, true);
+        CleanupStateTracker tracker = new CleanupStateTracker(state, persister);
         tracker.updateTsForEntry(OpStateTestConstants.KEYSPACE_TABLE_KEY_1, Instant.ofEpochMilli(10L));
         verify(state, times(1))
             .updateTsForEntry(eq(OpStateTestConstants.KEYSPACE_TABLE_KEY_1), eq(Instant.ofEpochMilli(10L)));
@@ -78,7 +78,7 @@ public class CleanupStateTrackerTest
         KeyspaceTableOpStateCache state =
             new KeyspaceTableOpStateCache(ImmutableMap.of(OpStateTestConstants.KEYSPACE_TABLE_KEY_1, Instant.ofEpochMilli(20L)));
 
-        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister, true));
+        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister));
         tracker.createCleanupEntryForTableIfNotExists(
             OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.empty());
         verify(tracker, times(0)).updateTsForEntry(any(), any());
@@ -90,7 +90,7 @@ public class CleanupStateTrackerTest
         KeyspaceTableOpStatePersister persister = new KeyspaceTableOpStatePersister(stateFilePath);
         KeyspaceTableOpStateCache state = new KeyspaceTableOpStateCache(ImmutableMap.of());
 
-        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister, true));
+        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister));
         tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.empty());
         verify(tracker, times(1))
             .updateTsForEntry(eq(OpStateTestConstants.KEYSPACE_TABLE_KEY_1), eq(CleanupStateTracker.MIN_TS));
@@ -102,7 +102,7 @@ public class CleanupStateTrackerTest
         KeyspaceTableOpStatePersister persister = new KeyspaceTableOpStatePersister(stateFilePath);
         KeyspaceTableOpStateCache state = new KeyspaceTableOpStateCache(ImmutableMap.of());
 
-        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister, true));
+        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister));
         tracker.createCleanupEntryForTableIfNotExists(
             OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.of(OpStateTestConstants.INSTANT_10));
         verify(tracker, times(1))
@@ -117,7 +117,7 @@ public class CleanupStateTrackerTest
         KeyspaceTableOpStateCache state =
             new KeyspaceTableOpStateCache(ImmutableMap.of(OpStateTestConstants.KEYSPACE_TABLE_KEY_1, instant1));
 
-        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister, true));
+        CleanupStateTracker tracker = spy(new CleanupStateTracker(state, persister));
         Map<KeyspaceTableKey, Instant> cacheEntries = state.getTableEntries();
         assertThat(cacheEntries.get(KeyspaceTableKey.of(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1)))
             .isEqualTo(instant1);
@@ -133,7 +133,7 @@ public class CleanupStateTrackerTest
     {
         KeyspaceTableOpStatePersister persister = new KeyspaceTableOpStatePersister(stateFilePath);
         KeyspaceTableOpStateCache state = new KeyspaceTableOpStateCache(ImmutableMap.of());
-        CleanupStateTracker tracker = new CleanupStateTracker(state, persister, true);
+        CleanupStateTracker tracker = new CleanupStateTracker(state, persister);
         assertThat(tracker.getLastSuccessfulCleanupTsForNode()).isEqualTo(CleanupStateTracker.MIN_TS);
     }
 
@@ -143,27 +143,22 @@ public class CleanupStateTrackerTest
         Instant instant1 = Instant.now().minusSeconds(30);
 
         KeyspaceTableOpStateCache state = spy(new KeyspaceTableOpStateCache(ImmutableMap.of()));
-        doReturn(OpStateTestConstants.KEYSPACE_TABLE_VALID_ENTRIES).when(state).getValidKeyspaceTableEntries();
+        when(state.getValidKeyspaceTableEntries()).thenReturn(OpStateTestConstants.KEYSPACE_TABLE_VALID_ENTRIES);
 
         KeyspaceTableOpStatePersister persister = spy(new KeyspaceTableOpStatePersister(stateFilePath));
-        // todo, wonky mock
         doReturn(false).when(persister).updateStateInPersistentLocation(
-            argThat(argument -> {
-                if (argument instanceof Map) {
-                    Map<?, ?> map = (Map<?, ?>) argument;
-                    return map.containsKey(OpStateTestConstants.KEYSPACE_TABLE_KEY_2) &&
-                           map.get(OpStateTestConstants.KEYSPACE_TABLE_KEY_2).equals(instant1);
-                }
-                return false;
-            })
-        );
+            argThat(map -> map.containsKey(OpStateTestConstants.KEYSPACE_TABLE_KEY_2) && map.get(OpStateTestConstants.KEYSPACE_TABLE_KEY_2).equals(instant1)
+        ));
 
-        CleanupStateTracker tracker = new CleanupStateTracker(state, persister, true);
+        CleanupStateTracker tracker = new CleanupStateTracker(state, persister);
         tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.of(instant1));
         tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2, Optional.of(instant1));
         assertThat(tracker.getLastSuccessfulCleanupTsForNode()).isEqualTo(instant1);
 
-        tracker = new CleanupStateTracker(new KeyspaceTableOpStateCache(ImmutableMap.of()), persister, false);
-        assertThat(tracker.getLastSuccessfulCleanupTsForNode()).isEqualTo(CleanupStateTracker.MIN_TS);
+        state = spy(new KeyspaceTableOpStateCache(ImmutableMap.of()));
+        when(state.getValidKeyspaceTableEntries()).thenReturn(OpStateTestConstants.KEYSPACE_TABLE_VALID_ENTRIES);
+        tracker = new CleanupStateTracker(state, persister);
+        Instant lastCleanupTs = tracker.getLastSuccessfulCleanupTsForNode();
+        assertThat(lastCleanupTs).isEqualTo(CleanupStateTracker.MIN_TS);
     }
 }

--- a/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
+++ b/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
@@ -158,7 +158,6 @@ public class CleanupStateTrackerTest
             })
         );
 
-
         CleanupStateTracker tracker = new CleanupStateTracker(state, persister, true);
         tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1, Optional.of(instant1));
         tracker.createCleanupEntryForTableIfNotExists(OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2, Optional.of(instant1));

--- a/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
+++ b/test/unit/org/apache/cassandra/service/opstate/CleanupStateTrackerTest.java
@@ -36,6 +36,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class CleanupStateTrackerTest
 {
@@ -131,6 +132,27 @@ public class CleanupStateTrackerTest
         KeyspaceTableOpStatePersister persister = new KeyspaceTableOpStatePersister(stateFilePath);
         KeyspaceTableOpStateCache state = new KeyspaceTableOpStateCache(ImmutableMap.of());
         CleanupStateTracker tracker = new CleanupStateTracker(state, persister);
+        assertThat(tracker.getLastSuccessfulCleanupTsForNode()).isEqualTo(CleanupStateTracker.MIN_TS);
+    }
+
+    @Test
+    public void recordSuccessfulCleanupForTableDoesNotPersistAndLosesCache()
+    {
+        Instant instant1 = Instant.now().minusSeconds(30);
+        Instant instant2 = instant1.plusSeconds(1);
+
+        KeyspaceTableOpStateCache state = new KeyspaceTableOpStateCache(ImmutableMap.of());
+        KeyspaceTableOpStatePersister persister = new KeyspaceTableOpStatePersister(stateFilePath);
+        when(persister.updateStateInPersistentLocation(ImmutableMap.of(
+        OpStateTestConstants.KEYSPACE_TABLE_KEY_2, instant2))).thenReturn(false);
+
+        CleanupStateTracker tracker = new CleanupStateTracker(state, persister);
+
+        tracker.recordSuccessfulCleanupForTable(OpStateTestConstants.KEYSPACE1, OpStateTestConstants.TABLE1);
+        tracker.recordSuccessfulCleanupForTable(OpStateTestConstants.KEYSPACE2, OpStateTestConstants.TABLE2);
+
+
+        tracker = new CleanupStateTracker(state, persister);
         assertThat(tracker.getLastSuccessfulCleanupTsForNode()).isEqualTo(CleanupStateTracker.MIN_TS);
     }
 }


### PR DESCRIPTION
This PR contains three items:
- additional logging of the exception whenever KeyspaceTableOpStatePersister fails to persist
- fix a bug where we attempt to delete the tmp file which has already successfully atomically moved to the actual json persisted file (and thus does not exist anymore)
- new unit test to test the behavior of what happens when CleanupStateTracker does not persist a cleanup time, loses the cached state, then tries to fetch the last cleanup timestamp. This confirms that the tracker knows that it is missing a cleanup timestamp entry for a valid table, and falls back to the min timestamp