### PR TITLE
Do not purge tombstones if keyspace is repairing

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionController.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionController.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Memtable;
 import org.apache.cassandra.db.RowPosition;
+import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.AlwaysPresentFilter;
 
@@ -79,7 +80,7 @@ public class CompactionController implements AutoCloseable
 
     void maybeRefreshOverlaps()
     {
-        if (doNotPurgeTombstones(cfs.keyspace.getName()))
+        if (doNotPurgeTombstones(cfs))
         {
             logger.debug("not refreshing overlaps - doNotPurgeTombstones returned true for keyspace {}",
                          SafeArg.of("keyspace", cfs.keyspace.getName()));
@@ -98,7 +99,7 @@ public class CompactionController implements AutoCloseable
 
     private void refreshOverlaps()
     {
-        if (doNotPurgeTombstones(cfs.keyspace.getName()))
+        if (doNotPurgeTombstones(cfs))
         {
             logger.debug("not refreshing overlaps - doNotPurgeTombstones returned true for keyspace {}",
                          SafeArg.of("keyspace", cfs.keyspace.getName()));
@@ -145,9 +146,9 @@ public class CompactionController implements AutoCloseable
         if (compacting == null)
             return Collections.<SSTableReader>emptySet();
 
-        if (doNotPurgeTombstones(cfStore.keyspace.getName())) {
-            logger.debug("not looking for droppable sstables - doNotPurgeTombstones returned true for keyspace {}",
-                         SafeArg.of("keyspace", cfStore.keyspace.getName()));
+        if (doNotPurgeTombstones(cfStore))
+        {
+            logger.debug("Not looking for droppable sstables - doNotPurgeTombstones returned true for keyspace {}", cfStore.keyspace.getName());
             return Collections.<SSTableReader>emptySet();
         }
 
@@ -219,7 +220,7 @@ public class CompactionController implements AutoCloseable
      */
     public Predicate<Long> getPurgeEvaluator(DecoratedKey key)
     {
-        if (doNotPurgeTombstones(getKeyspace()))
+        if (doNotPurgeTombstones(cfs))
         {
             logger.debug("Purge evaluator always returning false - doNotPurgeTombstones returned true for keyspace {}",
                          SafeArg.of("keyspace", getKeyspace()));
@@ -278,17 +279,18 @@ public class CompactionController implements AutoCloseable
     }
 
     /**
-     * @param keyspace
+     * @param cfs
      * @return true if this node may be streaming data for this keyspace, or if cassandra.never_purge_tombstones is set
      * If we are streaming, tombstones should not be purged so that we don't pre-maturely purge those that exceed gc_grace_seconds.
      * <p>
      * Note that this node may receive data without streaming, e.g. during a repair.
      */
-    private static boolean doNotPurgeTombstones(String keyspace)
+    private static boolean doNotPurgeTombstones(ColumnFamilyStore cfs)
     {
         return NEVER_PURGE_TOMBSTONES
                 || StorageService.instance.isRebuilding()
-                || pendingRangesExistForKeyspace(keyspace);
+                || pendingRangesExistForKeyspace(cfs.keyspace.getName())
+                || ActiveRepairService.instance.isRepairing(cfs.metadata.cfId);
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/compaction/CompactionController.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionController.java
@@ -149,7 +149,8 @@ public class CompactionController implements AutoCloseable
 
         if (doNotPurgeTombstones(cfStore))
         {
-            logger.debug("Not looking for droppable sstables - doNotPurgeTombstones returned true for keyspace {}", cfStore.keyspace.getName());
+            logger.debug("Not looking for droppable sstables - doNotPurgeTombstones returned true for keyspace {}",
+                         SafeArg.of("kesypace", cfStore.keyspace.getName()));
             return Collections.<SSTableReader>emptySet();
         }
 

--- a/src/java/org/apache/cassandra/db/compaction/CompactionController.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionController.java
@@ -19,14 +19,12 @@ package org.apache.cassandra.db.compaction;
 
 import java.util.*;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.UnsafeArg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/java/org/apache/cassandra/db/compaction/CompactionController.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionController.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.db.compaction;
 
 import java.util.*;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 
@@ -54,7 +55,7 @@ public class CompactionController implements AutoCloseable
 
     public final ColumnFamilyStore cfs;
     // note that overlapIterator and overlappingSSTables will be null if NEVER_PURGE_TOMBSTONES is set - this is a
-    // good thing so that noone starts using them and thinks that if overlappingSSTables is empty, there
+    // good thing so that no one starts using them and thinks that if overlappingSSTables is empty, there
     // is no overlap.
     private Refs<SSTableReader> overlappingSSTables;
     private OverlapIterator<RowPosition, SSTableReader> overlapIterator;
@@ -281,7 +282,8 @@ public class CompactionController implements AutoCloseable
     /**
      * @param cfs
      * @return true if this node may be streaming data for this keyspace, or if cassandra.never_purge_tombstones is set
-     * If we are streaming, tombstones should not be purged so that we don't pre-maturely purge those that exceed gc_grace_seconds.
+     * If the node is streaming, tombstones should not be purged. If we pre-maturely purge a tombstone that was written
+     * at time T+1, and the node started streaming at time T, we may end up with resurrected keys.
      * <p>
      * Note that this node may receive data without streaming, e.g. during a repair.
      */

--- a/src/java/org/apache/cassandra/service/ActiveRepairService.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairService.java
@@ -644,14 +644,7 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
 
         synchronized boolean isRepairing(UUID cfId)
         {
-            for (ColumnFamilyStore cfs : columnFamilyStores.values())
-            {
-                if (cfs.metadata.cfId.equals(cfId))
-                {
-                    return true;
-                }
-            }
-            return false;
+            return columnFamilyStores.containsKey(cfId);
         }
 
         public synchronized void maybeSnapshot(UUID cfId, UUID parentSessionId)

--- a/src/java/org/apache/cassandra/service/ActiveRepairService.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairService.java
@@ -504,9 +504,7 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
         for (ParentRepairSession session : parentRepairSessions.values())
         {
             if (session.isRepairing(cfId))
-            {
                 return true;
-            }
         }
         return false;
     }

--- a/src/java/org/apache/cassandra/service/ActiveRepairService.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairService.java
@@ -499,6 +499,18 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
         }
     }
 
+    public boolean isRepairing(UUID cfId)
+    {
+        for (ParentRepairSession session : parentRepairSessions.values())
+        {
+            if (session.isRepairing(cfId))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * We keep a ParentRepairSession around for the duration of the entire repair, for example, on a 256 token vnode rf=3 cluster
      * we would have 768 RepairSession but only one ParentRepairSession. We use the PRS to avoid anticompacting the sstables
@@ -628,6 +640,18 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
                 if (snapshotGenerations.contains(sstable.descriptor.generation))
                     activeSSTables.add(sstable);
             return activeSSTables;
+        }
+
+        synchronized boolean isRepairing(UUID cfId)
+        {
+            for (ColumnFamilyStore cfs : columnFamilyStores.values())
+            {
+                if (cfs.metadata.cfId.equals(cfId))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public synchronized void maybeSnapshot(UUID cfId, UUID parentSessionId)

--- a/src/java/org/apache/cassandra/service/ActiveRepairService.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairService.java
@@ -17,7 +17,6 @@
  */
 package org.apache.cassandra.service;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -38,7 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.db.ColumnFamily;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.compaction.CompactionManager;
@@ -54,7 +52,6 @@ import org.apache.cassandra.gms.IFailureDetector;
 import org.apache.cassandra.gms.IEndpointStateChangeSubscriber;
 import org.apache.cassandra.gms.IFailureDetectionEventListener;
 import org.apache.cassandra.gms.VersionedValue;
-import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.locator.TokenMetadata;
 import org.apache.cassandra.net.IAsyncCallbackWithFailure;

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
@@ -19,8 +19,11 @@
 package org.apache.cassandra.db.compaction;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Sets;
@@ -38,6 +41,7 @@ import org.apache.cassandra.db.composites.CellName;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.locator.SimpleStrategy;
+import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
@@ -53,6 +57,7 @@ public class CompactionControllerTest extends SchemaLoader
     private static final String KEYSPACE = "CompactionControllerTest";
     private static final String CF1 = "Standard1";
     private static final String CF2 = "Standard2";
+    private static final String CF3 = "Standard3";
 
     @BeforeClass
     public static void defineSchema() throws ConfigurationException
@@ -62,7 +67,8 @@ public class CompactionControllerTest extends SchemaLoader
                                     SimpleStrategy.class,
                                     KSMetaData.optsWithRF(1),
                                     SchemaLoader.standardCFMD(KEYSPACE, CF1),
-                                    SchemaLoader.standardCFMD(KEYSPACE, CF2));
+                                    SchemaLoader.standardCFMD(KEYSPACE, CF2),
+                                    SchemaLoader.standardCFMD(KEYSPACE, CF3));
     }
 
     @Test
@@ -209,6 +215,44 @@ public class CompactionControllerTest extends SchemaLoader
         } finally {
             StorageService.instance.unsafeSetRebuilding(false);
         }
+    }
+
+
+    @Test
+    public void testTombstonesNotPurgedWhenRepairing()
+    {
+        Keyspace keyspace = Keyspace.open(KEYSPACE);
+        ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF3);
+        cfs.truncateBlocking();
+
+        ByteBuffer rowKey = ByteBufferUtil.bytes("key");
+
+        long timestamp1 = FBUtilities.timestampMicros();
+        long timestamp2 = timestamp1 - 5;
+
+        // create sstable with tombstone that should be expired in no older timestamps
+        applyDeleteMutation(CF3, rowKey, timestamp2);
+        cfs.forceBlockingFlush();
+
+        // first sstable with tombstone is compacting
+        Set<SSTableReader> compacting = Sets.newHashSet(cfs.getSSTables());
+
+        applyMutation(CF3, rowKey, timestamp1);
+        cfs.forceBlockingFlush();
+
+        // second sstable is overlapping
+        Set<SSTableReader> overlapping = Sets.difference(Sets.newHashSet(cfs.getSSTables()), compacting);
+
+        // the first sstable should be expired because the overlapping sstable is newer and the gc period is later
+        int gcBefore = (int) (System.currentTimeMillis() / 1000) + 5;
+
+        UUID repairUuid = UUID.randomUUID();
+        ActiveRepairService.instance.registerParentRepairSession(
+            repairUuid, FBUtilities.getLocalAddress(), Collections.singletonList(cfs), Collections.emptySet(), false, false);
+
+        assertEquals(CompactionController.getFullyExpiredSSTables(cfs, compacting, overlapping, gcBefore), Collections.emptySet());
+        ActiveRepairService.instance.removeParentRepairSession(repairUuid);
+        assertEquals(CompactionController.getFullyExpiredSSTables(cfs, compacting, overlapping, gcBefore), compacting);
     }
 
     private void applyMutation(String cf, ByteBuffer rowKey, long timestamp)

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
@@ -19,9 +19,7 @@
 package org.apache.cassandra.db.compaction;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 


### PR DESCRIPTION
Derived from: https://github.com/palantir/cassandra/pull/634

**Corruption case**

- `keyspace1/cf1` is repairing and a neighboring node starts streaming the list of file snapshotted at time T to this node. Those sstables contain `key1` with `col1:value1`. 
- At T+1 a tombstone is written for `col1:val1`, deleting the column. 
- At T+1+gc_grace, the sstable on the node containing `col1:value1` + the tombstone is compacted, and the two cells (value + tombstone) are purged. 
- At T+2+gc_grace, the neighboring node finally streams the file containing `col1:value1`. The data is then resurrected.

**Fix and justification**

The `RepairRunnable` class creates a `ParentRepairSession` which gets tracked by the `ActiveRepairService`. This happens both on the coordinator's end: [code ref](https://github.com/palantir/cassandra/blob/1.213.0/src/java/org/apache/cassandra/service/ActiveRepairService.java#L282) and neighboring node's: [code ref ](https://github.com/palantir/cassandra/blob/1.213.0/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java#L91)
Those sessions get untracked after the repair sessions (and therefore the streams) finish, successfully or not: https://github.com/palantir/cassandra/pull/634#discussion_r1988430643

If a compaction gets triggered before the repair session starts and continues while the repair session is happening, the LifecycleTransaction associated with the transaction should not consider the tombstone in the example presented above

**Perf**

- Cassandra 2.2 does not automatically run full column family repairs. They have to be user triggered (which we usually only in disaster recovery circumstances). Because of this the `parentRepairSessions` map should be mostly empty.
- The purgeTombstone repair exception is targeting a single cf at a time. Considering we also already run bootstraps without purging tombstones, this is not expected to significantly affect the overall repair perf in disaster recovery scenarios