### PR TITLE
Use `assertWithError` instead of `assert` for LRRS code paths

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamily.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamily.java
@@ -136,22 +136,22 @@ public abstract class ColumnFamily implements Iterable<Cell>, IRowCacheEntry
 
     public void setPageToken(PageToken pageToken)
     {
-        Throwables.assertWithException(pageToken != null);
+        Throwables.assertWithError(pageToken != null);
 
         this.pageToken = pageToken;
     }
 
     public void setPageToken(Cell cell)
     {
-        Throwables.assertWithException(cell != null);
-        Throwables.assertWithException(pageToken == null);
+        Throwables.assertWithError(cell != null);
+        Throwables.assertWithError(pageToken == null);
 
         pageToken = PageToken.createPageToken(cell);
     }
 
     public void setPageTokenEndOfRow()
     {
-        Throwables.assertWithException(pageToken == null);
+        Throwables.assertWithError(pageToken == null);
 
         pageToken = PageToken.createPageTokenReachedEnd();
     }

--- a/src/java/org/apache/cassandra/db/ColumnFamily.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamily.java
@@ -136,22 +136,22 @@ public abstract class ColumnFamily implements Iterable<Cell>, IRowCacheEntry
 
     public void setPageToken(PageToken pageToken)
     {
-        assert pageToken != null;
+        Throwables.assertWithException(pageToken != null);
 
         this.pageToken = pageToken;
     }
 
     public void setPageToken(Cell cell)
     {
-        assert cell != null;
-        assert pageToken == null;
+        Throwables.assertWithException(cell != null);
+        Throwables.assertWithException(pageToken == null);
 
         pageToken = PageToken.createPageToken(cell);
     }
 
     public void setPageTokenEndOfRow()
     {
-        assert pageToken == null;
+        Throwables.assertWithException(pageToken == null);
 
         pageToken = PageToken.createPageTokenReachedEnd();
     }

--- a/src/java/org/apache/cassandra/db/ReadResponse.java
+++ b/src/java/org/apache/cassandra/db/ReadResponse.java
@@ -28,6 +28,7 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.Throwables;
 
 /*
  * The read response message is sent by the server when reading data
@@ -46,7 +47,7 @@ public class ReadResponse
     public ReadResponse(ByteBuffer dataDigest, PageTokenDigest pageTokenDigest)
     {
         this(null, dataDigest, pageTokenDigest);
-        assert dataDigest != null;
+        Throwables.assertWithException(dataDigest != null);
     }
 
     public ReadResponse(Row row)
@@ -82,12 +83,12 @@ public class ReadResponse
         Pair<ByteBuffer, PageTokenDigest> newDigest = Pair.create(dataDigest, pageTokenDigest);
         if (!digestUpdater.compareAndSet(this, curr, newDigest))
         {
-            assert newDigest.equals(this.digest) :
+            Throwables.assertWithException(newDigest.equals(this.digest),
                     String.format("Digest mismatch : data(%s), pageToken(%s) vs data(%s), pageTokenDigest(%s)",
                             Arrays.toString(dataDigest.array()),
                             pageTokenDigest,
                             Arrays.toString(this.digest.left.array()),
-                            this.digest.right);
+                            this.digest.right));
         }
     }
 

--- a/src/java/org/apache/cassandra/db/ReadResponse.java
+++ b/src/java/org/apache/cassandra/db/ReadResponse.java
@@ -47,7 +47,7 @@ public class ReadResponse
     public ReadResponse(ByteBuffer dataDigest, PageTokenDigest pageTokenDigest)
     {
         this(null, dataDigest, pageTokenDigest);
-        Throwables.assertWithException(dataDigest != null);
+        Throwables.assertWithError(dataDigest != null);
     }
 
     public ReadResponse(Row row)
@@ -83,7 +83,7 @@ public class ReadResponse
         Pair<ByteBuffer, PageTokenDigest> newDigest = Pair.create(dataDigest, pageTokenDigest);
         if (!digestUpdater.compareAndSet(this, curr, newDigest))
         {
-            Throwables.assertWithException(newDigest.equals(this.digest),
+            Throwables.assertWithError(newDigest.equals(this.digest),
                     String.format("Digest mismatch : data(%s), pageToken(%s) vs data(%s), pageTokenDigest(%s)",
                             Arrays.toString(dataDigest.array()),
                             pageTokenDigest,

--- a/src/java/org/apache/cassandra/db/filter/PageToken.java
+++ b/src/java/org/apache/cassandra/db/filter/PageToken.java
@@ -87,7 +87,7 @@ public class PageToken
         @Override
         public void serialize(PageToken pagetoken, DataOutputPlus out, int version) throws IOException
         {
-            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
+            Throwables.assertWithError(version >= MessagingService.VERSION_22_PLTR);
 
             out.writeBoolean(pagetoken.reachedEnd);
             if (!pagetoken.reachedEnd)
@@ -99,7 +99,7 @@ public class PageToken
         @Override
         public PageToken deserialize(DataInput in, int version) throws IOException
         {
-            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
+            Throwables.assertWithError(version >= MessagingService.VERSION_22_PLTR);
 
             return deserialize(in, ColumnSerializer.Flag.LOCAL, version);
         }
@@ -117,14 +117,14 @@ public class PageToken
         @Override
         public long serializedSize(PageToken pageToken, int version)
         {
-            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
+            Throwables.assertWithError(version >= MessagingService.VERSION_22_PLTR);
 
             return serializedSize(pageToken, TypeSizes.NATIVE, version);
         }
 
         public long serializedSize(PageToken pagetoken, TypeSizes typeSizes, int version)
         {
-            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
+            Throwables.assertWithError(version >= MessagingService.VERSION_22_PLTR);
 
             long size = typeSizes.sizeof(pagetoken.reachedEnd);
             if (!pagetoken.reachedEnd)

--- a/src/java/org/apache/cassandra/db/filter/PageToken.java
+++ b/src/java/org/apache/cassandra/db/filter/PageToken.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Throwables;
 
 public class PageToken
 {
@@ -86,7 +87,7 @@ public class PageToken
         @Override
         public void serialize(PageToken pagetoken, DataOutputPlus out, int version) throws IOException
         {
-            assert version >= MessagingService.VERSION_22_PLTR;
+            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
 
             out.writeBoolean(pagetoken.reachedEnd);
             if (!pagetoken.reachedEnd)
@@ -98,7 +99,7 @@ public class PageToken
         @Override
         public PageToken deserialize(DataInput in, int version) throws IOException
         {
-            assert version >= MessagingService.VERSION_22_PLTR;
+            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
 
             return deserialize(in, ColumnSerializer.Flag.LOCAL, version);
         }
@@ -116,14 +117,14 @@ public class PageToken
         @Override
         public long serializedSize(PageToken pageToken, int version)
         {
-            assert version >= MessagingService.VERSION_22_PLTR;
+            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
 
             return serializedSize(pageToken, TypeSizes.NATIVE, version);
         }
 
         public long serializedSize(PageToken pagetoken, TypeSizes typeSizes, int version)
         {
-            assert version >= MessagingService.VERSION_22_PLTR;
+            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
 
             long size = typeSizes.sizeof(pagetoken.reachedEnd);
             if (!pagetoken.reachedEnd)

--- a/src/java/org/apache/cassandra/db/filter/PageTokenDigest.java
+++ b/src/java/org/apache/cassandra/db/filter/PageTokenDigest.java
@@ -22,7 +22,6 @@ import org.apache.cassandra.db.*;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.net.MessagingService;
-import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Throwables;
 
@@ -98,14 +97,14 @@ public class PageTokenDigest
         @Override
         public void serialize(PageTokenDigest pageTokenDigest, DataOutputPlus out, int version) throws IOException
         {
-            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
+            Throwables.assertWithError(version >= MessagingService.VERSION_22_PLTR);
 
             boolean hasReachedEnd = pageTokenDigest.isReachedEnd();
             out.writeBoolean(hasReachedEnd);
             if (!hasReachedEnd)
             {
                 int digestSize = pageTokenDigest.digest().remaining();
-                Throwables.assertWithException(digestSize > 0);
+                Throwables.assertWithError(digestSize > 0);
                 out.writeInt(digestSize);
                 out.write(pageTokenDigest.digest());
             }
@@ -114,13 +113,13 @@ public class PageTokenDigest
         @Override
         public PageTokenDigest deserialize(DataInput in, int version) throws IOException
         {
-            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
+            Throwables.assertWithError(version >= MessagingService.VERSION_22_PLTR);
 
             boolean hasReachedEnd = in.readBoolean();
             if (!hasReachedEnd)
             {
                 int digestSize = in.readInt();
-                Throwables.assertWithException(digestSize > 0);
+                Throwables.assertWithError(digestSize > 0);
                 byte[] buffer = new byte[digestSize];
                 in.readFully(buffer, 0, digestSize);
                 return PageTokenDigest.createPageTokenDigest(ByteBuffer.wrap(buffer));
@@ -131,7 +130,7 @@ public class PageTokenDigest
         @Override
         public long serializedSize(PageTokenDigest pageTokenDigest, int version)
         {
-            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
+            Throwables.assertWithError(version >= MessagingService.VERSION_22_PLTR);
             
             TypeSizes typeSizes = TypeSizes.NATIVE;
 

--- a/src/java/org/apache/cassandra/db/filter/PageTokenDigest.java
+++ b/src/java/org/apache/cassandra/db/filter/PageTokenDigest.java
@@ -24,6 +24,7 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.Throwables;
 
 import java.io.DataInput;
 import java.io.IOException;
@@ -97,14 +98,14 @@ public class PageTokenDigest
         @Override
         public void serialize(PageTokenDigest pageTokenDigest, DataOutputPlus out, int version) throws IOException
         {
-            assert version >= MessagingService.VERSION_22_PLTR;
+            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
 
             boolean hasReachedEnd = pageTokenDigest.isReachedEnd();
             out.writeBoolean(hasReachedEnd);
             if (!hasReachedEnd)
             {
                 int digestSize = pageTokenDigest.digest().remaining();
-                assert digestSize > 0;
+                Throwables.assertWithException(digestSize > 0);
                 out.writeInt(digestSize);
                 out.write(pageTokenDigest.digest());
             }
@@ -113,13 +114,13 @@ public class PageTokenDigest
         @Override
         public PageTokenDigest deserialize(DataInput in, int version) throws IOException
         {
-            assert version >= MessagingService.VERSION_22_PLTR;
+            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
 
             boolean hasReachedEnd = in.readBoolean();
             if (!hasReachedEnd)
             {
                 int digestSize = in.readInt();
-                assert digestSize > 0;
+                Throwables.assertWithException(digestSize > 0);
                 byte[] buffer = new byte[digestSize];
                 in.readFully(buffer, 0, digestSize);
                 return PageTokenDigest.createPageTokenDigest(ByteBuffer.wrap(buffer));
@@ -130,7 +131,7 @@ public class PageTokenDigest
         @Override
         public long serializedSize(PageTokenDigest pageTokenDigest, int version)
         {
-            assert version >= MessagingService.VERSION_22_PLTR;
+            Throwables.assertWithException(version >= MessagingService.VERSION_22_PLTR);
             
             TypeSizes typeSizes = TypeSizes.NATIVE;
 

--- a/src/java/org/apache/cassandra/db/filter/SliceQueryFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/SliceQueryFilter.java
@@ -337,7 +337,7 @@ public class SliceQueryFilter implements IDiskAtomFilter
         while (!columnCounter.hasSeenAtLeast(count) && reducedCells.hasNext())
         {
             Cell cell = reducedCells.next();
-            Throwables.assertWithException(cell != null);
+            Throwables.assertWithError(cell != null);
 
             if (firstCell == null)
             {
@@ -346,9 +346,9 @@ public class SliceQueryFilter implements IDiskAtomFilter
 
             if (usePageToken && hitRangeScanThreshold(reducedCells.deadAndLiveCells()))
             {
-                Throwables.assertWithException(cell.name() != firstCell,
+                Throwables.assertWithError(cell.name() != firstCell,
                         "Hit the range scan threshold on the first cell. Either the configured threshold is too low or there are unexpected duplicate cells.");
-                Throwables.assertWithException(lastSeenCellInContainer == null || cell.name() != lastSeenCellInContainer,
+                Throwables.assertWithError(lastSeenCellInContainer == null || cell.name() != lastSeenCellInContainer,
                         "Hit the range scan threshold on a cell that is included in the results set. This should never happen.");
 
                 container.setPageToken(cell);

--- a/src/java/org/apache/cassandra/db/filter/SliceQueryFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/SliceQueryFilter.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.tracing.Tracing;
+import org.apache.cassandra.utils.Throwables;
 
 public class SliceQueryFilter implements IDiskAtomFilter
 {
@@ -336,7 +337,7 @@ public class SliceQueryFilter implements IDiskAtomFilter
         while (!columnCounter.hasSeenAtLeast(count) && reducedCells.hasNext())
         {
             Cell cell = reducedCells.next();
-            assert cell != null;
+            Throwables.assertWithException(cell != null);
 
             if (firstCell == null)
             {
@@ -345,10 +346,10 @@ public class SliceQueryFilter implements IDiskAtomFilter
 
             if (usePageToken && hitRangeScanThreshold(reducedCells.deadAndLiveCells()))
             {
-                assert cell.name() != firstCell :
-                        "Hit the range scan threshold on the first cell. Either the configured threshold is too low or there are unexpected duplicate cells.";
-                assert lastSeenCellInContainer == null || cell.name() != lastSeenCellInContainer :
-                        "Hit the range scan threshold on a cell that is included in the results set. This should never happen.";
+                Throwables.assertWithException(cell.name() != firstCell,
+                        "Hit the range scan threshold on the first cell. Either the configured threshold is too low or there are unexpected duplicate cells.");
+                Throwables.assertWithException(lastSeenCellInContainer == null || cell.name() != lastSeenCellInContainer,
+                        "Hit the range scan threshold on a cell that is included in the results set. This should never happen.");
 
                 container.setPageToken(cell);
                 break;

--- a/src/java/org/apache/cassandra/service/RowDataResolver.java
+++ b/src/java/org/apache/cassandra/service/RowDataResolver.java
@@ -76,7 +76,7 @@ public class RowDataResolver extends AbstractRowResolver
                 ReadResponse response = message.payload;
                 ColumnFamily cf = response.row().cf;
                 assert !response.isDigestQuery() : "Received digest response to repair read from " + message.from;
-                Throwables.assertWithException(!filter.usePageToken() || cf != null);
+                Throwables.assertWithError(!filter.usePageToken() || cf != null);
                 versions.add(cf);
                 endpoints.add(message.from);
 

--- a/src/java/org/apache/cassandra/service/RowDataResolver.java
+++ b/src/java/org/apache/cassandra/service/RowDataResolver.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.net.*;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Throwables;
 
 public class RowDataResolver extends AbstractRowResolver
 {
@@ -75,7 +76,7 @@ public class RowDataResolver extends AbstractRowResolver
                 ReadResponse response = message.payload;
                 ColumnFamily cf = response.row().cf;
                 assert !response.isDigestQuery() : "Received digest response to repair read from " + message.from;
-                assert !filter.usePageToken() || cf != null;
+                Throwables.assertWithException(!filter.usePageToken() || cf != null);
                 versions.add(cf);
                 endpoints.add(message.from);
 

--- a/src/java/org/apache/cassandra/service/RowDigestResolver.java
+++ b/src/java/org/apache/cassandra/service/RowDigestResolver.java
@@ -112,7 +112,7 @@ public class RowDigestResolver extends AbstractRowResolver
             }
             else if (!digest.equals(newDigest) || !Objects.equals(pageTokenDigest, newPageTokenDigest))
             {
-                logger.error("Mismatch for key {} ({},{} vs {},{})",
+                logger.debug("Mismatch for key {} ({},{} vs {},{})",
                              UnsafeArg.of("key", key),
                              SafeArg.of("digest1", ByteBufferUtil.bytesToHex(digest)),
                              SafeArg.of("pageTokenDigest1", pageTokenDigest),

--- a/src/java/org/apache/cassandra/thrift/CassandraServer.java
+++ b/src/java/org/apache/cassandra/thrift/CassandraServer.java
@@ -284,7 +284,7 @@ public class CassandraServer implements Cassandra.Iface
 
     private PageToken thriftifyPageToken(org.apache.cassandra.db.filter.PageToken pageToken)
     {
-        Throwables.assertWithException(pageToken != null, "Page token should never be null when using paging");
+        Throwables.assertWithError(pageToken != null, "Page token should never be null when using paging");
 
         if (pageToken.isReachedEnd())
         {
@@ -402,14 +402,14 @@ public class CassandraServer implements Cassandra.Iface
 
     private PageResult thriftifyColumnFamilyPaging(ColumnFamily cf, long now)
     {
-        Throwables.assertWithException(cf != null, "Resolved column family should never be null when using paging, since it includes a page token");
+        Throwables.assertWithError(cf != null, "Resolved column family should never be null when using paging, since it includes a page token");
 
         if (!cf.hasColumns())
         {
             return new PageResult().setColumns(EMPTY_COLUMNS).setPage_token(thriftifyPageToken(cf.pageToken()));
         }
 
-        Throwables.assertWithException(!cf.metadata().isSuper());
+        Throwables.assertWithError(!cf.metadata().isSuper());
         return thriftifyColumnsPaging(cf.getSortedColumns(), now, cf.pageToken());
     }
 

--- a/src/java/org/apache/cassandra/thrift/CassandraServer.java
+++ b/src/java/org/apache/cassandra/thrift/CassandraServer.java
@@ -67,6 +67,7 @@ import org.apache.cassandra.tracing.PalantirTracing;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.Throwables;
 import org.apache.cassandra.utils.UUIDGen;
 import org.apache.thrift.TException;
 
@@ -283,7 +284,7 @@ public class CassandraServer implements Cassandra.Iface
 
     private PageToken thriftifyPageToken(org.apache.cassandra.db.filter.PageToken pageToken)
     {
-        assert pageToken != null : "Page token should never be null when using paging";
+        Throwables.assertWithException(pageToken != null, "Page token should never be null when using paging");
 
         if (pageToken.isReachedEnd())
         {
@@ -401,14 +402,14 @@ public class CassandraServer implements Cassandra.Iface
 
     private PageResult thriftifyColumnFamilyPaging(ColumnFamily cf, long now)
     {
-        assert cf != null : "Resolved column family should never be null when using paging, since it includes a page token";
+        Throwables.assertWithException(cf != null, "Resolved column family should never be null when using paging, since it includes a page token");
 
         if (!cf.hasColumns())
         {
             return new PageResult().setColumns(EMPTY_COLUMNS).setPage_token(thriftifyPageToken(cf.pageToken()));
         }
 
-        assert !cf.metadata().isSuper();
+        Throwables.assertWithException(!cf.metadata().isSuper());
         return thriftifyColumnsPaging(cf.getSortedColumns(), now, cf.pageToken());
     }
 

--- a/src/java/org/apache/cassandra/thrift/ThriftValidation.java
+++ b/src/java/org/apache/cassandra/thrift/ThriftValidation.java
@@ -655,10 +655,10 @@ public class ThriftValidation
         Keyspace keyspace = Keyspace.open(keyspaceName);
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(columnFamilyName);
 
-        Throwables.assertWithException(!cfs.isRowCacheEnabled(), "Resumable range scans require the row cache to be disabled");
-        Throwables.assertWithException(!cfs.metadata.isSuper(), "Resumable range scans do not support super columns");
-        Throwables.assertWithException(!cfs.metadata.hasStaticColumns(), "Resumable range scans do not support static columns");
-        Throwables.assertWithException(cfs.indexManager == null || !cfs.indexManager.hasIndexes(), "Resumable range scans do not support secondary indexes");
+        Throwables.assertWithError(!cfs.isRowCacheEnabled(), "Resumable range scans require the row cache to be disabled");
+        Throwables.assertWithError(!cfs.metadata.isSuper(), "Resumable range scans do not support super columns");
+        Throwables.assertWithError(!cfs.metadata.hasStaticColumns(), "Resumable range scans do not support static columns");
+        Throwables.assertWithError(cfs.indexManager == null || !cfs.indexManager.hasIndexes(), "Resumable range scans do not support secondary indexes");
     }
 
     public static IDiskAtomFilter asIFilter(SlicePredicate sp, CFMetaData metadata, ByteBuffer superColumn)

--- a/src/java/org/apache/cassandra/thrift/ThriftValidation.java
+++ b/src/java/org/apache/cassandra/thrift/ThriftValidation.java
@@ -42,6 +42,7 @@ import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Throwables;
 
 /**
  * This has a lot of building blocks for CassandraServer to call to make sure it has valid input
@@ -654,10 +655,10 @@ public class ThriftValidation
         Keyspace keyspace = Keyspace.open(keyspaceName);
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(columnFamilyName);
 
-        assert !cfs.isRowCacheEnabled() : "Resumable range scans require the row cache to be disabled";
-        assert !cfs.metadata.isSuper() : "Resumable range scans do not support super columns";
-        assert !cfs.metadata.hasStaticColumns() : "Resumable range scans do not support static columns";
-        assert cfs.indexManager == null || !cfs.indexManager.hasIndexes() : "Resumable range scans do not support secondary indexes";
+        Throwables.assertWithException(!cfs.isRowCacheEnabled(), "Resumable range scans require the row cache to be disabled");
+        Throwables.assertWithException(!cfs.metadata.isSuper(), "Resumable range scans do not support super columns");
+        Throwables.assertWithException(!cfs.metadata.hasStaticColumns(), "Resumable range scans do not support static columns");
+        Throwables.assertWithException(cfs.indexManager == null || !cfs.indexManager.hasIndexes(), "Resumable range scans do not support secondary indexes");
     }
 
     public static IDiskAtomFilter asIFilter(SlicePredicate sp, CFMetaData metadata, ByteBuffer superColumn)

--- a/src/java/org/apache/cassandra/utils/Throwables.java
+++ b/src/java/org/apache/cassandra/utils/Throwables.java
@@ -91,7 +91,7 @@ public class Throwables
         return Optional.absent();
     }
 
-    public static void assertWithException(boolean condition)
+    public static void assertWithError(boolean condition)
     {
         if (!condition)
         {
@@ -99,7 +99,7 @@ public class Throwables
         }
     }
 
-    public static void assertWithException(boolean condition, String message)
+    public static void assertWithError(boolean condition, String message)
     {
         if (!condition)
         {

--- a/src/java/org/apache/cassandra/utils/Throwables.java
+++ b/src/java/org/apache/cassandra/utils/Throwables.java
@@ -90,4 +90,20 @@ public class Throwables
         }
         return Optional.absent();
     }
+
+    public static void assertWithException(boolean condition)
+    {
+        if (!condition)
+        {
+            throw new AssertionError();
+        }
+    }
+
+    public static void assertWithException(boolean condition, String message)
+    {
+        if (!condition)
+        {
+            throw new AssertionError(message);
+        }
+    }
 }

--- a/src/java/org/apache/cassandra/utils/Throwables.java
+++ b/src/java/org/apache/cassandra/utils/Throwables.java
@@ -21,9 +21,15 @@ package org.apache.cassandra.utils;
 import java.io.IOException;
 
 import com.google.common.base.Optional;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
+import org.apache.cassandra.FilterExperiment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Throwables
 {
+    private static final Logger log = LoggerFactory.getLogger(Throwables.class);
 
     public static Throwable merge(Throwable existingFail, Throwable newFail)
     {
@@ -91,18 +97,23 @@ public class Throwables
         return Optional.absent();
     }
 
-    public static void assertWithError(boolean condition)
+    public static void assertWithError(boolean condition, Arg<?>... args)
     {
         if (!condition)
         {
+            log.error("Assertion failed", (Object[]) args);
             throw new AssertionError();
         }
     }
 
-    public static void assertWithError(boolean condition, String message)
+    public static void assertWithError(boolean condition, String message, Arg<?>... args)
     {
         if (!condition)
         {
+            Arg<?>[] newArgs = new Arg[args.length + 1];
+            System.arraycopy(args, 0, newArgs, 0, args.length);
+            newArgs[args.length] = SafeArg.of("message", message);
+            log.error("Assertion failed", (Object[]) newArgs);
             throw new AssertionError(message);
         }
     }


### PR DESCRIPTION
Depending on the environment, cassandra may be run with assertions disabled in consideration of the perf hit to have them enabled. The assertions added for resumable range scans are likely to be desirable in all cases, so in this PR we throw an exception instead.