### PR TITLE
Feature: Instrument iterator equality for filter scans

### DIFF
--- a/src/java/org/apache/cassandra/FilterExperiment.java
+++ b/src/java/org/apache/cassandra/FilterExperiment.java
@@ -18,18 +18,13 @@
 
 package org.apache.cassandra;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
@@ -143,7 +138,7 @@ public enum FilterExperiment
             boolean areEqual = !iterator(legacy).hasNext();
             return areEqual ? ComparisonResult.EQUAL : ComparisonResult.MODERN_WAS_NULL;
         } else {
-            return compareByIterator(iterator(legacy), iterator(modern));
+            return compareByIterator(iterator(legacy), iterator(modern), legacy.metadata());
         }
     }
 
@@ -162,9 +157,9 @@ public enum FilterExperiment
         return ColumnFamily.digest(legacy).equals(ColumnFamily.digest(modern));
     }
 
-    static ComparisonResult compareByIterator(Iterator<Cell> legacyIterator, Iterator<Cell> modernIterator)
+    static ComparisonResult compareByIterator(Iterator<Cell> legacyIterator, Iterator<Cell> modernIterator, CFMetaData metadata)
     {
-        List<String> differences = new ArrayList<>();
+        int differences = 0;
         int index = -1;
         while (legacyIterator.hasNext() || modernIterator.hasNext())
         {
@@ -178,39 +173,42 @@ public enum FilterExperiment
                 {
                     continue;
                 }
-                differences.add(notEqual(index, legacy, modern));
+                log.warn("Items were not equal when comparing by iterator. Keyspace: {}, ColumnFamily: {}, index: {}, legacyClassName: {}, modernClassName: {}, timestampMatches: {}, nameMatches: {}, valueMatches: {}, legacySerializationFlags: {}, modernSerializationFlags: {}",
+                         SafeArg.of("keyspace", metadata.ksName),
+                         SafeArg.of("columnFamily", metadata.cfName),
+                         SafeArg.of("index", index),
+                         SafeArg.of("legacyClassName", legacy.getClass().getName()),
+                         SafeArg.of("modernClassName", modern.getClass().getName()),
+                         // These are what are compared in the .equals() implementation for AbstractCell.
+                         // TODO(lkjaerozhang): Follow up with information for the other types of cells.
+                         SafeArg.of("timestampMatches", legacy.timestamp() == modern.timestamp()),
+                         SafeArg.of("nameMatches", legacy.name() == modern.name()),
+                         SafeArg.of("valueMatches", legacy.value() == modern.value()),
+                         SafeArg.of("legacySerializationFlags", legacy.serializationFlags()),
+                         SafeArg.of("modernSerializationFlags", modern.serializationFlags()));
+                differences++;
             }
             else
             {
-                differences.add(missingItem(index, legacy != null, modern != null));
+                log.warn("Mismatched number of items at index {} when comparing by iterator. Legacy: {}, Modern: {}, Keyspace: {}, ColumnFamily: {}",
+                         SafeArg.of("index", index),
+                         SafeArg.of("hasLegacy", legacy != null),
+                         SafeArg.of("hasModern", modern != null),
+                         SafeArg.of("keyspace", metadata.ksName),
+                         SafeArg.of("columnFamily", metadata.cfName));
+                differences++;
             }
         }
 
-        if (differences.isEmpty()) {
+        if (differences == 0) {
             return ComparisonResult.EQUAL;
         } else {
-            log.warn("Column families returned different results via iterator: {}", SafeArg.of("differences", differences));
+            log.warn("Column families returned different results via iterator: {}, Keyspace: {}, ColumnFamily: {}",
+                     SafeArg.of("differences", differences),
+                     SafeArg.of("keyspace", metadata.ksName),
+                     SafeArg.of("columnFamily", metadata.cfName));
             return ComparisonResult.NOT_EQUAL_BY_ITERATOR;
         }
-    }
-
-    private static String missingItem(int index, boolean hasLegacyCell, boolean hasModernCell) {
-        return String.format("[%s: MissingItem(hasLegacyCell=%s, hasModernCell=%s)]",
-                             index, hasLegacyCell, hasModernCell);
-    }
-
-    private static String notEqual(int index, Cell legacy, Cell modern) {
-        return String.format("[%s: NotEqual(legacyClassName=%s, modernClassName=%s, timestampMatches=%s, nameMatches=%s, valueMatches=%s, legacySerializationFlags=%s, modernSerializationFlags=%s)]",
-                             index,
-                             legacy.getClass().getName(),
-                             modern.getClass().getName(),
-                             // These are what are compared in the .equals() implementation for AbstractCell.
-                             // TODO(lkjaerozhang): Follow up with information for the other types of cells.
-                             legacy.timestamp() == modern.timestamp(),
-                             legacy.name() == modern.name(),
-                             legacy.value() == modern.value(),
-                             legacy.serializationFlags(),
-                             modern.serializationFlags());
     }
 
     private static SafeArg safeLoggableColumnFamilyMetadata(String argName, ColumnFamily columnFamily) {

--- a/src/java/org/apache/cassandra/FilterExperiment.java
+++ b/src/java/org/apache/cassandra/FilterExperiment.java
@@ -19,6 +19,8 @@
 package org.apache.cassandra;
 
 import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -26,6 +28,7 @@ import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
@@ -138,7 +141,7 @@ public enum FilterExperiment
             boolean areEqual = !iterator(legacy).hasNext();
             return areEqual ? ComparisonResult.EQUAL : ComparisonResult.MODERN_WAS_NULL;
         } else {
-            return Iterators.elementsEqual(iterator(legacy), iterator(modern)) ? ComparisonResult.EQUAL : ComparisonResult.NOT_EQUAL_BY_ITERATOR;
+            return compareByIterator(iterator(legacy), iterator(modern));
         }
     }
 
@@ -147,8 +150,65 @@ public enum FilterExperiment
                                 Predicates.not(columnFamily.inOrderDeletionTester()::isDeleted));
     }
 
+    private static Optional<Cell> getNext(Iterator<Cell> iterator)
+    {
+        return iterator.hasNext() ? Optional.ofNullable(iterator.next()) : Optional.empty();
+    }
+
     static boolean areTrulyEqual(ColumnFamily legacy, ColumnFamily modern) {
         return ColumnFamily.digest(legacy).equals(ColumnFamily.digest(modern));
+    }
+
+    static ComparisonResult compareByIterator(Iterator<Cell> legacyIterator, Iterator<Cell> modernIterator)
+    {
+        ImmutableList.Builder<String> differencesBuilder = ImmutableList.builder();
+        int index = -1;
+        while (legacyIterator.hasNext() || modernIterator.hasNext())
+        {
+            index++;
+            Optional<Cell> legacy = getNext(legacyIterator);
+            Optional<Cell> modern = getNext(modernIterator);
+
+            if (legacy.isPresent() && modern.isPresent())
+            {
+                if (legacy.get().equals(modern.get()))
+                {
+                    continue;
+                }
+                differencesBuilder.add(notEqual(index, legacy.get(), modern.get()));
+            }
+            else
+            {
+                differencesBuilder.add(missingItem(index, legacy.isPresent(), modern.isPresent()));
+            }
+        }
+        List<String> differences = differencesBuilder.build();
+
+        if (differences.isEmpty()) {
+            return ComparisonResult.EQUAL;
+        } else {
+            log.warn("Column families returned different results via iterator: {}", SafeArg.of("differences", differences));
+            return ComparisonResult.NOT_EQUAL_BY_ITERATOR;
+        }
+    }
+
+    private static String missingItem(int index, boolean hasLegacyCell, boolean hasModernCell) {
+        return String.format("[%s: MissingItem(hasLegacyCell=%s, hasModernCell=%s)]",
+                             index, hasLegacyCell, hasModernCell);
+    }
+
+    private static String notEqual(int index, Cell legacy, Cell modern) {
+        return String.format("[%s: NotEqual(legacyClassName=%s, modernClassName=%s, timestampMatches=%s, nameMatches=%s, valueMatches=%s, legacySerializationFlags=%s, modernSerializationFlags=%s)]",
+                             index,
+                             legacy.getClass().getName(),
+                             modern.getClass().getName(),
+                             // These are what are compared in the .equals() implementation for AbstractCell.
+                             // TODO(lkjaerozhang): Follow up with information for the other types of cells.
+                             legacy.timestamp() == modern.timestamp(),
+                             legacy.name() == modern.name(),
+                             legacy.value() == modern.value(),
+                             legacy.serializationFlags(),
+                             modern.serializationFlags());
     }
 
     private static SafeArg safeLoggableColumnFamilyMetadata(String argName, ColumnFamily columnFamily) {

--- a/src/java/org/apache/cassandra/FilterExperiment.java
+++ b/src/java/org/apache/cassandra/FilterExperiment.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -44,6 +45,7 @@ import org.apache.cassandra.db.ColumnFamily;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.DefaultNameFactory;
 import org.apache.cassandra.metrics.MetricNameFactory;
+import org.apache.thrift.annotation.Nullable;
 
 public enum FilterExperiment
 {
@@ -150,9 +152,10 @@ public enum FilterExperiment
                                 Predicates.not(columnFamily.inOrderDeletionTester()::isDeleted));
     }
 
-    private static Optional<Cell> getNext(Iterator<Cell> iterator)
+    @Nullable
+    private static Cell getNext(Iterator<Cell> iterator)
     {
-        return iterator.hasNext() ? Optional.ofNullable(iterator.next()) : Optional.empty();
+        return iterator.hasNext() ? iterator.next() : null;
     }
 
     static boolean areTrulyEqual(ColumnFamily legacy, ColumnFamily modern) {
@@ -161,28 +164,27 @@ public enum FilterExperiment
 
     static ComparisonResult compareByIterator(Iterator<Cell> legacyIterator, Iterator<Cell> modernIterator)
     {
-        ImmutableList.Builder<String> differencesBuilder = ImmutableList.builder();
+        List<String> differences = new ArrayList<>();
         int index = -1;
         while (legacyIterator.hasNext() || modernIterator.hasNext())
         {
             index++;
-            Optional<Cell> legacy = getNext(legacyIterator);
-            Optional<Cell> modern = getNext(modernIterator);
+            Cell legacy = getNext(legacyIterator);
+            Cell modern = getNext(modernIterator);
 
-            if (legacy.isPresent() && modern.isPresent())
+            if (legacy != null && modern != null)
             {
-                if (legacy.get().equals(modern.get()))
+                if (legacy.equals(modern))
                 {
                     continue;
                 }
-                differencesBuilder.add(notEqual(index, legacy.get(), modern.get()));
+                differences.add(notEqual(index, legacy, modern));
             }
             else
             {
-                differencesBuilder.add(missingItem(index, legacy.isPresent(), modern.isPresent()));
+                differences.add(missingItem(index, legacy != null, modern != null));
             }
         }
-        List<String> differences = differencesBuilder.build();
 
         if (differences.isEmpty()) {
             return ComparisonResult.EQUAL;

--- a/test/unit/org/apache/cassandra/FilterExperimentTest.java
+++ b/test/unit/org/apache/cassandra/FilterExperimentTest.java
@@ -51,6 +51,13 @@ public class FilterExperimentTest
     }
 
     @Test
+    public void testAreEqual_falseIfNotEqual() {
+        ColumnFamily left = cf(value('a'), value('d'));
+        ColumnFamily right = cf(value('a'), value('c'));
+        assertThat(FilterExperiment.areEqual(left, right).isEqual()).isFalse();
+    }
+
+    @Test
     public void testAreEqual_trueIfEqual_cellwise() {
         ColumnFamily left = cf(value('a'), value('d'));
         ColumnFamily right = cf(value('a'), value('b'), rangeDelete('b', 'c'), value('d'));


### PR DESCRIPTION
Most filter experiment failures seem to be by iterator. This most likely means that one of the returned cells was not `left.equals(right)` by way of however that `Cell` subclass (of which there are 15) implements equality.

I've added a new comparison method that collects and stores what is safe to log about any differences. This should work out of the box to explain most Cell types, but I will follow up with any other interesting parameters for the other types. 