### PR TITLE
Experiment with New Optimized Collation Method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.4.0'
+        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.19.0'
         classpath 'com.palantir.gradle.docker:gradle-docker:0.27.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.13.0'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.19.0'
+        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.4.0'
         classpath 'com.palantir.gradle.docker:gradle-docker:0.27.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.13.0'
     }

--- a/src/java/org/apache/cassandra/FilterExperiment.java
+++ b/src/java/org/apache/cassandra/FilterExperiment.java
@@ -102,7 +102,7 @@ public enum FilterExperiment
         ColumnFamily optimizedEmitCellsResult = results.get(USE_OPTIMIZED_EMIT_CELLS);
 
         compareAndLogResults(legacyResult, optimizedResult, USE_OPTIMIZED, function, fallback);
-        compareAndLogResults(legacyResult, optimizedEmitCellsResult, USE_OPTIMIZED, function, fallback);
+        compareAndLogResults(legacyResult, optimizedEmitCellsResult, USE_OPTIMIZED_EMIT_CELLS, function, fallback);
 
         return legacyResult;
     }

--- a/src/java/org/apache/cassandra/FilterExperiment.java
+++ b/src/java/org/apache/cassandra/FilterExperiment.java
@@ -18,16 +18,20 @@
 
 package org.apache.cassandra;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
-import org.apache.cassandra.utils.Pair;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/java/org/apache/cassandra/FilterExperiment.java
+++ b/src/java/org/apache/cassandra/FilterExperiment.java
@@ -44,7 +44,7 @@ import org.apache.thrift.annotation.Nullable;
 
 public enum FilterExperiment
 {
-    USE_LEGACY, USE_OPTIMIZED;
+    USE_LEGACY, USE_OPTIMIZED, USE_OPTIMIZED_EMIT_CELLS;
 
     private static final Logger log = LoggerFactory.getLogger(FilterExperiment.class);
     private static final MetricNameFactory names = new DefaultNameFactory("FilterExperiment");

--- a/src/java/org/apache/cassandra/FilterExperiment.java
+++ b/src/java/org/apache/cassandra/FilterExperiment.java
@@ -18,14 +18,16 @@
 
 package org.apache.cassandra;
 
-import java.util.Iterator;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
+import org.apache.cassandra.utils.Pair;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,12 +54,20 @@ public enum FilterExperiment
             CassandraMetricsRegistry.Metrics.timer(names.createMetricName("Legacy"));
     private static final Timer optimizedTimer =
             CassandraMetricsRegistry.Metrics.timer(names.createMetricName("Optimized"));
+    private static final Timer optimizedEmittingTimer =
+            CassandraMetricsRegistry.Metrics.timer(names.createMetricName("OptimizedEmitting"));
     private static final Counter successes =
             CassandraMetricsRegistry.Metrics.counter(names.createMetricName("Successes"));
     private static final Counter failures =
             CassandraMetricsRegistry.Metrics.counter(names.createMetricName("Failures"));
     private static final Counter indeterminate =
             CassandraMetricsRegistry.Metrics.counter(names.createMetricName("Indeterminate"));
+    private static final Counter successesForEmitting =
+            CassandraMetricsRegistry.Metrics.counter(names.createMetricName("SuccessesForEmitting"));
+    private static final Counter failuresForEmitting =
+            CassandraMetricsRegistry.Metrics.counter(names.createMetricName("FailuresForEmitting"));
+    private static final Counter indeterminateForEmitting =
+            CassandraMetricsRegistry.Metrics.counter(names.createMetricName("IndeterminateForEmitting"));
 
     public static ColumnFamily execute(
             Function<FilterExperiment, ColumnFamily> function,
@@ -65,42 +75,138 @@ public enum FilterExperiment
         if (!shouldRunExperiment()) {
             return function.apply(USE_LEGACY);
         }
-        ColumnFamily legacyResult = time(() -> function.apply(USE_LEGACY), legacyTimer);
-        try {
-            ColumnFamily optimizedResult = time(() -> function.apply(USE_OPTIMIZED), optimizedTimer);
-            ComparisonResult initialComparison = areEqual(legacyResult, optimizedResult);
-            if (initialComparison.isEqual()) {
-                successes.inc();
-            } else if (!areTrulyEqual(legacyResult, function.apply(USE_LEGACY))) {
-                // This case means that the data was modified between getting the legacy and optimized result. As a result, this experiment is indeterminate.
-                indeterminate.inc();
-            } else if ((legacyResult.metadata().getGcGraceSeconds() == 0
-                           && areEqual(fallback.apply(USE_LEGACY), fallback.apply(USE_OPTIMIZED)).isEqual())) {
-                indeterminate.inc();
-                // TODO(lkjaerozhang): Give a better log message when I actually understand what this means.
-                //  The indeterminate codepath seems to have never been hit so it's probably fine to defer for now as
-                //  long as we still have signal if we do hit it.
-                log.warn("Query result changed under immediate compaction but results from 60 seconds ago are identical, result is indeterminate; Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
-                         legacyResult, optimizedResult, safeLoggableColumnFamilyMetadata("legacyMetadata", legacyResult), safeLoggableColumnFamilyMetadata("optimizedMetadata", optimizedResult));
-            } else {
-                failures.inc();
-                log.warn("Comparison failure while experimenting; Legacy: {}, Optimized: {}, Comparison method: {}, Legacy metadata: {}, Optimized metadata: {}",
-                         legacyResult, optimizedResult, SafeArg.of("comparisonMethod", initialComparison.name()), safeLoggableColumnFamilyMetadata("legacyMetadata", legacyResult), safeLoggableColumnFamilyMetadata("optimizedMetadata", optimizedResult));
+
+        List<FilterExperiment> experiments = Arrays.asList(FilterExperiment.values());
+        Collections.shuffle(experiments); // shuffle to prevent caching bias
+
+        Map<FilterExperiment, ColumnFamily> results = new HashMap<>();
+        for (FilterExperiment experiment : experiments)
+        {
+            try
+            {
+                results.put(experiment, time(() -> function.apply(experiment), getTimer(experiment)));
             }
-        } catch (RuntimeException e) {
-            failures.inc();
-            log.warn("Caught an exception while experimenting. This is probably unexpected", e);
+            catch (RuntimeException e)
+            {
+                getFailureCounter(experiment).ifPresent(Counter::inc);
+                log.warn("Caught an exception while experimenting. This is probably unexpected", e);
+            }
         }
+
+        ColumnFamily legacyResult = results.get(USE_LEGACY);
+        ColumnFamily optimizedResult = results.get(USE_OPTIMIZED);
+        ColumnFamily optimizedEmitCellsResult = results.get(USE_OPTIMIZED_EMIT_CELLS);
+
+        compareAndLogResults(legacyResult, optimizedResult, USE_OPTIMIZED, function, fallback);
+        compareAndLogResults(legacyResult, optimizedEmitCellsResult, USE_OPTIMIZED, function, fallback);
+
         return legacyResult;
     }
 
-    public static boolean shouldRunExperiment() {
+    private static void compareAndLogResults(
+            ColumnFamily legacyResult,
+            ColumnFamily optimizedResult,
+            FilterExperiment experiment,
+            Function<FilterExperiment, ColumnFamily> function,
+            Function<FilterExperiment, ColumnFamily> fallback
+    )
+    {
+        ComparisonResult initialComparison = areEqual(legacyResult, optimizedResult, experiment);
+        if (initialComparison.isEqual())
+        {
+            getSuccessCounter(experiment).ifPresent(Counter::inc);
+        }
+        else if (!areTrulyEqual(legacyResult, function.apply(USE_LEGACY)))
+        {
+            // This case means that the data was modified between getting the legacy and optimized result. As a result, this experiment is indeterminate.
+            getIndeterminateCounter(experiment).ifPresent(Counter::inc);
+        }
+        else if ((legacyResult.metadata().getGcGraceSeconds() == 0
+                && areEqual(fallback.apply(USE_LEGACY), fallback.apply(experiment), experiment).isEqual()))
+        {
+            getIndeterminateCounter(experiment).ifPresent(Counter::inc);
+            // TODO(lkjaerozhang): Give a better log message when I actually understand what this means.
+            //  The indeterminate codepath seems to have never been hit so it's probably fine to defer for now as
+            //  long as we still have signal if we do hit it.
+            log.warn("Query result changed under immediate compaction but results from 60 seconds ago are identical, result is indeterminate; Legacy: {}, Optimized: {}, Legacy metadata: {}, Optimized metadata: {}",
+                    legacyResult, optimizedResult, safeLoggableColumnFamilyMetadata("legacyMetadata", legacyResult), safeLoggableColumnFamilyMetadata("optimizedMetadata", optimizedResult), SafeArg.of("experiment", experiment));
+        }
+        else
+        {
+            getFailureCounter(experiment).ifPresent(Counter::inc);
+            log.warn("Comparison failure while experimenting; Legacy: {}, Optimized: {}, Comparison method: {}, Legacy metadata: {}, Optimized metadata: {}",
+                    legacyResult, optimizedResult, SafeArg.of("comparisonMethod", initialComparison.name()), safeLoggableColumnFamilyMetadata("legacyMetadata", legacyResult), safeLoggableColumnFamilyMetadata("optimizedMetadata", optimizedResult), SafeArg.of("experiment", experiment));
+        }
+    }
+
+    private static boolean shouldRunExperiment()
+    {
         return ThreadLocalRandom.current().nextDouble() <= DatabaseDescriptor.getFilterExperimentProbability();
     }
 
     private static <T> T time(Supplier<T> delegate, Timer timer) {
         try (Timer.Context context = timer.time()) {
             return delegate.get();
+        }
+    }
+
+    private static Timer getTimer(FilterExperiment experiment)
+    {
+        switch (experiment)
+        {
+            case USE_LEGACY:
+                return legacyTimer;
+            case USE_OPTIMIZED:
+                return optimizedTimer;
+            case USE_OPTIMIZED_EMIT_CELLS:
+                return optimizedEmittingTimer;
+            default:
+                throw new IllegalArgumentException("Unknown experiment: " + experiment);
+        }
+    }
+
+    private static Optional<Counter> getSuccessCounter(FilterExperiment experiment)
+    {
+        switch (experiment)
+        {
+            case USE_LEGACY:
+                return Optional.empty();
+            case USE_OPTIMIZED:
+                return Optional.of(successes);
+            case USE_OPTIMIZED_EMIT_CELLS:
+                return Optional.of(successesForEmitting);
+            default:
+                throw new IllegalArgumentException("Unknown experiment: " + experiment);
+        }
+    }
+
+    private static Optional<Counter> getFailureCounter(FilterExperiment experiment)
+    {
+        switch (experiment)
+        {
+            case USE_LEGACY:
+                return Optional.empty();
+            case USE_OPTIMIZED:
+                return Optional.of(failures);
+            case USE_OPTIMIZED_EMIT_CELLS:
+                return Optional.of(failuresForEmitting);
+            default:
+                throw new IllegalArgumentException("Unknown experiment: " + experiment);
+        }
+    }
+
+    private static Optional<Counter> getIndeterminateCounter(FilterExperiment experiment)
+    {
+        switch (experiment)
+        {
+            case USE_LEGACY:
+                return Optional.empty();
+            case USE_OPTIMIZED:
+                return Optional.of(indeterminate);
+            case USE_OPTIMIZED_EMIT_CELLS:
+                return Optional.of(indeterminateForEmitting);
+            default:
+                throw new IllegalArgumentException("Unknown experiment: " + experiment);
         }
     }
 
@@ -127,7 +233,8 @@ public enum FilterExperiment
      * added directly to returnCF rather than being present in the iterator. So this only happens once.
      */
     @VisibleForTesting
-    static ComparisonResult areEqual(ColumnFamily legacy, ColumnFamily modern) {
+    static ComparisonResult areEqual(ColumnFamily legacy, ColumnFamily modern, FilterExperiment experiment)
+    {
         if (areTrulyEqual(legacy, modern)) {
             return ComparisonResult.EQUAL;
         }
@@ -138,7 +245,7 @@ public enum FilterExperiment
             boolean areEqual = !iterator(legacy).hasNext();
             return areEqual ? ComparisonResult.EQUAL : ComparisonResult.MODERN_WAS_NULL;
         } else {
-            return compareByIterator(iterator(legacy), iterator(modern), legacy.metadata());
+            return compareByIterator(iterator(legacy), iterator(modern), legacy.metadata(), experiment);
         }
     }
 
@@ -157,7 +264,7 @@ public enum FilterExperiment
         return ColumnFamily.digest(legacy).equals(ColumnFamily.digest(modern));
     }
 
-    static ComparisonResult compareByIterator(Iterator<Cell> legacyIterator, Iterator<Cell> modernIterator, CFMetaData metadata)
+    static ComparisonResult compareByIterator(Iterator<Cell> legacyIterator, Iterator<Cell> modernIterator, CFMetaData metadata, FilterExperiment experiment)
     {
         int differences = 0;
         int index = -1;
@@ -174,28 +281,30 @@ public enum FilterExperiment
                     continue;
                 }
                 log.warn("Items were not equal when comparing by iterator. Keyspace: {}, ColumnFamily: {}, index: {}, legacyClassName: {}, modernClassName: {}, timestampMatches: {}, nameMatches: {}, valueMatches: {}, legacySerializationFlags: {}, modernSerializationFlags: {}",
-                         SafeArg.of("keyspace", metadata.ksName),
-                         SafeArg.of("columnFamily", metadata.cfName),
-                         SafeArg.of("index", index),
-                         SafeArg.of("legacyClassName", legacy.getClass().getName()),
-                         SafeArg.of("modernClassName", modern.getClass().getName()),
-                         // These are what are compared in the .equals() implementation for AbstractCell.
-                         // TODO(lkjaerozhang): Follow up with information for the other types of cells.
-                         SafeArg.of("timestampMatches", legacy.timestamp() == modern.timestamp()),
-                         SafeArg.of("nameMatches", legacy.name() == modern.name()),
-                         SafeArg.of("valueMatches", legacy.value() == modern.value()),
-                         SafeArg.of("legacySerializationFlags", legacy.serializationFlags()),
-                         SafeArg.of("modernSerializationFlags", modern.serializationFlags()));
+                        SafeArg.of("keyspace", metadata.ksName),
+                        SafeArg.of("columnFamily", metadata.cfName),
+                        SafeArg.of("index", index),
+                        SafeArg.of("legacyClassName", legacy.getClass().getName()),
+                        SafeArg.of("modernClassName", modern.getClass().getName()),
+                        // These are what are compared in the .equals() implementation for AbstractCell.
+                        // TODO(lkjaerozhang): Follow up with information for the other types of cells.
+                        SafeArg.of("timestampMatches", legacy.timestamp() == modern.timestamp()),
+                        SafeArg.of("nameMatches", legacy.name() == modern.name()),
+                        SafeArg.of("valueMatches", legacy.value() == modern.value()),
+                        SafeArg.of("legacySerializationFlags", legacy.serializationFlags()),
+                        SafeArg.of("modernSerializationFlags", modern.serializationFlags()),
+                        SafeArg.of("experiment", experiment));
                 differences++;
             }
             else
             {
                 log.warn("Mismatched number of items at index {} when comparing by iterator. Legacy: {}, Modern: {}, Keyspace: {}, ColumnFamily: {}",
-                         SafeArg.of("index", index),
-                         SafeArg.of("hasLegacy", legacy != null),
-                         SafeArg.of("hasModern", modern != null),
-                         SafeArg.of("keyspace", metadata.ksName),
-                         SafeArg.of("columnFamily", metadata.cfName));
+                        SafeArg.of("index", index),
+                        SafeArg.of("hasLegacy", legacy != null),
+                        SafeArg.of("hasModern", modern != null),
+                        SafeArg.of("keyspace", metadata.ksName),
+                        SafeArg.of("columnFamily", metadata.cfName),
+                        SafeArg.of("experiment", experiment));
                 differences++;
             }
         }
@@ -204,9 +313,10 @@ public enum FilterExperiment
             return ComparisonResult.EQUAL;
         } else {
             log.warn("Column families returned different results via iterator: {}, Keyspace: {}, ColumnFamily: {}",
-                     SafeArg.of("differences", differences),
-                     SafeArg.of("keyspace", metadata.ksName),
-                     SafeArg.of("columnFamily", metadata.cfName));
+                    SafeArg.of("differences", differences),
+                    SafeArg.of("keyspace", metadata.ksName),
+                    SafeArg.of("columnFamily", metadata.cfName),
+                    SafeArg.of("experiment", experiment));
             return ComparisonResult.NOT_EQUAL_BY_ITERATOR;
         }
     }

--- a/src/java/org/apache/cassandra/db/RangeTombstone.java
+++ b/src/java/org/apache/cassandra/db/RangeTombstone.java
@@ -94,6 +94,11 @@ public class RangeTombstone extends Interval<Composite, DeletionTime> implements
         return comparator.compare(min, rt.min) <= 0 && comparator.compare(max, rt.max) >= 0;
     }
 
+    public boolean includes(RangeTombstone rt, Comparator<Composite> comparator)
+    {
+        return comparator.compare(min, rt.min) <= 0 && comparator.compare(max, rt.max) >= 0;
+    }
+
     public boolean includes(Comparator<Composite> comparator, Composite name)
     {
         return comparator.compare(name, min) >= 0 && comparator.compare(name, max) <= 0;

--- a/src/java/org/apache/cassandra/db/filter/QueryFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/QueryFilter.java
@@ -132,19 +132,23 @@ public class QueryFilter
         if (experiment == FilterExperiment.USE_LEGACY || filter.isReversed() || isRowCacheEnabled(returnCF)) {
             legacyCollateOnDiskAtom(returnCF, toCollate, filter, key, gcBefore, timestamp);
         } else {
-            optimizedCollateOnDiskAtom(returnCF, toCollate, filter, key, gcBefore, timestamp);
+            optimizedCollateOnDiskAtom(returnCF, toCollate, filter, key, gcBefore, timestamp, experiment);
         }
     }
 
     private static void optimizedCollateOnDiskAtom(ColumnFamily returnCF,
-                                                  List<? extends Iterator<? extends OnDiskAtom>> toCollate,
-                                                  IDiskAtomFilter filter,
-                                                  DecoratedKey key,
-                                                  int gcBefore,
-                                                  long timestamp) {
+                                                   List<? extends Iterator<? extends OnDiskAtom>> toCollate,
+                                                   IDiskAtomFilter filter,
+                                                   DecoratedKey key,
+                                                   int gcBefore,
+                                                   long timestamp,
+                                                   FilterExperiment experiment)
+    {
         Iterator<OnDiskAtom> merged = merge(returnCF.getComparator(), toCollate);
         Iterator<OnDiskAtom> countRangeTombstones = RangeTombstoneCountingIterator.wrapIterator(gcBefore, returnCF, merged);
-        Iterator<OnDiskAtom> filtered = filterTombstones(returnCF.getComparator(), countRangeTombstones, gcBefore);
+        Iterator<OnDiskAtom> filtered = experiment == FilterExperiment.USE_OPTIMIZED_EMIT_CELLS ?
+                filterTombstonesEmitCells(returnCF.getComparator(), countRangeTombstones, gcBefore) :
+                filterTombstones(returnCF.getComparator(), countRangeTombstones, gcBefore);
         Iterator<Cell> reconciled = reconcileDuplicatesAndGatherTombstones(
             returnCF, filter.getColumnComparator(returnCF.getComparator()), filtered);
         filter.collectReducedColumns(returnCF, reconciled, key, gcBefore, timestamp);

--- a/src/java/org/apache/cassandra/db/filter/QueryFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/QueryFilter.java
@@ -351,7 +351,7 @@ public class QueryFilter
                     {
                         if (nextAtom instanceof RangeTombstone)
                         {
-                            maybePendingRangeTombstone = (RangeTombstone) peeking.next();
+                            setPendingRangeTombstone((RangeTombstone) peeking.next());
                             return maybePendingRangeTombstone;
                         }
                         else

--- a/src/java/org/apache/cassandra/db/filter/QueryFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/QueryFilter.java
@@ -380,9 +380,9 @@ public class QueryFilter
                     {
                         RangeTombstone tombstone = (RangeTombstone) nextAtom;
 
-                        // if the incoming range tombstone is droppable and is fully contained within the pending range tombstone,
+                        // if the incoming range tombstone is droppable and superceded by the pending range tombstone,
                         // we expect that we can skip emitting the incoming range tombstone
-                        if (maybePendingRangeTombstone.includes(tombstone, comparator) && tombstoneIsDroppable(tombstone))
+                        if (maybePendingRangeTombstone.supersedes(tombstone, comparator) && tombstoneIsDroppable(tombstone))
                         {
                             continue;
                         }

--- a/src/java/org/apache/cassandra/db/filter/QueryFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/QueryFilter.java
@@ -323,12 +323,10 @@ public class QueryFilter
     }
 
     /**
-     * A complex function which holds a RangeTombstone before emitting it. Uses the held range tombstone
-     * to elide emitting cells that are covered by it, or redundant other range tombstones. Emits the range
-     * tombstone iff an incompatible range tombstone is seen, otherwise skips.
+     * A similar method to filterTombstones except this iterator emits cells covered by the held range tombstone.
      */
     @VisibleForTesting
-    static Iterator<OnDiskAtom> filterTombstonesEmittingCells(
+    static Iterator<OnDiskAtom> filterTombstonesEmitCells(
             final CellNameType comparator, Iterator<? extends OnDiskAtom> backingIterator, int gcBefore)
     {
         final PeekingIterator<OnDiskAtom> peeking = Iterators.peekingIterator(backingIterator);
@@ -348,11 +346,6 @@ public class QueryFilter
                     OnDiskAtom nextAtom = peeking.peek();
                     // if the next atom is outside the range, we can dump any cached range tombstone that haven't
                     // deleted anything.
-                    // dg note: the second part of this condition that checks if a range tombstone is included in this one only checks
-                    // the min part of the range, meaning it assumes tombstones are always of the format (X, 0), which i think is true,
-                    // but it does seem like a strange assumption to make. i think we do have tombstones which are not of that format
-                    // for deleting the atlas tombstone or sentinel (?) but not sure if that matters
-
                     if (maybePendingRangeTombstone == null
                             || !maybePendingRangeTombstone.includes(comparator, nextAtom.name()))
                     {

--- a/src/java/org/apache/cassandra/db/filter/QueryFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/QueryFilter.java
@@ -322,6 +322,87 @@ public class QueryFilter
         };
     }
 
+    /**
+     * A complex function which holds a RangeTombstone before emitting it. Uses the held range tombstone
+     * to elide emitting cells that are covered by it, or redundant other range tombstones. Emits the range
+     * tombstone iff an incompatible range tombstone is seen, otherwise skips.
+     */
+    @VisibleForTesting
+    static Iterator<OnDiskAtom> filterTombstonesEmittingCells(
+            final CellNameType comparator, Iterator<? extends OnDiskAtom> backingIterator, int gcBefore)
+    {
+        final PeekingIterator<OnDiskAtom> peeking = Iterators.peekingIterator(backingIterator);
+        return new AbstractIterator<OnDiskAtom>()
+        {
+            RangeTombstone maybePendingRangeTombstone;
+
+            private void setPendingRangeTombstone(RangeTombstone newValue)
+            {
+                maybePendingRangeTombstone = newValue;
+            }
+
+            protected OnDiskAtom computeNext()
+            {
+                while (peeking.hasNext())
+                {
+                    OnDiskAtom nextAtom = peeking.peek();
+                    // if the next atom is outside the range, we can dump any cached range tombstone that haven't
+                    // deleted anything.
+                    // dg note: the second part of this condition that checks if a range tombstone is included in this one only checks
+                    // the min part of the range, meaning it assumes tombstones are always of the format (X, 0), which i think is true,
+                    // but it does seem like a strange assumption to make. i think we do have tombstones which are not of that format
+                    // for deleting the atlas tombstone or sentinel (?) but not sure if that matters
+
+                    if (maybePendingRangeTombstone == null
+                            || !maybePendingRangeTombstone.includes(comparator, nextAtom.name()))
+                    {
+                        if (nextAtom instanceof RangeTombstone)
+                        {
+                            maybePendingRangeTombstone = (RangeTombstone) peeking.next();
+                            return maybePendingRangeTombstone;
+                        }
+                        else
+                        {
+                            maybePendingRangeTombstone = null;
+                            return peeking.next();
+                        }
+                    }
+
+                    // we have a range tombstone, we're in the range
+                    if (nextAtom instanceof Cell)
+                    {
+                        // even if the next cell is overwritten by the range tombstone, still emit it
+                        return peeking.next();
+                    }
+                    else
+                    {
+                        RangeTombstone tombstone = (RangeTombstone) nextAtom;
+
+                        // If the range tombstone is droppable and we have an overlap, we expect that the present tombstone
+                        // will supercede the old, based on how we write, so we can skip emitting that tombstone.
+                        if (maybePendingRangeTombstone.supersedes(tombstone, comparator) && !tombstoneNotDroppable(tombstone))
+                        {
+                            peeking.next();
+                        }
+                        else
+                        {
+                            // cannot optimize, return, move on
+                            peeking.next();
+                            setPendingRangeTombstone(tombstone);
+                            return tombstone;
+                        }
+                    }
+                }
+                return endOfData();
+            }
+
+            private boolean tombstoneNotDroppable(RangeTombstone tombstone)
+            {
+                return tombstone != null && tombstone.getLocalDeletionTime() >= gcBefore;
+            }
+        };
+    }
+
     private static MergeIterator.Reducer<Cell, Cell> getReducer(final Comparator<Cell> comparator)
     {
         // define a 'reduced' iterator that merges columns w/ the same name, which

--- a/src/java/org/apache/cassandra/db/filter/QueryFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/QueryFilter.java
@@ -17,16 +17,7 @@
  */
 package org.apache.cassandra.db.filter;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Deque;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.PriorityQueue;
-import java.util.Queue;
-import java.util.SortedSet;
+import java.util.*;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.AbstractIterator;
@@ -329,7 +320,6 @@ public class QueryFilter
     static Iterator<OnDiskAtom> filterTombstonesEmitCells(
             final CellNameType comparator, Iterator<? extends OnDiskAtom> backingIterator, int gcBefore)
     {
-        final PeekingIterator<OnDiskAtom> peeking = Iterators.peekingIterator(backingIterator);
         return new AbstractIterator<OnDiskAtom>()
         {
             RangeTombstone maybePendingRangeTombstone;
@@ -341,47 +331,66 @@ public class QueryFilter
 
             protected OnDiskAtom computeNext()
             {
-                while (peeking.hasNext())
+                while (backingIterator.hasNext())
                 {
-                    OnDiskAtom nextAtom = peeking.peek();
-                    // if the next atom is outside the range, we can dump any cached range tombstone that haven't
-                    // deleted anything.
+                    OnDiskAtom nextAtom = backingIterator.next();
+                    if (Objects.isNull(nextAtom))
+                    {
+                        continue;
+                    }
+
                     if (maybePendingRangeTombstone == null
                             || !maybePendingRangeTombstone.includes(comparator, nextAtom.name()))
                     {
+                        // we either don't have a pending range tombstone, or
+                        // we do have a pending range tombstone and the incoming atom is either a range tombstone or a cell
+                        // if it is a range tombstone, it starts after the pending range tombstone ends and therefore is not in range
+                        // if it is a cell, it is after the pending range tombstone ends and therefore not in range / covered
                         if (nextAtom instanceof RangeTombstone)
                         {
-                            setPendingRangeTombstone((RangeTombstone) peeking.next());
+                            // always immediately return the range tombstone to maintain ordering
+                            // even though we will hold onto it to merge with other range tombstones
+                            // this is because we will emit cells covered by this range tombstone after
+                            setPendingRangeTombstone((RangeTombstone) nextAtom);
                             return maybePendingRangeTombstone;
                         }
                         else
                         {
-                            maybePendingRangeTombstone = null;
-                            return peeking.next();
+                            setPendingRangeTombstone(null);
+                            return nextAtom;
                         }
                     }
 
-                    // we have a range tombstone, we're in the range
+                    // we have a pending range tombstone, and the incoming atom is either a range tombstone or a cell
+                    // if it is a cell, it is in range of the range tombstone
+                    // if it is a range tombstone, it starts before the pending range tombstone ends
+                    // in this case, we may be able to merge the incoming range tombstone if it is droppable and
+                    // fully contained within the pending range tombstone's range
                     if (nextAtom instanceof Cell)
                     {
                         // even if the next cell is overwritten by the range tombstone, still emit it
-                        return peeking.next();
+                        // this is the key difference of this method vs filterTombstones
+                        return nextAtom;
                     }
                     else
                     {
                         RangeTombstone tombstone = (RangeTombstone) nextAtom;
 
-                        // If the range tombstone is droppable and we have an overlap, we expect that the present tombstone
-                        // will supercede the old, based on how we write, so we can skip emitting that tombstone.
-                        if (maybePendingRangeTombstone.supersedes(tombstone, comparator) && !tombstoneNotDroppable(tombstone))
+                        // if the incoming range tombstone is droppable and is fully contained within the pending range tombstone,
+                        // we expect that we can skip emitting the incoming range tombstone
+                        if (maybePendingRangeTombstone.includes(tombstone, comparator) && tombstoneIsDroppable(tombstone))
                         {
-                            peeking.next();
+                            continue;
                         }
                         else
                         {
-                            // cannot optimize, return, move on
-                            peeking.next();
-                            setPendingRangeTombstone(tombstone);
+                            // cannot optimize so we return the tombstone
+                            // however we only want to set the pending range tombstone to the incoming range tombstone
+                            // if the incoming one's end comes after the pending one's end
+                            if (!maybePendingRangeTombstone.includes(tombstone, comparator))
+                            {
+                                setPendingRangeTombstone(tombstone);
+                            }
                             return tombstone;
                         }
                     }
@@ -389,9 +398,9 @@ public class QueryFilter
                 return endOfData();
             }
 
-            private boolean tombstoneNotDroppable(RangeTombstone tombstone)
+            private boolean tombstoneIsDroppable(RangeTombstone tombstone)
             {
-                return tombstone != null && tombstone.getLocalDeletionTime() >= gcBefore;
+                return tombstone.getLocalDeletionTime() < gcBefore;
             }
         };
     }

--- a/test/unit/org/apache/cassandra/FilterExperimentTest.java
+++ b/test/unit/org/apache/cassandra/FilterExperimentTest.java
@@ -47,43 +47,43 @@ public class FilterExperimentTest
     @Test
     public void testAreEqual_trueIfEqual() {
         ColumnFamily cf = cf(value('a'), rangeDelete('b', 'c'));
-        assertThat(FilterExperiment.areEqual(cf, cf).isEqual()).isTrue();
+        assertThat(FilterExperiment.areEqual(cf, cf, FilterExperiment.USE_OPTIMIZED).isEqual()).isTrue();
     }
 
     @Test
     public void testAreEqual_falseIfNotEqual() {
         ColumnFamily left = cf(value('a'), value('d'));
         ColumnFamily right = cf(value('a'), value('c'));
-        assertThat(FilterExperiment.areEqual(left, right).isEqual()).isFalse();
+        assertThat(FilterExperiment.areEqual(left, right, FilterExperiment.USE_OPTIMIZED).isEqual()).isFalse();
     }
 
     @Test
     public void testAreEqual_trueIfEqual_cellwise() {
         ColumnFamily left = cf(value('a'), value('d'));
         ColumnFamily right = cf(value('a'), value('b'), rangeDelete('b', 'c'), value('d'));
-        assertThat(FilterExperiment.areEqual(left, right).isEqual()).isTrue();
+        assertThat(FilterExperiment.areEqual(left, right, FilterExperiment.USE_OPTIMIZED).isEqual()).isTrue();
     }
 
     @Test
     public void testAreEqual_handlesNull() {
         ColumnFamily left = cf();
         ColumnFamily right = null;
-        assertThat(FilterExperiment.areEqual(left, right).isEqual()).isTrue();
-        assertThat(FilterExperiment.areEqual(right, left).isEqual()).isTrue();
+        assertThat(FilterExperiment.areEqual(left, right, FilterExperiment.USE_OPTIMIZED).isEqual()).isTrue();
+        assertThat(FilterExperiment.areEqual(right, left, FilterExperiment.USE_OPTIMIZED).isEqual()).isTrue();
     }
 
     @Test
     public void testAreEqual_falseIfMoreCells() {
         ColumnFamily left = cf(value('a'), value('b'));
         ColumnFamily right = cf(value('a'));
-        assertThat(FilterExperiment.areEqual(left, right).isEqual()).isFalse();
+        assertThat(FilterExperiment.areEqual(left, right, FilterExperiment.USE_OPTIMIZED).isEqual()).isFalse();
     }
 
     @Test
     public void testAreEqual_falseIfMoreCells_fromRangeTombstones() {
         ColumnFamily left = cf(value('a'), value('b'), rangeDelete('b', 'c'));
         ColumnFamily right = cf(value('a'), value('b'));
-        assertThat(FilterExperiment.areEqual(left, right).isEqual()).isFalse();
+        assertThat(FilterExperiment.areEqual(left, right, FilterExperiment.USE_OPTIMIZED).isEqual()).isFalse();
     }
 
     private static ColumnFamily cf(OnDiskAtom... atoms) {

--- a/test/unit/org/apache/cassandra/db/filter/QueryFilterTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/QueryFilterTest.java
@@ -53,40 +53,95 @@ public class QueryFilterTest {
     private static final int WRITE_TIME = 123;
 
     @Test
-    public void testCollateOnDiskAtom_safeInPresenceOfRepeatedTombstones() {
+    public void testCollateOnDiskAtom_withoutEmitCells_safeInPresenceOfRepeatedTombstones()
+    {
         List<Cell> left = ImmutableList.of(value('a'), value('d'), value('e'), value('f'));
         List<OnDiskAtom> right = ImmutableList.of(rangeDelete('a', 'e'), value('a'), value('b'), rangeDelete('a', 'e'), value('g'));
         ColumnFamily cf = newCF();
-        collate(cf, left.iterator(), right.iterator());
+        collateWithoutEmitCells(cf, left.iterator(), right.iterator());
         assertThat(cf.deletionInfo().isLive()).isTrue();
         assertThat(cf.iterator()).containsExactly(value('f'), value('g'));
     }
 
     @Test
-    public void testCollateOnDiskAtom_dropsUnnecessaryCellsAndTombstones() {
+    public void testCollateOnDiskAtom_withoutEmitCells_dropsUnnecessaryCellsAndTombstones()
+    {
         List<Cell> left = ImmutableList.of(value('a'), value('d'));
         List<RangeTombstone> right = ImmutableList.of(rangeDelete('a', 'c'));
         ColumnFamily cf = newCF();
-        collate(cf, left.iterator(), right.iterator());
+        collateWithoutEmitCells(cf, left.iterator(), right.iterator());
         assertThat(cf.deletionInfo().isLive()).isTrue();
         assertThat(cf.iterator()).containsExactly(value('d'));
     }
 
     @Test
-    public void testCollateOnDiskAtom_gathersNecessaryTombstones() {
+    public void testCollateOnDiskAtom_withoutEmitCells_gathersNecessaryTombstones()
+    {
         List<Cell> left = ImmutableList.of(value('a'), value('d'));
         List<RangeTombstone> right = ImmutableList.of(rangeDelete('a', 'c'), rangeDelete('b', 'c', TOMBSTONES_TS + 1));
         ColumnFamily cf = newCF();
-        collate(cf, left.iterator(), right.iterator());
+        collateWithoutEmitCells(cf, left.iterator(), right.iterator());
         assertThat(cf.deletionInfo().rangeIterator()).containsExactly(rangeDelete('a', 'c'));
         assertThat(cf.iterator()).containsExactly(value('d'));
     }
 
     @Test
-    public void testCollateOnDiskAtom_merges() {
+    public void testCollateOnDiskAtom_withoutEmitCells_merges()
+    {
         List<Cell> left = ImmutableList.of(value('a'), value('c'), value('e'));
         List<Cell> right = ImmutableList.of(value('b'), value('d'));
-        assertThat(collate(left.iterator(), right.iterator()))
+        ColumnFamily cf = newCF();
+        assertThat(collateWithoutEmitCells(cf, left.iterator(), right.iterator()))
+                .containsExactly(value('a'), value('b'), value('c'), value('d'), value('e'));
+    }
+
+    @Test
+    public void testCollateOnDiskAtom_withEmitCells_safeInPresenceOfRepeatedTombstones()
+    {
+        List<OnDiskAtom> left = ImmutableList.of(value('a'), rangeDelete('a', 'e'), value('d'), value('e'), value('f'));
+        List<OnDiskAtom> right = ImmutableList.of(rangeDelete('a', 'e'), value('a'), value('b'), value('g'));
+        ColumnFamily cf = newCF();
+        collateWithEmitCells(cf, left.iterator(), right.iterator());
+        assertThat(cf.deletionInfo().isLive()).isFalse();
+        assertThat(cf.deletionInfo().rangeCount()).isEqualTo(1);
+        assertThat(cf.iterator())
+                .containsExactly(value('f'), value('g'));
+    }
+
+    @Test
+    public void testCollateOnDiskAtom_withEmitCells_dropsUnnecessaryCellsAndTombstones()
+    {
+        List<OnDiskAtom> left = ImmutableList.of(value('a'), rangeDelete('b', 'c'));
+        List<OnDiskAtom> right = ImmutableList.of(rangeDelete('a', 'c'), value('d'));
+        ColumnFamily cf = newCF();
+        collateWithEmitCells(cf, left.iterator(), right.iterator());
+        assertThat(cf.deletionInfo().isLive()).isFalse();
+        assertThat(cf.deletionInfo().rangeCount()).isEqualTo(1);
+        assertThat(cf.iterator()).containsExactly(value('d'));
+    }
+
+    @Test
+    public void testCollateOnDiskAtom_withEmitCells_doesNotDropNewerTombstones()
+    {
+        List<Cell> left = ImmutableList.of(value('a'), value('d'));
+        List<RangeTombstone> right = ImmutableList.of(
+                rangeDelete('a', 'c'),
+                rangeDelete('b', 'c', TOMBSTONES_TS + 1),
+                rangeDelete('c', 'c', TOMBSTONES_TS + 2)
+        );
+        ColumnFamily cf = newCF();
+        collateWithEmitCells(cf, left.iterator(), right.iterator());
+        assertThat(cf.deletionInfo().rangeCount()).isEqualTo(3);
+        assertThat(cf.iterator()).containsExactly(value('d'));
+    }
+
+    @Test
+    public void testCollateOnDiskAtom_withEmitCells_merges()
+    {
+        List<Cell> left = ImmutableList.of(value('a'), value('c'), value('e'));
+        List<Cell> right = ImmutableList.of(value('b'), value('d'));
+        ColumnFamily cf = newCF();
+        assertThat(collateWithEmitCells(cf, left.iterator(), right.iterator()))
                 .containsExactly(value('a'), value('b'), value('c'), value('d'), value('e'));
     }
 
@@ -94,13 +149,28 @@ public class QueryFilterTest {
         return ArrayBackedSortedColumns.factory.create(metadata);
     }
 
-    private static List<Cell> collate(Iterator<? extends OnDiskAtom>... cells) {
-        return collate(newCF(), cells);
+    private static List<Cell> collateWithoutEmitCells(ColumnFamily returnCf, Iterator<? extends OnDiskAtom>... cells)
+    {
+        return collate(FilterExperiment.USE_OPTIMIZED, returnCf, cells);
     }
 
-    private static List<Cell> collate(ColumnFamily returnCf, Iterator<? extends OnDiskAtom>... cells) {
+    private static List<Cell> collateWithEmitCells(ColumnFamily returnCf, Iterator<? extends OnDiskAtom>... cells)
+    {
+        return collate(FilterExperiment.USE_OPTIMIZED_EMIT_CELLS, returnCf, cells);
+    }
+
+    private static List<Cell> collate(FilterExperiment experimentType, ColumnFamily returnCf, Iterator<? extends OnDiskAtom>... cells)
+    {
         IDiskAtomFilter filter = new SliceQueryFilter(ColumnSlice.ALL_COLUMNS, false, Integer.MAX_VALUE);
-        QueryFilter.collateOnDiskAtom(returnCf, Arrays.asList(cells), filter, null, WRITE_TIME + 1, 10_000, FilterExperiment.USE_OPTIMIZED);
+        QueryFilter.collateOnDiskAtom(
+                returnCf,
+                Arrays.asList(cells),
+                filter,
+                null,
+                WRITE_TIME + 1,
+                10_000,
+                experimentType
+        );
         return read(returnCf);
     }
 
@@ -136,56 +206,98 @@ public class QueryFilterTest {
 
     @Test
     public void testFilterTombstones_tombstone_skipped_if_next_tombstone_does_not_overlap() {
-        assertThat(filter(rangeDelete('a', 'b'), rangeDelete('c', 'd'), value('c'))).isEmpty();
+        assertThat(filterWithoutEmitCells(rangeDelete('a', 'b'), rangeDelete('c', 'd'), value('c'))).isEmpty();
     }
 
     @Test
     public void testFilterTombstones_tombstone_skipped_if_next_cell_does_not_overlap() {
         Cell value = value('c');
         Cell unsortedOverlappingToEnsureWeClearedTombstone = value('a');
-        assertThat(filter(rangeDelete('a', 'b'), value, unsortedOverlappingToEnsureWeClearedTombstone))
+        assertThat(filterWithoutEmitCells(rangeDelete('a', 'b'), value, unsortedOverlappingToEnsureWeClearedTombstone))
             .containsExactly(value, unsortedOverlappingToEnsureWeClearedTombstone);
     }
 
     @Test
     public void testFilterTombstones_never_returns_tombstones_out_of_order() {
         OnDiskAtom[] cells = new OnDiskAtom[] { rangeDelete('a', 'c', 123), value('a', 124) };
-        assertThat(filter(cells)).containsExactly(cells);
+        assertThat(filterWithoutEmitCells(cells)).containsExactly(cells);
     }
 
     @Test
     public void testFilterTombstones_skips_cell_if_overlapped_by_current_tombstone() {
-        assertThat(filter(rangeDelete('a', 'b'), value('a'))).isEmpty();
+        assertThat(filterWithoutEmitCells(rangeDelete('a', 'b'), value('a'))).isEmpty();
     }
 
     @Test
     public void testFilterTombstones_does_not_skip_overlapping_cell_if_cell_newer_than_tombstone() {
         Cell value = value('a', TOMBSTONES_TS);
-        assertThat(filter(rangeDelete('a', 'b'), value)).contains(value);
+        assertThat(filterWithoutEmitCells(rangeDelete('a', 'b'), value)).contains(value);
     }
 
     @Test
     public void testFilterTombstones_coalesces_tombstones_that_supercede() {
-        assertThat(filter(rangeDelete('a', 'd'), rangeDelete('b', 'c'), rangeDelete('b', 'd', TOMBSTONES_TS + 1)))
+        assertThat(filterWithoutEmitCells(rangeDelete('a', 'd'), rangeDelete('b', 'c'), rangeDelete('b', 'd', TOMBSTONES_TS + 1)))
                 .containsExactly(rangeDelete('a', 'd'));
     }
 
     @Test
     public void testFilterTombstones_does_not_coalesce_when_incompatible_timestamps() {
-        assertThat(filter(rangeDelete('a', 'd'), rangeDelete('b', 'c', TOMBSTONES_TS + 1), rangeDelete('b', 'd', TOMBSTONES_TS + 2)))
+        assertThat(filterWithoutEmitCells(rangeDelete('a', 'd'), rangeDelete('b', 'c', TOMBSTONES_TS + 1), rangeDelete('b', 'd', TOMBSTONES_TS + 2)))
                 .containsExactly(rangeDelete('a', 'd'), rangeDelete('b', 'c', TOMBSTONES_TS + 1));
     }
 
     @Test
     public void testFilterTombstones_returns_range_tombstones_that_are_not_droppable() {
         RangeTombstone tombstone = nonDroppableRangeDelete('a', 'b');
-        assertThat(filter(tombstone, value('a'), rangeDelete('d', 'f'))).containsExactly(tombstone);
+        assertThat(filterWithoutEmitCells(tombstone, value('a'), rangeDelete('d', 'f'))).containsExactly(tombstone);
     }
 
     @Test
     public void testFilterTombstones_returns_pending_last_tombstone_if_not_droppable() {
         RangeTombstone tombstone = nonDroppableRangeDelete('a', 'c');
-        assertThat(filter(tombstone)).containsExactly(tombstone);
+        assertThat(filterWithoutEmitCells(tombstone)).containsExactly(tombstone);
+    }
+
+    @Test
+    public void filterTombstonesEmitCells_tombstone_emits_tombstones_if_no_overlap()
+    {
+        assertThat(filterWithEmitCells(rangeDelete('a', 'b'), rangeDelete('c', 'd')))
+                .containsExactly(rangeDelete('a', 'b'), rangeDelete('c', 'd'));
+    }
+
+    @Test
+    public void filterTombstonesEmitCells_never_returns_tombstones_out_of_order()
+    {
+        OnDiskAtom[] cells = new OnDiskAtom[]{rangeDelete('a', 'c', 123), value('a', 124)};
+        assertThat(filterWithEmitCells(cells)).containsExactly(cells);
+    }
+
+    @Test
+    public void filterTombstonesEmitCells_emits_cell_even_if_overlapped_by_current_tombstone()
+    {
+        assertThat(filterWithEmitCells(rangeDelete('a', 'b'), value('a')))
+                .containsExactly(rangeDelete('a', 'b'), value('a'));
+    }
+
+    @Test
+    public void filterTombstonesEmitCells_coalesces_tombstones_that_supercede()
+    {
+        assertThat(filterWithEmitCells(rangeDelete('a', 'd'), rangeDelete('b', 'c'), rangeDelete('b', 'd', TOMBSTONES_TS + 1)))
+                .containsExactly(rangeDelete('a', 'd'), rangeDelete('b', 'd', TOMBSTONES_TS + 1));
+    }
+
+    @Test
+    public void filterTombstonesEmitCells_does_not_coalesce_when_incompatible_timestamps()
+    {
+        assertThat(filterWithEmitCells(rangeDelete('a', 'd'), rangeDelete('b', 'c', TOMBSTONES_TS + 1), rangeDelete('b', 'd', TOMBSTONES_TS + 2)))
+                .containsExactly(rangeDelete('a', 'd'), rangeDelete('b', 'c', TOMBSTONES_TS + 1), rangeDelete('b', 'd', TOMBSTONES_TS + 2));
+    }
+
+    @Test
+    public void filterTombstonesEmitCells_does_not_coalesces_when_not_droppable()
+    {
+        assertThat(filterWithEmitCells(rangeDelete('a', 'd'), nonDroppableRangeDelete('b', 'c'), rangeDelete('b', 'd', TOMBSTONES_TS + 1)))
+                .containsExactly(rangeDelete('a', 'd'), nonDroppableRangeDelete('b', 'c'), rangeDelete('b', 'd', TOMBSTONES_TS + 1));
     }
 
     private static List<Cell> reconcileDuplicates(ColumnFamily returnCF, OnDiskAtom... cells) {
@@ -195,8 +307,19 @@ public class QueryFilterTest {
                 Arrays.asList(cells).iterator()));
     }
 
+    private static List<OnDiskAtom> filterWithoutEmitCells(OnDiskAtom... atoms)
+    {
+        return filter(FilterExperiment.USE_OPTIMIZED, atoms);
+    }
+
+    private static List<OnDiskAtom> filterWithEmitCells(OnDiskAtom... atoms)
+    {
+        return filter(FilterExperiment.USE_OPTIMIZED_EMIT_CELLS, atoms);
+    }
+
     // add a bunch of cells either side to check for edge cases
-    private static List<OnDiskAtom> filter(OnDiskAtom... atoms) {
+    private static List<OnDiskAtom> filter(FilterExperiment experimentType, OnDiskAtom... atoms)
+    {
         int buffering = 25;
         List<OnDiskAtom> enhanced = new ArrayList<>(buffering + atoms.length + buffering);
         for (int i = 0; i < 25; i++) {
@@ -208,7 +331,11 @@ public class QueryFilterTest {
         for (int i = 0; i < 25; i++) {
             enhanced.add(value((char) ('z' + i)));
         }
-        List<OnDiskAtom> result = ImmutableList.copyOf(QueryFilter.filterTombstones(metadata.comparator, enhanced.iterator(), WRITE_TIME + 1));
+        List<OnDiskAtom> result = ImmutableList.copyOf(
+                experimentType == FilterExperiment.USE_OPTIMIZED ?
+                        QueryFilter.filterTombstones(metadata.comparator, enhanced.iterator(), WRITE_TIME + 1) :
+                        QueryFilter.filterTombstonesEmitCells(metadata.comparator, enhanced.iterator(), WRITE_TIME + 1)
+        );
         return result.subList(buffering, result.size() - buffering);
     }
 


### PR DESCRIPTION
This PR modifies the filter experiment to test a new collation method that emits cells covered by a range tombstone from the iterator. This is one way to make the optimized collation method compatible with resumable range scans https://github.com/palantir/cassandra/pull/701. It does this by emitting cells that the previous method drops within the iterator. We need to keep these cells so they that they are counted in the `CountingCellIterator`, which is used for metrics as well as the resumable range scans threshold.

This PR also randomizes the order in which experiments are being run to avoid caching bias, which is suspected to exist currently.